### PR TITLE
feat: restore AV/Ashtakavarga overlay with planet selector; remove BN…

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,6 @@ import { buildReportMarkdown } from '@/lib/exportReport';
 import FileActions, { ChartSnapshot } from '@/components/FileActions';
 import BcpSummary from '@/components/BcpSummary';
 import BcpManualOverride from '@/components/BcpManualOverride';
-import BnnPanel from '@/components/bnn/BnnPanel';
 import BNNEventDetectionPanel from '@/components/BNNEventDetectionPanel';
 import WorkspaceView from '@/components/workspace/WorkspaceView';
 
@@ -909,23 +908,13 @@ export default function Home() {
             )}
             {desktopTab === 'bnn' && (
               chartData
-                ? <div className="space-y-6">
-                    <BNNEventDetectionPanel
-                      chart={chartData}
-                      birthDatetime={birthDatetime}
-                      targetDate={targetDate}
-                      bnnOverrideStr={bnnOverrideStr}
-                      onBnnOverrideStrChange={setBnnOverrideStr}
-                    />
-                    {chartDisplaySettings.showBnnDebug && (
-                      <div className="border-t border-zinc-200 dark:border-zinc-700 pt-4">
-                        <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600 mb-3">
-                          Advanced BNN Engine Debug
-                        </div>
-                        <BnnPanel chart={chartData} />
-                      </div>
-                    )}
-                  </div>
+                ? <BNNEventDetectionPanel
+                    chart={chartData}
+                    birthDatetime={birthDatetime}
+                    targetDate={targetDate}
+                    bnnOverrideStr={bnnOverrideStr}
+                    onBnnOverrideStrChange={setBnnOverrideStr}
+                  />
                 : <EmptyState message="Calculate a chart to see BNN analysis" />
             )}
             {desktopTab === 'workspace' && (
@@ -1043,23 +1032,13 @@ export default function Home() {
         {activeTab === 'bnn' && (
           <Panel>
             {chartData
-              ? <div className="space-y-6">
-                  <BNNEventDetectionPanel
-                    chart={chartData}
-                    birthDatetime={birthDatetime}
-                    targetDate={targetDate}
-                    bnnOverrideStr={bnnOverrideStr}
-                    onBnnOverrideStrChange={setBnnOverrideStr}
-                  />
-                  {chartDisplaySettings.showBnnDebug && (
-                    <div className="border-t border-zinc-200 dark:border-zinc-700 pt-4">
-                      <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600 mb-3">
-                        Advanced BNN Engine Debug
-                      </div>
-                      <BnnPanel chart={chartData} />
-                    </div>
-                  )}
-                </div>
+              ? <BNNEventDetectionPanel
+                  chart={chartData}
+                  birthDatetime={birthDatetime}
+                  targetDate={targetDate}
+                  bnnOverrideStr={bnnOverrideStr}
+                  onBnnOverrideStrChange={setBnnOverrideStr}
+                />
               : <EmptyState message="Calculate a chart in Data to see BNN analysis" />
             }
           </Panel>

--- a/src/components/ChartSection.tsx
+++ b/src/components/ChartSection.tsx
@@ -7,6 +7,7 @@ import SouthIndianChart from './SouthIndianChart';
 import VargaMatrix from '@/pages/VargaMatrix';
 import DrishtiPanel from '@/components/DrishtiPanel';
 import { getAshtakavargaOverlay } from '@/lib/ashtakavarga';
+import type { AvMode } from '@/lib/ashtakavarga';
 import { calculateJupiterianRounds } from '@/lib/bnn/jupiterianRounds';
 import { calculateMinorProgression } from '@/lib/bnn/jupiterMinorProgression';
 import TransitDateControls from './TransitDateControls';
@@ -157,7 +158,9 @@ export default function ChartSection({
 
   const yearHouse = showBcpHighlights ? bcp.activeYearHouse : 0;
   const monthHouse = showBcpHighlights ? bcp.activeMonthHouse : 0;
-  const ashtakavargaOverlay = chartDisplaySettings.showAshtakavarga ? getAshtakavargaOverlay(chart) : [];
+  const avMode: AvMode = chartDisplaySettings.avMode ?? 'off';
+  const ashtakavargaOverlay = avMode !== 'off' ? getAshtakavargaOverlay(chart, avMode) : [];
+  const avOverlayLabel = avMode === 'sav' ? 'SAV' : avMode !== 'off' ? `${avMode} BAV` : undefined;
   const bnnMajorHouse = chartDisplaySettings.showBnnMajorHighlight ? bnnHouses.major : 0;
   const bnnMinorHouse = chartDisplaySettings.showBnnMinorHighlight ? bnnHouses.minor : 0;
 
@@ -196,6 +199,7 @@ export default function ChartSection({
           specialLagnas={chart.specialLagnas ?? []}
           transitPlanets={transitPlanets}
           ashtakavargaOverlay={ashtakavargaOverlay}
+          avOverlayLabel={avOverlayLabel}
           showSigns={chartDisplaySettings.showSigns}
           showNatalPlanets={chartDisplaySettings.showNatalPlanets}
           showTransitPlanets={chartDisplaySettings.showTransitPlanets}
@@ -218,6 +222,7 @@ export default function ChartSection({
           specialLagnas={chart.specialLagnas ?? []}
           transitPlanets={transitPlanets}
           ashtakavargaOverlay={ashtakavargaOverlay}
+          avOverlayLabel={avOverlayLabel}
           showSigns={chartDisplaySettings.showSigns}
           showNatalPlanets={chartDisplaySettings.showNatalPlanets}
           showTransitPlanets={chartDisplaySettings.showTransitPlanets}

--- a/src/components/NorthIndianChart.tsx
+++ b/src/components/NorthIndianChart.tsx
@@ -38,6 +38,7 @@ interface Props {
   nakshatraAdjust?: number;
   bnnMajorHouse?: number;
   bnnMinorHouse?: number;
+  avOverlayLabel?: string;
   legendLayers?: { bcp?: boolean; bnn?: boolean; transit?: boolean };
 }
 
@@ -169,6 +170,7 @@ export default function NorthIndianChart({
   nakshatraAdjust = 0,
   bnnMajorHouse = 0,
   bnnMinorHouse = 0,
+  avOverlayLabel,
   legendLayers,
 }: Props) {
   const { resolvedTheme } = useTheme();
@@ -339,7 +341,7 @@ export default function NorthIndianChart({
           {bnnMinorHouse > 0 && legendLayers?.bnn !== false && <span style={{ color: isDark ? BNN_MINOR_DARK : BNN_MINOR_LIGHT }} className="font-semibold">╌ BNN Minor</span>}
           {showTransitPlanets && legendLayers?.transit !== false && <span style={{ color: TRANSIT_COLOR }} className="font-semibold">■ Transit</span>}
           {showSpecialLagnas && <span style={{ color: SPECIAL_LAGNA_COLOR }} className="font-semibold">■ Special</span>}
-          {ashtakavargaOverlay.length > 0 && <span style={{ color: ASHTAKAVARGA_COLOR }} className="font-semibold">AV Ashtakavarga</span>}
+          {ashtakavargaOverlay.length > 0 && <span style={{ color: ASHTAKAVARGA_COLOR }} className="font-semibold">AV / {avOverlayLabel ?? 'Ashtakavarga'}</span>}
         </div>
       )}
     </div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { ChartDisplaySettings, CalculationSettings, DashaSettings, DEFAULT_DASHA_SETTINGS } from '@/types';
+import type { AvMode } from '@/lib/ashtakavarga';
 import { type DegreePrecision } from '@/lib/formatDegree';
 import { APP_NAME, APP_VERSION } from '@/lib/config';
 import { DASHA_REGISTRY, DashaKey } from '@/lib/dashaRegistry';
@@ -42,7 +43,18 @@ const ADVANCED_TOGGLES: { key: keyof ChartDisplaySettings; label: string }[] = [
   { key: 'showGrahaDrishti', label: 'graha dṛṣṭi' },
   { key: 'showRashiDrishti', label: 'rāśi dṛṣṭi' },
   { key: 'showBnnAlpha', label: 'BNN alpha (research)' },
-  { key: 'showBnnDebug', label: 'BNN Engine Debug' },
+];
+
+const AV_MODE_OPTIONS: { value: AvMode; label: string }[] = [
+  { value: 'off', label: 'Off' },
+  { value: 'sav', label: 'SAV — Sarvashtakavarga (total)' },
+  { value: 'Sun', label: 'Sun BAV' },
+  { value: 'Moon', label: 'Moon BAV' },
+  { value: 'Mars', label: 'Mars BAV' },
+  { value: 'Mercury', label: 'Mercury BAV' },
+  { value: 'Jupiter', label: 'Jupiter BAV' },
+  { value: 'Venus', label: 'Venus BAV' },
+  { value: 'Saturn', label: 'Saturn BAV' },
 ];
 
 const CORE_DASHAS = DASHA_REGISTRY.filter(d => d.group === 'Core');
@@ -197,6 +209,20 @@ export default function SettingsPanel(props: Props) {
                   }}
                 />
               </div>
+            </div>
+            <div className="mt-3">
+              <label className="block text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600 mb-1">
+                AV / Ashtakavarga
+              </label>
+              <select
+                className={SELECT}
+                value={chartDisplaySettings.avMode ?? 'off'}
+                onChange={(e) => onUpdateChartDisplay?.({ avMode: e.target.value as AvMode })}
+              >
+                {AV_MODE_OPTIONS.map(({ value, label }) => (
+                  <option key={value} value={value}>{label}</option>
+                ))}
+              </select>
             </div>
             <div className="mt-2 flex items-center justify-between gap-2">
               <span className="text-xs font-mono text-zinc-600 dark:text-zinc-300 shrink-0">degrees</span>

--- a/src/components/SouthIndianChart.tsx
+++ b/src/components/SouthIndianChart.tsx
@@ -36,6 +36,7 @@ interface Props {
   nakshatraAdjust?: number;
   bnnMajorHouse?: number;
   bnnMinorHouse?: number;
+  avOverlayLabel?: string;
   legendLayers?: { bcp?: boolean; bnn?: boolean; transit?: boolean };
 }
 
@@ -124,6 +125,7 @@ export default function SouthIndianChart({
   nakshatraAdjust = 0,
   bnnMajorHouse = 0,
   bnnMinorHouse = 0,
+  avOverlayLabel,
   legendLayers,
 }: Props) {
   const { resolvedTheme } = useTheme();
@@ -294,7 +296,7 @@ export default function SouthIndianChart({
           {bnnMinorHouse > 0 && legendLayers?.bnn !== false && <span style={{ color: bnnMinColor }} className="font-semibold">╌ BNN Minor</span>}
           {showTransitPlanets && legendLayers?.transit !== false && <span style={{ color: TRANSIT_COLOR }} className="font-semibold">■ Transit</span>}
           {showSpecialLagnas && <span style={{ color: SPECIAL_LAGNA_COLOR }} className="font-semibold">■ Special</span>}
-          {ashtakavargaOverlay.length > 0 && <span style={{ color: ASHTAKAVARGA_COLOR }} className="font-semibold">AV Ashtakavarga</span>}
+          {ashtakavargaOverlay.length > 0 && <span style={{ color: ASHTAKAVARGA_COLOR }} className="font-semibold">AV / {avOverlayLabel ?? 'Ashtakavarga'}</span>}
         </div>
       )}
     </div>

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -5,6 +5,7 @@ import type {
   ChartData, BcpResult, PlanetData, ChartDisplaySettings,
   DashaSettings, WorkspacePanel, WorkspacePanelType,
 } from '@/types';
+import { getAshtakavargaOverlay } from '@/lib/ashtakavarga';
 import NorthIndianChart from '../NorthIndianChart';
 import SouthIndianChart from '../SouthIndianChart';
 import TransitDateControls from '../TransitDateControls';
@@ -197,6 +198,9 @@ export default function WorkspaceView({
 
   // ── Chart rendering helper ──
   const chartStyle = chartDisplaySettings.chartStyle ?? 'north';
+  const avMode = chartDisplaySettings.avMode ?? 'off';
+  const ashtakavargaOverlay = avMode !== 'off' ? getAshtakavargaOverlay(chart, avMode) : [];
+  const avOverlayLabel = avMode === 'sav' ? 'SAV' : avMode !== 'off' ? `${avMode} BAV` : undefined;
 
   function renderChart(opts: {
     yearHouse?: number;
@@ -234,6 +238,8 @@ export default function WorkspaceView({
       bnnMinorHouse: bnnMin,
       transitPlanets: showTransit ? transitPlanets : [],
       showTransitPlanets: showTransit,
+      ashtakavargaOverlay,
+      avOverlayLabel,
       legendLayers,
     };
 

--- a/src/lib/ashtakavarga.ts
+++ b/src/lib/ashtakavarga.ts
@@ -1,4 +1,5 @@
 export type AshtakavargaPlanet = 'Sun' | 'Moon' | 'Mars' | 'Mercury' | 'Jupiter' | 'Venus' | 'Saturn';
+export type AvMode = 'off' | 'sav' | AshtakavargaPlanet;
 
 export type AshtakavargaChartPlanet = {
   name: string;
@@ -133,9 +134,26 @@ export function buildAshtakavarga(chart: AshtakavargaChartLike): AshtakavargaRes
   return { bav, sav };
 }
 
-export function getAshtakavargaOverlay(_chart: AshtakavargaChartLike): AshtakavargaOverlayCell[] {
-  // Hotfix: AV overlay was being forced onto the chart without any Settings toggle.
-  // Keep the AV calculation helpers intact, but do not render AV markers until a proper
-  // explicit showAshtakavarga setting is wired through the UI.
-  return [];
+function bavRowToOverlayCells(chart: AshtakavargaChartLike, row: BhinnaAshtakavargaRow): AshtakavargaOverlayCell[] {
+  return row.houses.map((bindu, index) => {
+    const house = index + 1;
+    const signIndex = getHouseSignIndex(chart, house);
+    const strength = getStrength(bindu);
+    return {
+      house,
+      sign: typeof signIndex === 'number' ? SIGN_ABBR[signIndex] : '—',
+      bindu,
+      strength,
+      label: `${bindu}`,
+    };
+  });
+}
+
+export function getAshtakavargaOverlay(chart: AshtakavargaChartLike, mode: AvMode): AshtakavargaOverlayCell[] {
+  if (mode === 'off') return [];
+  const { bav, sav } = buildAshtakavarga(chart);
+  if (mode === 'sav') return sav.overlay;
+  const row = bav.find(r => r.planet === mode);
+  if (!row) return [];
+  return bavRowToOverlayCells(chart, row);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import type { DegreePrecision } from '@/lib/formatDegree';
 export type { DegreePrecision };
+import type { AvMode } from '@/lib/ashtakavarga';
+export type { AvMode };
 
 export interface GeoResult {
   name: string;
@@ -128,11 +130,10 @@ export interface ChartDisplaySettings {
   showGrahaDrishti: boolean;
   showRashiDrishti: boolean;
   showBnnAlpha: boolean;
-  showAshtakavarga: boolean;
+  avMode: AvMode;
   showBnnJupiterianRounds: boolean;
   showBnnJupiterMinor: boolean;
   showBnnEventDetection: boolean;
-  showBnnDebug: boolean;
   showBnnMajorHighlight: boolean;
   showBnnMinorHighlight: boolean;
   showWorkspace: boolean;
@@ -156,11 +157,10 @@ export const DEFAULT_CHART_DISPLAY: ChartDisplaySettings = {
   showGrahaDrishti: false,
   showRashiDrishti: false,
   showBnnAlpha: false,
-  showAshtakavarga: false,
+  avMode: 'off',
   showBnnJupiterianRounds: false,
   showBnnJupiterMinor: false,
   showBnnEventDetection: true,
-  showBnnDebug: false,
   showBnnMajorHighlight: true,
   showBnnMinorHighlight: true,
   showWorkspace: false,


### PR DESCRIPTION
…N debug UI

- Add `AvMode` type ('off' | 'sav' | AshtakavargaPlanet) to ashtakavarga.ts
- Fix `getAshtakavargaOverlay()` to accept a mode parameter and return real computed data: SAV totals for 'sav', per-planet BAV cells for planet modes
- Replace `showAshtakavarga: boolean` with `avMode: AvMode` in ChartDisplaySettings
- Remove `showBnnDebug` from types, settings toggle, and both BNN tab renders (BnnPanel component kept intact; only the user-facing debug panel removed)
- Add AV / Ashtakavarga dropdown in SettingsPanel under chart overlays: Off / SAV (Sarvashtakavarga) / Sun–Saturn BAV modes
- Thread `avOverlayLabel` prop through ChartSection → NorthIndianChart / SouthIndianChart so the legend shows the active mode (e.g. "AV / Sun BAV")
- Add AV overlay support to WorkspaceView charts via chartDisplaySettings.avMode