### PR TITLE
fix: implement full Parashara Ashtakavarga with correct BAV and SAV

### DIFF
--- a/src/lib/ashtakavarga.ts
+++ b/src/lib/ashtakavarga.ts
@@ -41,17 +41,83 @@ export type AshtakavargaResult = {
 const SIGN_ABBR = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
 const PLANETS: AshtakavargaPlanet[] = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn'];
 
-// Classical-style compact BAV rules: bindu-giving houses counted from each planet's own natal house.
-// This is the correct architecture for BAV/SAV, but still marked beta because full Parashara AV
-// also includes separate contributor-specific rules and reduction systems.
-export const BAV_RULES: Record<AshtakavargaPlanet, number[]> = {
-  Sun: [1, 2, 4, 7, 8, 9, 10, 11],
-  Moon: [3, 6, 7, 10, 11],
-  Mars: [3, 5, 6, 10, 11],
-  Mercury: [2, 4, 6, 8, 10, 11],
-  Jupiter: [5, 6, 9, 11],
-  Venus: [6, 7, 12],
-  Saturn: [3, 5, 6, 10, 11],
+type Contributor = AshtakavargaPlanet | 'Ascendant';
+const CONTRIBUTORS: Contributor[] = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn', 'Ascendant'];
+
+// Full Parashara Ashtakavarga bindu tables (BPHS).
+// For each planet P, for each contributing body C, the house positions
+// (counted from C's natal sign) that grant one bindu to P's BAV.
+const PARASHARA_AV: Record<AshtakavargaPlanet, Record<Contributor, number[]>> = {
+  Sun: {
+    Sun:        [1, 2, 4, 7, 8, 9, 10, 11],
+    Moon:       [3, 6, 10, 11],
+    Mars:       [1, 2, 4, 7, 8, 9, 10, 11],
+    Mercury:    [3, 5, 6, 9, 10, 11, 12],
+    Jupiter:    [5, 6, 9, 11],
+    Venus:      [6, 7, 12],
+    Saturn:     [1, 2, 4, 7, 8, 9, 10, 11],
+    Ascendant:  [1, 2, 4, 7, 8, 9, 10, 11],
+  },
+  Moon: {
+    Sun:        [3, 6, 7, 8, 10, 11],
+    Moon:       [1, 3, 6, 7, 10, 11],
+    Mars:       [2, 3, 5, 6, 9, 10, 11],
+    Mercury:    [1, 3, 4, 5, 7, 8, 10, 11],
+    Jupiter:    [1, 4, 7, 8, 10, 11, 12],
+    Venus:      [3, 4, 5, 7, 9, 10, 11],
+    Saturn:     [3, 5, 6, 11],
+    Ascendant:  [3, 6, 10, 11],
+  },
+  Mars: {
+    Sun:        [3, 5, 6, 10, 11],
+    Moon:       [3, 6, 11],
+    Mars:       [1, 2, 4, 7, 8, 10, 11],
+    Mercury:    [3, 5, 6, 11],
+    Jupiter:    [6, 10, 11, 12],
+    Venus:      [6, 8, 11, 12],
+    Saturn:     [1, 4, 7, 8, 9, 10, 11],
+    Ascendant:  [1, 2, 4, 7, 8, 9, 10, 11],
+  },
+  Mercury: {
+    Sun:        [5, 6, 9, 11, 12],
+    Moon:       [2, 4, 6, 8, 10, 11],
+    Mars:       [1, 2, 4, 7, 8, 9, 10, 11],
+    Mercury:    [1, 3, 5, 6, 9, 10, 11, 12],
+    Jupiter:    [6, 8, 11, 12],
+    Venus:      [1, 2, 3, 4, 5, 8, 9, 11],
+    Saturn:     [1, 2, 4, 7, 8, 9, 10, 11],
+    Ascendant:  [1, 2, 4, 7, 8, 9, 10, 11],
+  },
+  Jupiter: {
+    Sun:        [1, 2, 3, 4, 7, 8, 9, 10, 11],
+    Moon:       [2, 5, 7, 9, 11],
+    Mars:       [1, 2, 4, 7, 8, 10, 11],
+    Mercury:    [1, 2, 4, 5, 6, 9, 10, 11],
+    Jupiter:    [1, 2, 3, 4, 7, 8, 10, 11],
+    Venus:      [2, 5, 6, 9, 10, 11],
+    Saturn:     [3, 5, 6, 12],
+    Ascendant:  [1, 2, 4, 5, 6, 7, 9, 10, 11],
+  },
+  Venus: {
+    Sun:        [8, 11, 12],
+    Moon:       [1, 2, 3, 4, 5, 8, 9, 11, 12],
+    Mars:       [3, 4, 6, 9, 11, 12],
+    Mercury:    [3, 5, 6, 9, 11],
+    Jupiter:    [5, 8, 9, 10, 11],
+    Venus:      [1, 2, 3, 4, 5, 8, 9, 10, 11],
+    Saturn:     [3, 4, 5, 8, 9, 10, 11],
+    Ascendant:  [1, 2, 3, 4, 5, 8, 9, 11],
+  },
+  Saturn: {
+    Sun:        [1, 2, 4, 7, 8, 10, 11],
+    Moon:       [3, 6, 11],
+    Mars:       [3, 5, 6, 10, 11, 12],
+    Mercury:    [6, 8, 9, 10, 11, 12],
+    Jupiter:    [5, 6, 11, 12],
+    Venus:      [6, 11, 12],
+    Saturn:     [3, 5, 6, 11],
+    Ascendant:  [1, 3, 4, 6, 10, 11],
+  },
 };
 
 function getPlanet(chart: AshtakavargaChartLike, name: string): AshtakavargaChartPlanet | undefined {
@@ -75,24 +141,45 @@ function getRelativeHouse(fromHouse: number, toHouse: number): number {
   return ((toHouse - fromHouse + 12) % 12) + 1;
 }
 
-function getStrength(bindu: number): AshtakavargaOverlayCell['strength'] {
-  if (bindu >= 5) return 'very-high';
-  if (bindu >= 4) return 'high';
-  if (bindu >= 3) return 'medium';
+function getBavStrength(bindu: number): AshtakavargaOverlayCell['strength'] {
+  if (bindu >= 6) return 'very-high';
+  if (bindu >= 5) return 'high';
+  if (bindu >= 4) return 'medium';
+  return 'low';
+}
+
+function getSavStrength(bindu: number): AshtakavargaOverlayCell['strength'] {
+  if (bindu >= 30) return 'very-high';
+  if (bindu >= 25) return 'high';
+  if (bindu >= 20) return 'medium';
   return 'low';
 }
 
 export function buildBhinnaAshtakavarga(chart: AshtakavargaChartLike): BhinnaAshtakavargaRow[] {
   return PLANETS.map((planetName) => {
-    const planet = getPlanet(chart, planetName);
-    const planetHouse = getPlanetHouse(chart, planet);
-    const rules = BAV_RULES[planetName];
+    const rules = PARASHARA_AV[planetName];
 
     const houses = Array.from({ length: 12 }, (_, index) => {
       const house = index + 1;
-      if (typeof planetHouse !== 'number') return 0;
-      const relativeHouse = getRelativeHouse(planetHouse, house);
-      return rules.includes(relativeHouse) ? 1 : 0;
+      let bindu = 0;
+
+      for (const contributor of CONTRIBUTORS) {
+        let contributorHouse: number | null;
+        if (contributor === 'Ascendant') {
+          contributorHouse = 1;
+        } else {
+          const contributorPlanet = getPlanet(chart, contributor);
+          contributorHouse = getPlanetHouse(chart, contributorPlanet);
+        }
+        if (typeof contributorHouse !== 'number') continue;
+
+        const relativeHouse = getRelativeHouse(contributorHouse, house);
+        if (rules[contributor].includes(relativeHouse)) {
+          bindu += 1;
+        }
+      }
+
+      return bindu;
     });
 
     return {
@@ -111,7 +198,7 @@ export function buildSarvaAshtakavarga(chart: AshtakavargaChartLike, bav: Bhinna
   const overlay = houses.map((bindu, index) => {
     const house = index + 1;
     const signIndex = getHouseSignIndex(chart, house);
-    const strength = getStrength(bindu);
+    const strength = getSavStrength(bindu);
     return {
       house,
       sign: typeof signIndex === 'number' ? SIGN_ABBR[signIndex] : '—',
@@ -138,7 +225,7 @@ function bavRowToOverlayCells(chart: AshtakavargaChartLike, row: BhinnaAshtakava
   return row.houses.map((bindu, index) => {
     const house = index + 1;
     const signIndex = getHouseSignIndex(chart, house);
-    const strength = getStrength(bindu);
+    const strength = getBavStrength(bindu);
     return {
       house,
       sign: typeof signIndex === 'number' ? SIGN_ABBR[signIndex] : '—',


### PR DESCRIPTION
Replace the simplified single-contributor BAV rules with the complete Parashara Ashtakavarga bindu tables (BPHS). Each planet's BAV now sums contributions from all 7 planets + ascendant using their house-relative positions, producing distinct per-planet values (2–7 range per house). SAV is correctly the sum of all seven planet BAVs (20–40+ range).

Strength thresholds updated: BAV uses 4/5/6+ scale; SAV uses 20/25/30+.