### PR TITLE
feat: Bhava Bala — occupant contribution, debug view, status, verific…

### DIFF
--- a/src/lib/bhavaBala.test.ts
+++ b/src/lib/bhavaBala.test.ts
@@ -1,0 +1,401 @@
+// Bhava Bala verification fixture
+// Run: npx ts-node --project tsconfig.json src/lib/bhavaBala.test.ts
+//
+// Uses a fixed Aries ascendant chart so every component can be manually reproduced.
+// Two houses (H1 and H4) are fully worked through step-by-step in comments below.
+
+import { buildClassicalBhavaBala } from './bhavaBala';
+
+// ---------------------------------------------------------------------------
+// Fixed chart: Aries ascendant, planets placed at sign midpoints
+// ---------------------------------------------------------------------------
+//
+// Ascendant: sign=1 (Aries, 1-indexed)
+//
+// Planet longitudes (sidereal, placed at sign midpoints for clarity):
+//   Sun     135° — Leo      (sign 5,  H5)
+//   Moon     45° — Taurus   (sign 2,  H2)
+//   Mars    225° — Scorpio  (sign 8,  H8)
+//   Mercury 165° — Virgo    (sign 6,  H6)
+//   Jupiter 105° — Cancer   (sign 4,  H4) ← occupies H4
+//   Venus   195° — Libra    (sign 7,  H7) ← occupies H7
+//   Saturn  285° — Capricorn(sign 10, H10) ← occupies H10
+//
+// House lords (whole sign from Aries ascendant):
+//   H1=Ar(Mars)  H2=Ta(Venus)  H3=Ge(Mercury)  H4=Cn(Moon)   H5=Le(Sun)
+//   H6=Vi(Mercury) H7=Li(Venus) H8=Sc(Mars)    H9=Sg(Jupiter)
+//   H10=Cp(Saturn) H11=Aq(Saturn) H12=Pi(Jupiter)
+
+const FIXTURE_CHART = {
+  ascendant: { sign: 1 },
+  planets: [
+    { name: 'Sun',     longitude: 135, sign: 5  },
+    { name: 'Moon',    longitude: 45,  sign: 2  },
+    { name: 'Mars',    longitude: 225, sign: 8  },
+    { name: 'Mercury', longitude: 165, sign: 6  },
+    { name: 'Jupiter', longitude: 105, sign: 4  },
+    { name: 'Venus',   longitude: 195, sign: 7  },
+    { name: 'Saturn',  longitude: 285, sign: 10 },
+  ],
+};
+
+// Pre-set Ṣaḍbala virupa — round numbers for easy manual arithmetic.
+// Not real chart values; chosen to make the verification self-contained.
+const FIXTURE_SHADBALA = [
+  { planet: 'Sun',     totalVirupa: 450, requiredVirupa: 390 }, // ratio ≈ 1.154
+  { planet: 'Moon',    totalVirupa: 420, requiredVirupa: 360 }, // ratio ≈ 1.167
+  { planet: 'Mars',    totalVirupa: 350, requiredVirupa: 300 }, // ratio ≈ 1.167
+  { planet: 'Mercury', totalVirupa: 480, requiredVirupa: 420 }, // ratio ≈ 1.143
+  { planet: 'Jupiter', totalVirupa: 520, requiredVirupa: 390 }, // ratio ≈ 1.333
+  { planet: 'Venus',   totalVirupa: 380, requiredVirupa: 330 }, // ratio ≈ 1.152
+  { planet: 'Saturn',  totalVirupa: 310, requiredVirupa: 300 }, // ratio ≈ 1.033
+];
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) throw new Error(`FAIL: ${message}`);
+}
+
+function approxEqual(a: number, b: number, epsilon = 0.6): boolean {
+  return Math.abs(a - b) <= epsilon;
+}
+
+// ---------------------------------------------------------------------------
+// House 1 — Aries (lord: Mars, no occupants)
+//
+// Sign midpoint = signIndex(0) × 30 + 15 = 15°
+//
+// Drig Bala — diff = normalizeDegrees(15 − planet.longitude):
+//
+//   Sun   (135°): diff = (15−135+360)%360 = 240°
+//                 std |240−180|=60 > 45 → 0; no special → no aspect
+//
+//   Moon   (45°): diff = (15−45+360)%360 = 330°
+//                 std |330−180|=150 > 45 → 0 → no aspect
+//
+//   Mars  (225°): diff = (15−225+360)%360 = 150°
+//                 std |150−180|=30 ≤ 45 → 1−30/45 = 0.333
+//                 special 90°: |150−90|=60 > 35 → 0
+//                 special 210°: |150−210|=60 > 35 → 0
+//                 → strength 0.333 (malefic, < 0.66) → drig4 += −60×0.333 = −20.0
+//
+//   Mercury(165°): diff = (15−165+360)%360 = 210°
+//                 std |210−180|=30 ≤ 45 → 1−30/45 = 0.333
+//                 → strength 0.333 (benefic, < 0.66) → drig2 += +100×0.333 = +33.33
+//
+//   Jupiter(105°): diff = (15−105+360)%360 = 270°
+//                 std |270−180|=90 > 45 → 0
+//                 special 120°: |270−120|=150 > 35 → 0
+//                 special 240°: |270−240|=30 ≤ 35 → 1−30/35 = 0.143
+//                 → strength 0.143 (benefic, < 0.66) → drig2 += +100×0.143 = +14.29
+//
+//   Venus  (195°): diff = (15−195+360)%360 = 180°
+//                 std |180−180|=0 ≤ 45 → 1.0
+//                 → strength 1.0 (benefic, ≥ 0.66) → drig1 += +180×1.0 = +180.0
+//
+//   Saturn (285°): diff = (15−285+360)%360 = 90°
+//                 std |90−180|=90 > 45 → 0
+//                 special 60°: |90−60|=30 ≤ 35 → 1−30/35 = 0.143
+//                 special 270°: |90−270|=180 > 35 → 0
+//                 → strength 0.143 (malefic, < 0.66) → drig4 += −60×0.143 = −8.57
+//
+//   drig1 = 180.0, drig2 = 33.33+14.29 = 47.62, drig3 = 0, drig4 = −20.0+(−8.57) = −28.57
+//
+// Bhavadhipati: Mars Ṣaḍbala = 350 vp / 300 req = 1.167×  → bhavesha = 350
+//
+// Occupants: none
+//
+// ~Dig Bala: H1 is kendra (angular) → +15 vp
+//
+// Total = 180.0 + 47.62 + 0 + (−28.57) + 350 + 0 + 15 = 564.05
+// ---------------------------------------------------------------------------
+function testHouse1(): { pass: number; fail: number } {
+  let pass = 0, fail = 0;
+  console.log('--- House 1 (Aries, lord: Mars, no occupants) ---');
+
+  const rows = buildClassicalBhavaBala(FIXTURE_CHART, FIXTURE_SHADBALA);
+  const h1 = rows[0];
+
+  let ok = h1.sign === 'Ar' && h1.lord === 'Mars';
+  console.log(`${ok ? '✓' : '✗'} H1: sign=Ar lord=Mars, got sign=${h1.sign} lord=${h1.lord}`);
+  ok ? pass++ : fail++;
+
+  ok = h1.bhavesha === 350;
+  console.log(`${ok ? '✓' : '✗'} H1 bhavesha: expected 350 vp (Mars), got ${h1.bhavesha}`);
+  ok ? pass++ : fail++;
+
+  ok = approxEqual(h1.drig1, 180.0);
+  console.log(`${ok ? '✓' : '✗'} H1 drig1 (Venus full 7th): expected 180.0, got ${h1.drig1.toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  ok = approxEqual(h1.drig2, 47.62);
+  console.log(`${ok ? '✓' : '✗'} H1 drig2 (Mercury+Jupiter weak): expected ~47.62, got ${h1.drig2.toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  ok = approxEqual(h1.drig3, 0, 0.01);
+  console.log(`${ok ? '✓' : '✗'} H1 drig3 (no strong malefic): expected 0, got ${h1.drig3.toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  ok = approxEqual(h1.drig4, -28.57);
+  console.log(`${ok ? '✓' : '✗'} H1 drig4 (Mars+Saturn weak): expected ~−28.57, got ${h1.drig4.toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  ok = h1.occupants.length === 0 && h1.occupantTotal === 0;
+  console.log(`${ok ? '✓' : '✗'} H1 occupants: expected none, got ${h1.occupants.length}`);
+  ok ? pass++ : fail++;
+
+  ok = h1.kendra === 15;
+  console.log(`${ok ? '✓' : '✗'} H1 ~Dig: expected +15 vp (kendra), got ${h1.kendra}`);
+  ok ? pass++ : fail++;
+
+  // 180.0 + 47.62 + 0 + (−28.57) + 350 + 0 + 15 = 564.05
+  ok = approxEqual(h1.total, 564.05, 1.5);
+  console.log(`${ok ? '✓' : '✗'} H1 total: expected ~564.05, got ${h1.total.toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  return { pass, fail };
+}
+
+// ---------------------------------------------------------------------------
+// House 4 — Cancer (lord: Moon, Jupiter occupies)
+//
+// Sign midpoint = signIndex(3) × 30 + 15 = 105°
+//
+// Drig Bala — diff = normalizeDegrees(105 − planet.longitude):
+//
+//   Sun   (135°): diff=(105−135+360)%360=330°; std |330−180|=150>45→0 → no aspect
+//   Moon   (45°): diff=(105−45+360)%360=60°; std |60−180|=120>45→0 → no aspect
+//
+//   Mars  (225°): diff=(105−225+360)%360=240°
+//                 std |240−180|=60>45→0
+//                 special 90°: |240−90|=150>35→0
+//                 special 210°: |240−210|=30≤35→1−30/35=0.143
+//                 → strength 0.143 (malefic, <0.66) → drig4 += −60×0.143 = −8.57
+//
+//   Mercury(165°): diff=(105−165+360)%360=300°; std |300−180|=120>45→0; no special → no aspect
+//
+//   Jupiter(105°): diff=(105−105+360)%360=0°
+//                 std |0−180|=180>45→0; special 120°:|0−120|=120>35→0; special 240°:|0−240|=240>35→0
+//                 → no aspect (Jupiter is the occupant; 0° diff yields no drishti)
+//
+//   Venus  (195°): diff=(105−195+360)%360=270°; std |270−180|=90>45→0; no special → no aspect
+//
+//   Saturn (285°): diff=(105−285+360)%360=180°
+//                 std |180−180|=0≤45→1.0
+//                 special 60°:|180−60|=120>35→0; special 270°:|180−270|=90>35→0
+//                 → strength 1.0 (malefic, ≥0.66) → drig3 += −90×1.0 = −90.0
+//
+//   drig1=0, drig2=0, drig3=−90.0, drig4=−8.57
+//
+// Bhavadhipati: Moon Ṣaḍbala = 420 vp / 360 req = 1.167× → bhavesha = 420
+//
+// Occupants: Jupiter (sign=4, benefic)
+//   Ṣaḍbala ratio = 520/390 = 1.333
+//   contribution = +45 × min(1.333, 2.0) = 45 × 1.333 = +60.0 vp
+//
+// ~Dig Bala: H4 is kendra (angular) → +15 vp
+//
+// Total = 0 + 0 + (−90.0) + (−8.57) + 420 + 60.0 + 15 = 396.43
+// ---------------------------------------------------------------------------
+function testHouse4(): { pass: number; fail: number } {
+  let pass = 0, fail = 0;
+  console.log('\n--- House 4 (Cancer, lord: Moon, Jupiter occupies) ---');
+
+  const rows = buildClassicalBhavaBala(FIXTURE_CHART, FIXTURE_SHADBALA);
+  const h4 = rows[3];
+
+  let ok = h4.sign === 'Cn' && h4.lord === 'Moon';
+  console.log(`${ok ? '✓' : '✗'} H4: sign=Cn lord=Moon, got sign=${h4.sign} lord=${h4.lord}`);
+  ok ? pass++ : fail++;
+
+  ok = h4.bhavesha === 420;
+  console.log(`${ok ? '✓' : '✗'} H4 bhavesha: expected 420 vp (Moon), got ${h4.bhavesha}`);
+  ok ? pass++ : fail++;
+
+  ok = approxEqual(h4.drig3, -90.0);
+  console.log(`${ok ? '✓' : '✗'} H4 drig3 (Saturn full 7th): expected −90.0, got ${h4.drig3.toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  ok = approxEqual(h4.drig4, -8.57);
+  console.log(`${ok ? '✓' : '✗'} H4 drig4 (Mars special 4th): expected ~−8.57, got ${h4.drig4.toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  ok = approxEqual(h4.drig1 + h4.drig2, 0, 0.01);
+  console.log(`${ok ? '✓' : '✗'} H4 drig+ (no benefic aspects): expected 0, got ${(h4.drig1 + h4.drig2).toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  ok = h4.occupants.length === 1 && h4.occupants[0].name === 'Jupiter';
+  console.log(`${ok ? '✓' : '✗'} H4 occupant: expected Jupiter, got ${h4.occupants.map((o) => o.name).join(',') || 'none'}`);
+  ok ? pass++ : fail++;
+
+  // +45 × min(520/390, 2.0) = 45 × 1.333 = 60.0
+  ok = approxEqual(h4.occupantTotal, 60.0, 1.0);
+  console.log(`${ok ? '✓' : '✗'} H4 occupantTotal: expected ~60.0 (+45×1.333), got ${h4.occupantTotal.toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  ok = h4.kendra === 15;
+  console.log(`${ok ? '✓' : '✗'} H4 ~Dig: expected +15 vp (kendra), got ${h4.kendra}`);
+  ok ? pass++ : fail++;
+
+  // 0 + 0 + (−90.0) + (−8.57) + 420 + 60.0 + 15 = 396.43
+  ok = approxEqual(h4.total, 396.43, 1.5);
+  console.log(`${ok ? '✓' : '✗'} H4 total: expected ~396.43 (0+0−90−8.57+420+60+15), got ${h4.total.toFixed(2)}`);
+  ok ? pass++ : fail++;
+
+  return { pass, fail };
+}
+
+// ---------------------------------------------------------------------------
+// House 12 — Pisces (lord: Jupiter, no occupants, cadent)
+// ---------------------------------------------------------------------------
+function testHouse12(): { pass: number; fail: number } {
+  let pass = 0, fail = 0;
+  console.log('\n--- House 12 (Pisces, lord: Jupiter, cadent) ---');
+
+  const rows = buildClassicalBhavaBala(FIXTURE_CHART, FIXTURE_SHADBALA);
+  const h12 = rows[11];
+
+  let ok = h12.sign === 'Pi' && h12.lord === 'Jupiter';
+  console.log(`${ok ? '✓' : '✗'} H12: sign=Pi lord=Jupiter, got sign=${h12.sign} lord=${h12.lord}`);
+  ok ? pass++ : fail++;
+
+  ok = h12.bhavesha === 520;
+  console.log(`${ok ? '✓' : '✗'} H12 bhavesha: expected 520 vp (Jupiter), got ${h12.bhavesha}`);
+  ok ? pass++ : fail++;
+
+  // H12 is apoklima (cadent) → kendra/Dig = 0
+  ok = h12.kendra === 0;
+  console.log(`${ok ? '✓' : '✗'} H12 ~Dig: expected 0 (apoklima/cadent), got ${h12.kendra}`);
+  ok ? pass++ : fail++;
+
+  // Jupiter is in H4, not H12
+  ok = h12.occupants.length === 0;
+  console.log(`${ok ? '✓' : '✗'} H12 occupants: expected none (Jupiter is in H4), got ${h12.occupants.length}`);
+  ok ? pass++ : fail++;
+
+  return { pass, fail };
+}
+
+// ---------------------------------------------------------------------------
+// All 12 house signs and lords (Aries ascendant, whole-sign)
+// ---------------------------------------------------------------------------
+function testAllHouseSigns(): { pass: number; fail: number } {
+  let pass = 0, fail = 0;
+  console.log('\n--- All 12 house signs and lords (Aries ascendant) ---');
+
+  const EXPECTED = [
+    { sign: 'Ar', lord: 'Mars'    },
+    { sign: 'Ta', lord: 'Venus'   },
+    { sign: 'Ge', lord: 'Mercury' },
+    { sign: 'Cn', lord: 'Moon'    },
+    { sign: 'Le', lord: 'Sun'     },
+    { sign: 'Vi', lord: 'Mercury' },
+    { sign: 'Li', lord: 'Venus'   },
+    { sign: 'Sc', lord: 'Mars'    },
+    { sign: 'Sg', lord: 'Jupiter' },
+    { sign: 'Cp', lord: 'Saturn'  },
+    { sign: 'Aq', lord: 'Saturn'  },
+    { sign: 'Pi', lord: 'Jupiter' },
+  ];
+
+  const rows = buildClassicalBhavaBala(FIXTURE_CHART, FIXTURE_SHADBALA);
+  assert(rows.length === 12, `expected 12 rows, got ${rows.length}`);
+  pass++;
+
+  for (let i = 0; i < 12; i++) {
+    const ok = rows[i].sign === EXPECTED[i].sign && rows[i].lord === EXPECTED[i].lord;
+    console.log(`${ok ? '✓' : '✗'} H${i + 1}: expected ${EXPECTED[i].sign}/${EXPECTED[i].lord}, got ${rows[i].sign}/${rows[i].lord}`);
+    ok ? pass++ : fail++;
+  }
+
+  return { pass, fail };
+}
+
+// ---------------------------------------------------------------------------
+// Occupants across all houses — spot-check Saturn in H10, Venus in H7
+// ---------------------------------------------------------------------------
+function testOccupants(): { pass: number; fail: number } {
+  let pass = 0, fail = 0;
+  console.log('\n--- Occupant placement and contribution ---');
+
+  const rows = buildClassicalBhavaBala(FIXTURE_CHART, FIXTURE_SHADBALA);
+
+  // Saturn (malefic) in H10 (Capricorn)
+  const h10 = rows[9];
+  let ok = h10.occupants.length === 1 && h10.occupants[0].name === 'Saturn';
+  console.log(`${ok ? '✓' : '✗'} H10 occupant: expected Saturn, got ${h10.occupants.map((o) => o.name).join(',') || 'none'}`);
+  ok ? pass++ : fail++;
+
+  // Saturn is malefic: contribution = −30 × min(310/300, 2) = −30 × 1.033 = −31.0
+  ok = h10.occupants[0].nature === 'malefic' && h10.occupants[0].contribution < 0;
+  console.log(`${ok ? '✓' : '✗'} H10 Saturn: malefic with negative contribution (${h10.occupants[0]?.contribution?.toFixed(1)})`);
+  ok ? pass++ : fail++;
+
+  // Venus (benefic) in H7
+  const h7 = rows[6];
+  ok = h7.occupants.length === 1 && h7.occupants[0].name === 'Venus';
+  console.log(`${ok ? '✓' : '✗'} H7 occupant: expected Venus, got ${h7.occupants.map((o) => o.name).join(',') || 'none'}`);
+  ok ? pass++ : fail++;
+
+  ok = h7.occupants[0].nature === 'benefic' && h7.occupants[0].contribution > 0;
+  console.log(`${ok ? '✓' : '✗'} H7 Venus: benefic with positive contribution (${h7.occupants[0]?.contribution?.toFixed(1)})`);
+  ok ? pass++ : fail++;
+
+  // Empty houses should have no occupants
+  const h1 = rows[0];
+  ok = h1.occupants.length === 0;
+  console.log(`${ok ? '✓' : '✗'} H1 (no occupants): expected 0, got ${h1.occupants.length}`);
+  ok ? pass++ : fail++;
+
+  return { pass, fail };
+}
+
+// ---------------------------------------------------------------------------
+// Panapara houses get +7.5 Dig, apoklima get 0
+// ---------------------------------------------------------------------------
+function testDigBala(): { pass: number; fail: number } {
+  let pass = 0, fail = 0;
+  console.log('\n--- ~Dig Bala (kendra +15, panapara +7.5, apoklima 0) ---');
+
+  const rows = buildClassicalBhavaBala(FIXTURE_CHART, FIXTURE_SHADBALA);
+
+  const kendraHouses = [1, 4, 7, 10];
+  const panaparaHouses = [2, 5, 8, 11];
+  const apoklimaHouses = [3, 6, 9, 12];
+
+  for (const h of kendraHouses) {
+    const ok = rows[h - 1].kendra === 15;
+    console.log(`${ok ? '✓' : '✗'} H${h} kendra: expected 15, got ${rows[h - 1].kendra}`);
+    ok ? pass++ : fail++;
+  }
+  for (const h of panaparaHouses) {
+    const ok = rows[h - 1].kendra === 7.5;
+    console.log(`${ok ? '✓' : '✗'} H${h} panapara: expected 7.5, got ${rows[h - 1].kendra}`);
+    ok ? pass++ : fail++;
+  }
+  for (const h of apoklimaHouses) {
+    const ok = rows[h - 1].kendra === 0;
+    console.log(`${ok ? '✓' : '✗'} H${h} apoklima: expected 0, got ${rows[h - 1].kendra}`);
+    ok ? pass++ : fail++;
+  }
+
+  return { pass, fail };
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+function main(): void {
+  const h1 = testHouse1();
+  const h4 = testHouse4();
+  const h12 = testHouse12();
+  const all = testAllHouseSigns();
+  const occ = testOccupants();
+  const dig = testDigBala();
+
+  const total = h1.pass + h4.pass + h12.pass + all.pass + occ.pass + dig.pass;
+  const failed = h1.fail + h4.fail + h12.fail + all.fail + occ.fail + dig.fail;
+  console.log(`\n${total} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+main();

--- a/src/lib/bhavaBala.ts
+++ b/src/lib/bhavaBala.ts
@@ -1,25 +1,52 @@
+export type OccupantDetail = {
+  name: string;
+  nature: 'benefic' | 'malefic';
+  shadbalaVirupa: number;
+  shadbalaRatio: number | null;
+  contribution: number;
+  note: string;
+};
+
+export type DrigDetail = {
+  planet: string;
+  nature: 'benefic' | 'malefic';
+  aspectStrength: number;
+  contribution: number;
+};
+
 export type BhavaBalaRow = {
   house: number;
   sign: string;
   lord: string;
-  drig1: number;
-  drig2: number;
-  drig3: number;
-  drig4: number;
+  // 1. Bhavadhipati Bala — house lord's Ṣaḍbala virupa
   bhavesha: number;
+  bhaveshaRequired: number;
+  bhaveshaRatio: number;
+  bhaveshaSource: string;
+  // 2. Bhava Drig Bala — simplified drishti to sign midpoint (~approx: sign*30+15°, not exact cusp)
+  drig1: number;  // strong benefic (strength ≥ 0.66): +180 × strength
+  drig2: number;  // weak benefic (strength < 0.66): +100 × strength
+  drig3: number;  // strong malefic (strength ≥ 0.66): −90 × strength
+  drig4: number;  // weak malefic (strength < 0.66): −60 × strength
+  drigDetails: DrigDetail[];
+  // 3. Occupant (Bhava Graha) contribution — ~approx: benefic +45×ratio, malefic −30×ratio
+  occupants: OccupantDetail[];
+  occupantTotal: number;
+  // 4. ~Bhava Dig Bala — positional bonus: kendra +15, panapara +7.5, apoklima 0 (~approx)
   kendra: number;
+  // Total in virupa
   total: number;
 };
 
 type ChartPlanet = {
   name: string;
   longitude: number;
-  sign: number;
+  sign: number;   // 1-indexed (1=Aries … 12=Pisces)
   house?: number;
 };
 
 type ChartLike = {
-  ascendant?: { sign?: number };
+  ascendant?: { sign?: number };  // sign is 1-indexed
   planets?: ChartPlanet[];
 };
 
@@ -27,12 +54,24 @@ type ShadbalaLike = {
   planet: string;
   total?: number;
   totalVirupa?: number;
+  requiredVirupa?: number;
+};
+
+type ShadbalaEntry = {
+  virupa: number;
+  required: number;
+  ratio: number;
 };
 
 const SIGN_ABBR = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
 const SIGN_LORDS = ['Mars', 'Venus', 'Mercury', 'Moon', 'Sun', 'Mercury', 'Venus', 'Mars', 'Jupiter', 'Saturn', 'Saturn', 'Jupiter'];
 const PLANETS = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn'];
-const BENEFICS = ['Moon', 'Mercury', 'Jupiter', 'Venus'];
+const BENEFICS = new Set(['Moon', 'Mercury', 'Jupiter', 'Venus']);
+
+// Classical required Ṣaḍbala minimums — used as fallback when `requiredVirupa` is not passed in.
+const SHADBALA_REQUIRED_VIRUPA: Record<string, number> = {
+  Sun: 390, Moon: 360, Mars: 300, Mercury: 420, Jupiter: 390, Venus: 330, Saturn: 300,
+};
 
 function normalizeDegrees(value: number): number {
   return ((value % 360) + 360) % 360;
@@ -46,6 +85,7 @@ function getPlanet(chart: ChartLike, name: string): ChartPlanet | undefined {
   return chart.planets?.find((planet) => planet.name === name);
 }
 
+// ascendantSign is 1-indexed; returns 0-indexed sign index for the Nth house.
 function getHouseSignIndex(ascendantSign: number | undefined, house: number): number | null {
   if (typeof ascendantSign !== 'number') return null;
   return (ascendantSign + house - 2 + 12) % 12;
@@ -80,12 +120,15 @@ export function getClassicalAspectStrength(fromName: string, fromLongitude: numb
 }
 
 // Simplified Bhava Drig Bala: orb-based drishti to the sign midpoint (sign * 30 + 15°).
-// NOT the cusp-based Drig Bala from classical texts — the actual house cusp longitude is
-// not available here, so the sign midpoint is used as a proxy.
-// drig1/drig3: strong aspects (strength >= 0.66); drig2/drig4: weaker aspects.
-function calculateBhavaDrig(chart: ChartLike, house: number): Pick<BhavaBalaRow, 'drig1' | 'drig2' | 'drig3' | 'drig4'> {
+// NOT cusp-based — the actual house cusp longitude is unavailable, so sign midpoint is a proxy.
+// Benefic aspects: +180 vp (strong, str≥0.66) or +100 vp (weak). Malefic: −90 (strong) or −60 (weak).
+// Returns drig1–4 totals plus per-planet drigDetails for debug display.
+function calculateBhavaDrig(
+  chart: ChartLike,
+  house: number,
+): { drig1: number; drig2: number; drig3: number; drig4: number; drigDetails: DrigDetail[] } {
   const midpoint = getHouseMidLongitude(chart.ascendant?.sign, house);
-  const result = { drig1: 0, drig2: 0, drig3: 0, drig4: 0 };
+  const result = { drig1: 0, drig2: 0, drig3: 0, drig4: 0, drigDetails: [] as DrigDetail[] };
   if (typeof midpoint !== 'number') return result;
 
   PLANETS.forEach((name) => {
@@ -95,44 +138,107 @@ function calculateBhavaDrig(chart: ChartLike, house: number): Pick<BhavaBalaRow,
     const aspect = getClassicalAspectStrength(name, planet.longitude, midpoint);
     if (!aspect) return;
 
-    if (BENEFICS.includes(name)) {
-      if (aspect >= 0.66) result.drig1 += 180 * aspect;
-      else result.drig2 += 100 * aspect;
+    const isBenefic = BENEFICS.has(name);
+    const nature = isBenefic ? 'benefic' : 'malefic' as 'benefic' | 'malefic';
+    let contribution = 0;
+
+    if (isBenefic) {
+      if (aspect >= 0.66) {
+        contribution = 180 * aspect;
+        result.drig1 += contribution;
+      } else {
+        contribution = 100 * aspect;
+        result.drig2 += contribution;
+      }
     } else if (aspect >= 0.66) {
-      result.drig3 -= 90 * aspect;
+      contribution = -90 * aspect;
+      result.drig3 += contribution;
     } else {
-      result.drig4 -= 60 * aspect;
+      contribution = -60 * aspect;
+      result.drig4 += contribution;
     }
+
+    result.drigDetails.push({ planet: name, nature, aspectStrength: aspect, contribution });
   });
 
   return result;
 }
 
-function createShadbalaMap(shadbala: ShadbalaLike[]): Record<string, number> {
+// Occupant (Bhava Graha) contribution — approximate.
+// Finds planets occupying this house (via whole-sign match to planet.sign).
+// Benefic planet: +45 × min(Ṣaḍbala ratio, 2.0) virupa.
+// Malefic planet: −30 × min(Ṣaḍbala ratio, 2.0) virupa.
+// Ratio defaults to 1.0 if Ṣaḍbala is not available.
+// A stronger benefic occupant adds more; a stronger malefic subtracts more.
+function calculateOccupants(
+  chart: ChartLike,
+  house: number,
+  shadbalaMap: Record<string, ShadbalaEntry>,
+): { occupants: OccupantDetail[]; occupantTotal: number } {
+  const ascendantSign = chart.ascendant?.sign;
+  const houseSignIndex = getHouseSignIndex(ascendantSign, house);
+  if (typeof houseSignIndex !== 'number') return { occupants: [], occupantTotal: 0 };
+
+  const houseSign1 = houseSignIndex + 1;  // convert to 1-indexed to match planet.sign
+  const occupants: OccupantDetail[] = [];
+  let occupantTotal = 0;
+
+  PLANETS.forEach((name) => {
+    const planet = getPlanet(chart, name);
+    if (typeof planet?.sign !== 'number') return;
+    if (planet.sign !== houseSign1) return;
+
+    const isBenefic = BENEFICS.has(name);
+    const nature = isBenefic ? 'benefic' : 'malefic' as 'benefic' | 'malefic';
+    const entry = shadbalaMap[name];
+    const shadbalaVirupa = entry?.virupa ?? 0;
+    const shadbalaRequired = entry?.required ?? SHADBALA_REQUIRED_VIRUPA[name] ?? 0;
+    const shadbalaRatio = shadbalaRequired > 0 && shadbalaVirupa > 0
+      ? shadbalaVirupa / shadbalaRequired
+      : null;
+    const effectiveRatio = shadbalaRatio !== null ? Math.min(shadbalaRatio, 2.0) : 1.0;
+    const base = isBenefic ? 45 : -30;
+    const contribution = base * effectiveRatio;
+    occupantTotal += contribution;
+
+    const ratioLabel = shadbalaRatio !== null
+      ? `${shadbalaRatio.toFixed(2)}× req`
+      : 'no Ṣaḍbala';
+    const note = `${ratioLabel}; ~${Math.abs(base)}×min(${effectiveRatio.toFixed(2)},2)`;
+
+    occupants.push({ name, nature, shadbalaVirupa, shadbalaRatio, contribution, note });
+  });
+
+  return { occupants, occupantTotal };
+}
+
+function createShadbalaMap(shadbala: ShadbalaLike[]): Record<string, ShadbalaEntry> {
   return Object.fromEntries(
-    shadbala.map((row) => [
-      row.planet,
-      typeof row.totalVirupa === 'number'
+    shadbala.map((row) => {
+      const virupa = typeof row.totalVirupa === 'number'
         ? row.totalVirupa
         : typeof row.total === 'number'
           ? row.total * 60
-          : 0,
-    ]),
+          : 0;
+      const required = row.requiredVirupa ?? SHADBALA_REQUIRED_VIRUPA[row.planet] ?? 0;
+      const ratio = required > 0 ? virupa / required : 0;
+      return [row.planet, { virupa, required, ratio }];
+    }),
   );
 }
 
-// Computes a partial classical Bhava Bala using two of the classical components:
-//   1. Bhavesha Bala  — the house lord's total Shadbala (virupa), passed in via `shadbala`.
-//   2. Bhava Drig Bala — simplified drishti to the house sign midpoint (see calculateBhavaDrig).
-//   3. Kendra bonus — +15 virupa for angular houses (H1, H4, H7, H10), per classical convention.
+// Computes classical Bhava Bala using explicit subcomponents. All values in virupa (no 0–100 normalisation).
 //
-// NOT yet implemented (require additional inputs not currently available):
-//   • Bhava Digbala (directional strength of the house)
-//   • Bhava Kala Bala (temporal strength)
-//   • Cusp-based Bhava Drig (exact house cusp longitudes)
+// Components included:
+//   1. Bhavadhipati Bala  — lord's Ṣaḍbala total virupa (source shown in bhaveshaSource)
+//   2. Bhava Drig Bala    — ~approx: orb-based drishti to sign midpoint (sign*30+15°)
+//   3. Occupant Bala      — ~approx: benefic +45×ratio, malefic −30×ratio virupa
+//   4. ~Bhava Dig Bala    — ~approx: kendra +15, panapara +7.5, apoklima 0 virupa
 //
-// All values are in virupa. There is no normalization to 0–100; consumers should interpret
-// totals relative to each other within a chart, not against a fixed scale.
+// Components NOT yet implemented (require additional inputs not currently available):
+//   • Exact Bhava Drig Bala using house cusp longitudes instead of sign midpoints
+//   • Classical Bhava Kala Bala (temporal house strength)
+//
 export function buildClassicalBhavaBala(chart: ChartLike, shadbala: ShadbalaLike[]): BhavaBalaRow[] {
   const ascendantSign = chart.ascendant?.sign;
   const shadbalaMap = createShadbalaMap(shadbala);
@@ -141,17 +247,36 @@ export function buildClassicalBhavaBala(chart: ChartLike, shadbala: ShadbalaLike
     const house = index + 1;
     const signIndex = getHouseSignIndex(ascendantSign, house);
     const lord = typeof signIndex === 'number' ? SIGN_LORDS[signIndex] : '—';
+
     const drig = calculateBhavaDrig(chart, house);
-    const bhavesha = shadbalaMap[lord] ?? 0;
-    const kendra = [1, 4, 7, 10].includes(house) ? 15 : 0;
-    const total = drig.drig1 + drig.drig2 + drig.drig3 + drig.drig4 + bhavesha + kendra;
+    const { occupants, occupantTotal } = calculateOccupants(chart, house, shadbalaMap);
+
+    const lordEntry = shadbalaMap[lord];
+    const bhavesha = lordEntry?.virupa ?? 0;
+    const bhaveshaRequired = lordEntry?.required ?? SHADBALA_REQUIRED_VIRUPA[lord] ?? 0;
+    const bhaveshaRatio = lordEntry?.ratio ?? 0;
+    const bhaveshaSource = lordEntry
+      ? `Ṣaḍbala ${Math.round(bhavesha)} vp / ${bhaveshaRequired} req = ${bhaveshaRatio.toFixed(2)}×`
+      : 'fallback: 0 vp (Ṣaḍbala not computed)';
+
+    // ~Bhava Dig Bala: kendra (angular) +15, panapara (succedent) +7.5, apoklima (cadent) 0.
+    // Approximate — full Bhava Dig Bala requires house cusp directional longitude.
+    const kendra = [1, 4, 7, 10].includes(house) ? 15 : [2, 5, 8, 11].includes(house) ? 7.5 : 0;
+
+    const total = drig.drig1 + drig.drig2 + drig.drig3 + drig.drig4
+      + bhavesha + occupantTotal + kendra;
 
     return {
       house,
       sign: typeof signIndex === 'number' ? SIGN_ABBR[signIndex] : '—',
       lord,
-      ...drig,
       bhavesha,
+      bhaveshaRequired,
+      bhaveshaRatio,
+      bhaveshaSource,
+      ...drig,
+      occupants,
+      occupantTotal,
       kendra,
       total,
     };

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,17 @@
 export const CHANGELOG = [
   {
+    version: 'v1.55',
+    changes: [
+      'Bhava Bala: added occupant (Bhava Graha) contribution — ~approx: benefic occupant +45 × Ṣaḍbala ratio, malefic −30 × ratio virupa',
+      'Bhava Bala: Bhavadhipati column now shows lord virupa, required minimum, and ratio transparently (source from Ṣaḍbala)',
+      'Bhava Bala: ~Bhava Dig Bala expanded — kendra +15 vp, panapara +7.5 vp, apoklima 0 vp (labeled approximate)',
+      'Bhava Bala: expandable per-house debug row shows lord source, each occupant with contribution, each aspecting planet with contribution and aspect strength, and explicit A+B+C=total formula',
+      'Bhava Bala: Status column added — strong/ok/weak relative to chart mean (not a fixed threshold)',
+      'Bhava Bala: negative contributions visible in Drig− column and occupant column for malefic planets',
+      'Added bhavaBala.test.ts: deterministic verification fixture with fully worked H1 and H4 manual calculations',
+    ],
+  },
+  {
     version: 'v1.54',
     changes: [
       'Shadbala rewritten to use classical virūpa totals and planet-specific minimum thresholds',

--- a/src/pages/VargaMatrix.jsx
+++ b/src/pages/VargaMatrix.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, Fragment } from 'react';
 import { getVargaSignIndex, getSignIndex, getDegreesInSign } from '@/lib/varga';
 import { buildClassicalBhavaBala } from '@/lib/bhavaBala';
 
@@ -309,44 +309,128 @@ export function ShadbalaCard({ chart }) {
 }
 
 export function BhavaBalaCard({ chart }) {
+  const [expandedHouse, setExpandedHouse] = useState(null);
   if (!chart) return <div className="flex items-center justify-center h-40 text-zinc-400 dark:text-zinc-600 text-xs font-mono text-center px-4">Calculate a chart to see Bhava Bala</div>;
-  // Bhavesha Bala uses the lord's Shadbala (already computed). Drig Bala uses simplified
-  // orb-based drishti to the house sign midpoint. Bhava Digbala and Kala Bala not included.
   const shadbala = buildShadbalaRows(chart);
   const bhavaBala = buildClassicalBhavaBala(chart, shadbala);
+  const mean = bhavaBala.reduce((s, r) => s + r.total, 0) / 12;
+
+  function getStatus(total) {
+    if (total >= mean * 1.1) return 'strong';
+    if (total >= mean * 0.9) return 'ok';
+    return 'weak';
+  }
+  function getStatusCls(status) {
+    if (status === 'strong') return 'text-emerald-600 dark:text-emerald-400';
+    if (status === 'ok') return 'text-amber-600 dark:text-amber-400';
+    return 'text-red-600 dark:text-red-400';
+  }
+
   return (
     <div className="space-y-3">
       <div>
         <div className="text-xs font-mono font-semibold text-zinc-700 dark:text-zinc-300">Bhava Bala <span className="text-[9px] font-normal text-amber-600 dark:text-amber-400 ml-1">beta</span></div>
-        <div className="text-[10px] font-mono text-zinc-400 dark:text-zinc-600 mt-1">Bhavesha = lord&apos;s Ṣaḍbala (virupa). Drig = simplified drishti to sign midpoint. Kendra = +15 virupa (H1/4/7/10). Bhava Digbala and Kala Bala not yet included.</div>
+        <div className="text-[10px] font-mono text-zinc-400 dark:text-zinc-600 mt-1">
+          Bhavadhipati = lord&apos;s Ṣaḍbala virupa (ratio shown). ~Drig = orb-based drishti to sign midpoint.
+          ~Occupant = benefic +45×ratio, malefic −30×ratio. ~Dig = kendra +15/panapara +7.5 vp.
+          Status relative to chart mean. Click a row for per-house debug breakdown.
+        </div>
       </div>
       <div className="overflow-x-auto border border-zinc-200 dark:border-zinc-700 rounded-lg">
-        <table className="w-full min-w-[640px] border-collapse text-xs font-mono">
+        <table className="w-full min-w-[860px] border-collapse text-xs font-mono">
           <thead>
             <tr className="bg-zinc-100 dark:bg-zinc-800">
               <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">House</th>
               <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Sign</th>
               <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Lord</th>
-              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Bhavesha</th>
-              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Drig+</th>
-              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Drig−</th>
-              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Kendra</th>
-              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Total</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Bhavadhipati vp</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">~Occupants</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">~Drig+</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">~Drig−</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">~Dig</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Total vp</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Status</th>
             </tr>
           </thead>
           <tbody>
-            {bhavaBala.map((row) => (
-              <tr key={row.house} className="border-b border-zinc-100 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
-                <td className="p-2 border border-zinc-100 dark:border-zinc-800 font-bold text-emerald-700 dark:text-green-400">H{row.house}</td>
-                <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">{row.sign}</td>
-                <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">{row.lord}</td>
-                <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">{formatScore(row.bhavesha)}</td>
-                <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">{formatScore(row.drig1 + row.drig2)}</td>
-                <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">{formatScore(row.drig3 + row.drig4)}</td>
-                <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">{formatScore(row.kendra)}</td>
-                <td className="p-2 border border-zinc-100 dark:border-zinc-800 font-bold text-amber-700 dark:text-amber-300">{formatScore(row.total)}</td>
-              </tr>
-            ))}
+            {bhavaBala.map((row) => {
+              const status = getStatus(row.total);
+              const statusCls = getStatusCls(status);
+              const isExpanded = expandedHouse === row.house;
+              const totalPct = mean > 0 ? Math.round((row.total / mean) * 100) : 0;
+              const drigPos = row.drig1 + row.drig2;
+              const drigNeg = row.drig3 + row.drig4;
+              return (
+                <Fragment key={row.house}>
+                  <tr
+                    className="border-b border-zinc-100 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer"
+                    onClick={() => setExpandedHouse(isExpanded ? null : row.house)}
+                  >
+                    <td className="p-2 border border-zinc-100 dark:border-zinc-800 font-bold text-emerald-700 dark:text-green-400 whitespace-nowrap">
+                      H{row.house} <span className="text-[9px] text-zinc-400 dark:text-zinc-600">{isExpanded ? '▼' : '▶'}</span>
+                    </td>
+                    <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">{row.sign}</td>
+                    <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">{row.lord}</td>
+                    <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300" title={row.bhaveshaSource}>
+                      {formatScore(row.bhavesha)}
+                      <span className="ml-1 text-[9px] text-zinc-400 dark:text-zinc-500">{row.bhaveshaRatio.toFixed(2)}×</span>
+                    </td>
+                    <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">
+                      {row.occupants.length === 0 ? <span className="text-zinc-400 dark:text-zinc-600">—</span> : row.occupants.map((o) => (
+                        <span key={o.name} className={o.nature === 'benefic' ? 'text-emerald-700 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'}>
+                          {o.name}({o.contribution > 0 ? '+' : ''}{Math.round(o.contribution)})
+                        </span>
+                      ))}
+                    </td>
+                    <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-emerald-700 dark:text-emerald-400">{drigPos > 0 ? `+${formatScore(drigPos)}` : '—'}</td>
+                    <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-red-600 dark:text-red-400">{drigNeg < 0 ? formatScore(drigNeg) : '—'}</td>
+                    <td className="p-2 border border-zinc-100 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300">{row.kendra > 0 ? `+${formatScore(row.kendra)}` : '—'}</td>
+                    <td className="p-2 border border-zinc-100 dark:border-zinc-800 font-bold text-amber-700 dark:text-amber-300 whitespace-nowrap">
+                      {Math.round(row.total)} <span className="text-[9px] text-zinc-400 dark:text-zinc-500">({totalPct}%)</span>
+                    </td>
+                    <td className={`p-2 border border-zinc-100 dark:border-zinc-800 font-bold ${statusCls}`}>{status}</td>
+                  </tr>
+                  {isExpanded && (
+                    <tr className="bg-zinc-50 dark:bg-zinc-800/40">
+                      <td colSpan={10} className="p-3 border border-zinc-100 dark:border-zinc-800 text-[10px] font-mono text-zinc-600 dark:text-zinc-400">
+                        <div className="space-y-1.5">
+                          <div>
+                            <span className="text-zinc-500 dark:text-zinc-500">Lord:</span> {row.lord} —{' '}
+                            <span className="text-zinc-500 dark:text-zinc-500">source:</span> {row.bhaveshaSource}
+                          </div>
+                          <div>
+                            <span className="text-zinc-500 dark:text-zinc-500">~Occupants:</span>{' '}
+                            {row.occupants.length === 0
+                              ? 'none'
+                              : row.occupants.map((o) => `${o.name} (${o.nature}, ${o.note}) → ${o.contribution > 0 ? '+' : ''}${o.contribution.toFixed(1)} vp`).join('; ')}
+                          </div>
+                          <div>
+                            <span className="text-zinc-500 dark:text-zinc-500">~Drig aspects to H{row.house} sign midpoint:</span>{' '}
+                            {row.drigDetails.length === 0
+                              ? 'none'
+                              : row.drigDetails.map((d) => `${d.planet}(${d.nature[0]}: ${d.contribution > 0 ? '+' : ''}${d.contribution.toFixed(1)} vp, str=${d.aspectStrength.toFixed(2)})`).join('; ')}
+                          </div>
+                          <div>
+                            <span className="text-zinc-500 dark:text-zinc-500">~Dig Bala:</span>{' '}
+                            {row.kendra > 0
+                              ? `+${row.kendra} vp (${[1, 4, 7, 10].includes(row.house) ? 'kendra/angular' : 'panapara/succedent'})`
+                              : '0 (apoklima/cadent)'} — approximate
+                          </div>
+                          <div className="border-t border-zinc-200 dark:border-zinc-700 pt-1.5 text-zinc-500 dark:text-zinc-500">
+                            Calculation: Bhavadhipati {formatScore(row.bhavesha)}
+                            {row.occupantTotal !== 0 && ` + ~Occ ${row.occupantTotal > 0 ? '+' : ''}${row.occupantTotal.toFixed(1)}`}
+                            {` + ~Drig+ ${formatScore(row.drig1 + row.drig2)}`}
+                            {` + ~Drig− ${formatScore(row.drig3 + row.drig4)}`}
+                            {row.kendra > 0 && ` + ~Dig ${row.kendra}`}
+                            {' = '}<span className="font-bold text-amber-700 dark:text-amber-300">{Math.round(row.total)} vp</span>
+                          </div>
+                        </div>
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
…ation fixture

- bhavaBala.ts: add OccupantDetail/DrigDetail types; calculate Bhava Graha Bala (~approx: benefic +45×ratio, malefic −30×ratio virupa scaled by Ṣaḍbala ratio); expose drigDetails per planet for transparent breakdown; add bhaveshaRequired/Ratio/Source fields; extend ~Dig Bala to include panapara houses (+7.5 vp) alongside kendra (+15 vp)
- VargaMatrix.jsx: update BhavaBalaCard with new columns (Bhavadhipati shows virupa + ratio, ~Occupants with signed per-planet values, ~Drig+, ~Drig−, ~Dig, Total%, Status); add expandable per-house debug row showing lord source, occupants with notes, each aspecting planet with contribution and strength, and explicit A+B+C=total formula
- bhavaBala.test.ts: new deterministic verification fixture; H1 and H4 fully worked through step-by-step in comments (drig, bhavesha, occupant, dig); covers all 12 sign/lord assignments, panapara/apoklima Dig Bala, and occupant placement for malefic (H10 Saturn) and benefic (H7 Venus)
- changelog: add v1.55 entry