### PR TITLE
refactor: BNN into single Event Detection module, remove Pada/D108/AV

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,8 +22,6 @@ import FileActions, { ChartSnapshot } from '@/components/FileActions';
 import BcpSummary from '@/components/BcpSummary';
 import BcpManualOverride from '@/components/BcpManualOverride';
 import BnnPanel from '@/components/bnn/BnnPanel';
-import BNNJupiterianRoundsPanel from '@/components/BNNJupiterianRoundsPanel';
-import BNNJupiterMinorPanel from '@/components/BNNJupiterMinorPanel';
 import BNNEventDetectionPanel from '@/components/BNNEventDetectionPanel';
 import WorkspaceView from '@/components/workspace/WorkspaceView';
 
@@ -912,33 +910,13 @@ export default function Home() {
             {desktopTab === 'bnn' && (
               chartData
                 ? <div className="space-y-6">
-                    {chartDisplaySettings.showBnnEventDetection && (
-                      <BNNEventDetectionPanel
-                        chart={chartData}
-                        birthDatetime={birthDatetime}
-                        targetDate={targetDate}
-                        bnnOverrideStr={bnnOverrideStr}
-                        onBnnOverrideStrChange={setBnnOverrideStr}
-                      />
-                    )}
-                    {chartDisplaySettings.showBnnJupiterianRounds && (
-                      <div className="border-t border-zinc-200 dark:border-zinc-700 pt-4">
-                        <BNNJupiterianRoundsPanel
-                          chart={chartData}
-                          birthDatetime={birthDatetime}
-                          targetDate={targetDate}
-                        />
-                      </div>
-                    )}
-                    {chartDisplaySettings.showBnnJupiterMinor && (
-                      <div className="border-t border-zinc-200 dark:border-zinc-700 pt-4">
-                        <BNNJupiterMinorPanel
-                          chart={chartData}
-                          birthDatetime={birthDatetime}
-                          targetDate={targetDate}
-                        />
-                      </div>
-                    )}
+                    <BNNEventDetectionPanel
+                      chart={chartData}
+                      birthDatetime={birthDatetime}
+                      targetDate={targetDate}
+                      bnnOverrideStr={bnnOverrideStr}
+                      onBnnOverrideStrChange={setBnnOverrideStr}
+                    />
                     {chartDisplaySettings.showBnnDebug && (
                       <div className="border-t border-zinc-200 dark:border-zinc-700 pt-4">
                         <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600 mb-3">
@@ -1066,33 +1044,13 @@ export default function Home() {
           <Panel>
             {chartData
               ? <div className="space-y-6">
-                  {chartDisplaySettings.showBnnEventDetection && (
-                    <BNNEventDetectionPanel
-                      chart={chartData}
-                      birthDatetime={birthDatetime}
-                      targetDate={targetDate}
-                      bnnOverrideStr={bnnOverrideStr}
-                      onBnnOverrideStrChange={setBnnOverrideStr}
-                    />
-                  )}
-                  {chartDisplaySettings.showBnnJupiterianRounds && (
-                    <div className="border-t border-zinc-200 dark:border-zinc-700 pt-4">
-                      <BNNJupiterianRoundsPanel
-                        chart={chartData}
-                        birthDatetime={birthDatetime}
-                        targetDate={targetDate}
-                      />
-                    </div>
-                  )}
-                  {chartDisplaySettings.showBnnJupiterMinor && (
-                    <div className="border-t border-zinc-200 dark:border-zinc-700 pt-4">
-                      <BNNJupiterMinorPanel
-                        chart={chartData}
-                        birthDatetime={birthDatetime}
-                        targetDate={targetDate}
-                      />
-                    </div>
-                  )}
+                  <BNNEventDetectionPanel
+                    chart={chartData}
+                    birthDatetime={birthDatetime}
+                    targetDate={targetDate}
+                    bnnOverrideStr={bnnOverrideStr}
+                    onBnnOverrideStrChange={setBnnOverrideStr}
+                  />
                   {chartDisplaySettings.showBnnDebug && (
                     <div className="border-t border-zinc-200 dark:border-zinc-700 pt-4">
                       <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600 mb-3">

--- a/src/components/AshtakavargaPanel.tsx
+++ b/src/components/AshtakavargaPanel.tsx
@@ -1,65 +1,12 @@
 'use client';
 
-import { buildAshtakavarga } from '@/lib/ashtakavarga';
-
-export default function AshtakavargaPanel({ chart }: any) {
-  if (!chart) return null;
-
-  const { bav, sav } = buildAshtakavarga(chart);
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export default function AshtakavargaPanel(_props: { chart?: unknown }) {
   return (
-    <div className="space-y-4">
-      <div>
-        <div className="text-xs font-mono text-zinc-500">&gt; ashtakavarga.bav</div>
-        <div className="overflow-x-auto border rounded">
-          <table className="text-xs font-mono min-w-[720px]">
-            <thead>
-              <tr>
-                <th>Planet</th>
-                {Array.from({ length: 12 }, (_, i) => (
-                  <th key={i}>H{i + 1}</th>
-                ))}
-                <th>Total</th>
-              </tr>
-            </thead>
-            <tbody>
-              {bav.map((row) => (
-                <tr key={row.planet}>
-                  <td>{row.planet}</td>
-                  {row.houses.map((v, i) => (
-                    <td key={i}>{v}</td>
-                  ))}
-                  <td>{row.total}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-
-      <div>
-        <div className="text-xs font-mono text-zinc-500">&gt; ashtakavarga.sav</div>
-        <div className="overflow-x-auto border rounded">
-          <table className="text-xs font-mono min-w-[720px]">
-            <thead>
-              <tr>
-                {Array.from({ length: 12 }, (_, i) => (
-                  <th key={i}>H{i + 1}</th>
-                ))}
-                <th>Total</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                {sav.houses.map((v, i) => (
-                  <td key={i}>{v}</td>
-                ))}
-                <td>{sav.total}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
+    <div className="rounded-md border border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 px-3 py-4 text-center">
+      <p className="text-xs font-mono text-zinc-400 dark:text-zinc-600">
+        Ashtakavarga not available yet
+      </p>
     </div>
   );
 }

--- a/src/components/BNNEventDetectionPanel.tsx
+++ b/src/components/BNNEventDetectionPanel.tsx
@@ -7,6 +7,11 @@ import { calculateJupiterianRounds } from '@/lib/bnn/jupiterianRounds';
 import { calculateMinorProgression } from '@/lib/bnn/jupiterMinorProgression';
 import { detectBNNEventWindows, type BNNEventWindow } from '@/lib/bnn/eventDetection';
 
+const SIGN_ABBR: Record<number, string> = {
+  1: 'Ar', 2: 'Ta', 3: 'Ge', 4: 'Cn', 5: 'Le', 6: 'Vi',
+  7: 'Li', 8: 'Sc', 9: 'Sg', 10: 'Cp', 11: 'Aq', 12: 'Pi',
+};
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function parseBirthDatetime(dt: string): Date | null {
@@ -165,6 +170,8 @@ export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDat
   const natalJupiterSignIndex = natalJupiter ? natalJupiter.sign - 1 : 0;
   const natalJupiterDegree = natalJupiter ? natalJupiter.degree : 0;
 
+  const [collapsed, setCollapsed] = useState(false);
+
   const autoAge = useMemo(() => {
     if (!birthDatetime || !targetDate) return null;
     const birth = parseBirthDatetime(birthDatetime);
@@ -225,97 +232,146 @@ export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDat
   const ageYearsInt = Math.floor(effectiveAge);
   const ageMonthsInt = Math.round((effectiveAge - ageYearsInt) * 12);
 
-  const majorActiveSign = roundsResult.currentRound
+  const temporaryLagna = roundsResult.currentRound
     ? SIGN_NAMES[roundsResult.currentRound.activeSignIndex]
     : null;
+  const currentRoundNumber = roundsResult.currentRound?.roundNumber ?? null;
+  const balanceDegrees = roundsResult.balanceDegrees;
+  const natalJupSignName = SIGN_NAMES[natalJupiterSignIndex];
+  const natalJupSignAbbr = SIGN_ABBR[natalJupiter.sign] ?? natalJupSignName;
 
   const highWindows = eventWindows.filter(w => w.confidence === 'high');
   const mediumWindows = eventWindows.filter(w => w.confidence === 'medium');
   const lowWindows = eventWindows.filter(w => w.confidence === 'low');
 
   return (
-    <div className="space-y-5">
-      <div className="text-xs font-mono text-zinc-500 dark:text-zinc-500">&gt; BNN Event Detection</div>
+    <div className="space-y-4">
+      {/* Header — collapsible */}
+      <button
+        type="button"
+        onClick={() => setCollapsed(v => !v)}
+        className="flex items-center justify-between w-full text-left"
+      >
+        <span className="text-xs font-mono text-zinc-500 dark:text-zinc-500">&gt; BNN Event Detection</span>
+        <span className="text-[9px] text-zinc-400 dark:text-zinc-600 ml-2">{collapsed ? '▶' : '▼'}</span>
+      </button>
 
-      {/* Context strip */}
-      <div className="rounded-md border border-zinc-200 dark:border-zinc-700 px-3 py-2 space-y-1">
-        <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600">
-          context
-        </div>
-        <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-[10px] font-mono">
-          <span className="text-zinc-500 dark:text-zinc-400">
-            age{' '}
-            <span className="text-emerald-700 dark:text-green-400 font-semibold">
-              {ageYearsInt}y {ageMonthsInt}m
-            </span>
-          </span>
-          {majorActiveSign && (
-            <span className="text-zinc-500 dark:text-zinc-400">
-              major round:{' '}
-              <span className="text-zinc-700 dark:text-zinc-300">{majorActiveSign}</span>
-            </span>
-          )}
-          <span className="text-zinc-500 dark:text-zinc-400">
-            minor sign:{' '}
-            <span className="text-zinc-700 dark:text-zinc-300">{minorProgression.minorSignName}</span>
-          </span>
-        </div>
-      </div>
+      {!collapsed && (
+        <div className="space-y-5">
+          {/* Context strip */}
+          <div className="rounded-md border border-zinc-200 dark:border-zinc-700 px-3 py-2.5 space-y-2">
+            <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600">
+              context
+            </div>
 
-      {/* Age override */}
-      <div className="space-y-1.5">
-        <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600">age</div>
-        {autoAge !== null && (
-          <div className="text-xs font-mono text-zinc-500 dark:text-zinc-400">
-            auto: {ageYearsInt} yrs {ageMonthsInt} mo
+            {/* Age row */}
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-[10px] font-mono">
+              <span className="text-zinc-500 dark:text-zinc-400">
+                auto:{' '}
+                <span className="text-zinc-700 dark:text-zinc-300">
+                  {autoAge !== null ? `${Math.floor(autoAge)}y ${Math.round((autoAge - Math.floor(autoAge)) * 12)}m` : '—'}
+                </span>
+              </span>
+              <span className="text-zinc-500 dark:text-zinc-400">
+                using:{' '}
+                <span className="text-emerald-700 dark:text-green-400 font-semibold">
+                  {ageYearsInt}y {ageMonthsInt}m
+                </span>
+              </span>
+            </div>
+
+            {/* Jupiter + round */}
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-[10px] font-mono">
+              <span className="text-zinc-500 dark:text-zinc-400">
+                natal ♃:{' '}
+                <span className="text-zinc-700 dark:text-zinc-300">
+                  {natalJupSignAbbr} {natalJupiterDegree.toFixed(1)}°
+                </span>
+              </span>
+              <span className="text-zinc-500 dark:text-zinc-400">
+                balance:{' '}
+                <span className="text-zinc-700 dark:text-zinc-300">{balanceDegrees.toFixed(1)}°</span>
+              </span>
+              {currentRoundNumber !== null && (
+                <span className="text-zinc-500 dark:text-zinc-400">
+                  round:{' '}
+                  <span className="text-zinc-700 dark:text-zinc-300">#{currentRoundNumber}</span>
+                </span>
+              )}
+            </div>
+
+            {/* Temp Lagna + Minor */}
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-[10px] font-mono">
+              {temporaryLagna && (
+                <span className="text-zinc-500 dark:text-zinc-400">
+                  temp lagna:{' '}
+                  <span className="text-orange-600 dark:text-orange-400 font-semibold">{temporaryLagna}</span>
+                </span>
+              )}
+              <span className="text-zinc-500 dark:text-zinc-400">
+                minor sign:{' '}
+                <span className="text-violet-600 dark:text-violet-400 font-semibold">{minorProgression.minorSignName}</span>
+              </span>
+            </div>
+
+            {/* Age override inline */}
+            <div className="flex items-center gap-2 pt-1 border-t border-zinc-100 dark:border-zinc-800">
+              <label className="text-[10px] font-mono text-zinc-400 dark:text-zinc-600 shrink-0">age override:</label>
+              <input
+                type="number"
+                min="0"
+                max="120"
+                step="0.1"
+                value={overrideStr}
+                onChange={e => setOverrideStr(e.target.value)}
+                placeholder={effectiveAge.toFixed(1)}
+                className={INPUT}
+              />
+              {overrideStr.trim() && (
+                <button
+                  type="button"
+                  onClick={() => setOverrideStr('')}
+                  className="text-[9px] font-mono text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300"
+                >
+                  clear
+                </button>
+              )}
+            </div>
           </div>
-        )}
-        <div className="flex items-center gap-2">
-          <label className="text-xs font-mono text-zinc-500 dark:text-zinc-400">override:</label>
-          <input
-            type="number"
-            min="0"
-            max="120"
-            step="0.1"
-            value={overrideStr}
-            onChange={e => setOverrideStr(e.target.value)}
-            placeholder={effectiveAge.toFixed(1)}
-            className={INPUT}
+
+          {/* Strong event windows */}
+          <EventGroup
+            label="Strong event windows"
+            labelClass="text-emerald-600 dark:text-green-500"
+            windows={highWindows}
+            emptyText="No high-confidence event windows active."
           />
+
+          {/* Medium event windows */}
+          <EventGroup
+            label="Medium event windows"
+            labelClass="text-amber-600 dark:text-amber-500"
+            windows={mediumWindows}
+            emptyText="No medium-confidence event windows active."
+          />
+
+          {/* Low / background */}
+          <EventGroup
+            label="Low / background themes"
+            labelClass="text-zinc-400 dark:text-zinc-600"
+            windows={lowWindows}
+            emptyText="No background themes active."
+          />
+
+          {/* Explanation note */}
+          <div className="rounded-md border border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 px-3 py-2">
+            <p className="text-[10px] font-mono text-zinc-400 dark:text-zinc-600 leading-relaxed">
+              BNN Event Detection combines Jupiterian Round (major) and Minor Jupiter Progression (minor).
+              High = both active. Always confirm with dasha and transit.
+            </p>
+          </div>
         </div>
-      </div>
-
-      {/* High confidence */}
-      <EventGroup
-        label="Strong event windows"
-        labelClass="text-emerald-600 dark:text-green-500"
-        windows={highWindows}
-        emptyText="No high-confidence event windows active."
-      />
-
-      {/* Medium confidence */}
-      <EventGroup
-        label="Medium event windows"
-        labelClass="text-amber-600 dark:text-amber-500"
-        windows={mediumWindows}
-        emptyText="No medium-confidence event windows active."
-      />
-
-      {/* Low confidence */}
-      <EventGroup
-        label="Low / background themes"
-        labelClass="text-zinc-400 dark:text-zinc-600"
-        windows={lowWindows}
-        emptyText="No background themes active."
-      />
-
-      {/* Disclaimer */}
-      <div className="rounded-md border border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 px-3 py-2">
-        <p className="text-[10px] font-mono text-zinc-400 dark:text-zinc-600 leading-relaxed">
-          Event windows combine Jupiterian Round (major layer) and Minor Jupiter Progression (minor layer).
-          High = strong activation in both layers. Always confirm with dasha and transit before treating as prediction.
-        </p>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/components/JyotishGrahaTable.tsx
+++ b/src/components/JyotishGrahaTable.tsx
@@ -109,7 +109,9 @@ interface Props {
   showOuterPlanets?: boolean;
   showSpecialLagnas?: boolean;
   showNakshatra?: boolean;
+  /** @deprecated Pada columns removed */
   showNakshatraPada?: boolean;
+  /** @deprecated D108 removed */
   showD108?: boolean;
   nakshatraAdjust?: number;
 }
@@ -121,8 +123,6 @@ export default function JyotishGrahaTable({
   showOuterPlanets = false,
   showSpecialLagnas = true,
   showNakshatra = true,
-  showNakshatraPada = true,
-  showD108 = false,
   nakshatraAdjust = 0,
 }: Props) {
   const adjLon = (lon: number) => ((lon + nakshatraAdjust) % 360 + 360) % 360;
@@ -174,9 +174,6 @@ export default function JyotishGrahaTable({
             <th className="p-2 text-left">Graha</th>
             <th className="p-2 text-left">Pos</th>
             {showNakshatra && <th className="p-2 text-left">Nakṣatra</th>}
-            {showNakshatraPada && <th className="p-2 text-left">Pada</th>}
-            {showNakshatraPada && <th className="p-2 text-left">Pada108</th>}
-            {showD108 && <th className="p-2 text-left">D108</th>}
           </tr>
         </thead>
         <tbody>
@@ -186,9 +183,6 @@ export default function JyotishGrahaTable({
               <td className="p-2 text-zinc-800 dark:text-zinc-100">{row.name}</td>
               <td className="p-2 text-zinc-700 dark:text-zinc-300 whitespace-nowrap">{row.position}</td>
               {showNakshatra && <td className="p-2 text-cyan-700 dark:text-cyan-300 whitespace-nowrap">{row.nakshatra}</td>}
-              {showNakshatraPada && <td className="p-2 text-zinc-600 dark:text-zinc-300">{row.pada}</td>}
-              {showNakshatraPada && <td className="p-2 text-zinc-600 dark:text-zinc-300">{row.pada108}</td>}
-              {showD108 && <td className="p-2 text-purple-700 dark:text-purple-300 whitespace-nowrap">{row.d108}</td>}
             </tr>
           ))}
         </tbody>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -36,18 +36,12 @@ const PRECISION_OPTIONS: [DegreePrecision, string][] = [
 const ADVANCED_TOGGLES: { key: keyof ChartDisplaySettings; label: string }[] = [
   { key: 'showWorkspace', label: 'workspace mode' },
   { key: 'showTransitPlanets', label: 'transit' },
-  { key: 'showNakshatraPada', label: 'pada + pada108' },
-  { key: 'showD108', label: 'D108 (experimental)' },
   { key: 'showOuterPlanets', label: 'outer planets' },
   { key: 'showSpecialLagnas', label: 'special lagnas' },
   { key: 'showPanchang', label: 'panchang' },
   { key: 'showGrahaDrishti', label: 'graha dṛṣṭi' },
   { key: 'showRashiDrishti', label: 'rāśi dṛṣṭi' },
   { key: 'showBnnAlpha', label: 'BNN alpha (research)' },
-  { key: 'showAshtakavarga', label: 'ashtakavarga (AV)' },
-  { key: 'showBnnJupiterianRounds', label: 'BNN Jupiterian Rounds' },
-  { key: 'showBnnJupiterMinor', label: 'BNN Jupiter Minor' },
-  { key: 'showBnnEventDetection', label: 'BNN Event Detection' },
   { key: 'showBnnDebug', label: 'BNN Engine Debug' },
 ];
 

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,16 @@
 export const CHANGELOG = [
   {
+    version: 'v1.56',
+    changes: [
+      'BNN simplified into single Event Detection module; removed standalone Jupiterian Rounds and Minor Progression panels',
+      'BNN Event Detection context now shows natal Jupiter sign/degree, balance, current round number, and Temporary Lagna',
+      'BNN Event Detection panel is collapsible; age override cleared with one click',
+      'Removed Pada, Pada108, and D108 Experimental columns from Graha Table',
+      'Removed BNN Jupiterian Rounds and BNN Jupiter Minor settings toggles',
+      'Ashtakavarga handling corrected: shows "Ashtakavarga not available yet" instead of unreliable values',
+    ],
+  },
+  {
     version: 'v1.55',
     changes: [
       'Bhava Bala: added occupant (Bhava Graha) contribution — ~approx: benefic occupant +45 × Ṣaḍbala ratio, malefic −30 × ratio virupa',


### PR DESCRIPTION
- Replace standalone BNNJupiterianRoundsPanel and BNNJupiterMinorPanel with a single BNNEventDetectionPanel that is always shown in the BNN tab
- Enhance BNNEventDetectionPanel context: natal Jupiter sign/degree, balance, current round number, Temporary Lagna, minor sign
- Add collapsible section header and inline age override clear button
- Update explanation note to match spec exactly
- Remove Pada, Pada108, D108 Experimental columns from JyotishGrahaTable
- Remove BNN Jupiterian Rounds, BNN Jupiter Minor, Pada, D108 toggles from SettingsPanel advanced section
- Hide Ashtakavarga (unreliable) and show 'Ashtakavarga not available yet'
- Add v1.56 changelog entry
- Build and lint verified: no new errors