### PR TITLE
Add Deva Keralam and Siddhar Nadi amsa calculations

### DIFF
--- a/src/components/ChartSection.tsx
+++ b/src/components/ChartSection.tsx
@@ -12,6 +12,7 @@ import { calculateJupiterianRounds } from '@/lib/bnn/jupiterianRounds';
 import { calculateMinorProgression } from '@/lib/bnn/jupiterMinorProgression';
 import TransitDateControls from './TransitDateControls';
 import BCPAgeControls from './BCPAgeControls';
+import NadiAmsaPanel from './NadiAmsaPanel';
 
 function parseBirthDt(dt: string): Date | null {
   const m = dt.trim().match(/^(\d{2})\.(\d{2})\.(\d{4})\s(\d{2})\.(\d{2})\.(\d{2})$/);
@@ -87,7 +88,7 @@ export default function ChartSection({
 }: ChartSectionProps) {
   const [chartStyle, setChartStyle] = useState<ChartStyle>(chartDisplaySettings.chartStyle ?? 'north');
   const [showBcpHighlights, setShowBcpHighlights] = useState<boolean>(isBcpEnabled());
-  const [view, setView] = useState<'chart' | 'varga' | 'drishti'>('chart');
+  const [view, setView] = useState<'chart' | 'varga' | 'nadi' | 'drishti'>('chart');
 
   const bnnHouses = useMemo(() => {
     // Use parent-provided houses when available (keeps age override in sync with chart highlights)
@@ -164,7 +165,7 @@ export default function ChartSection({
   const bnnMajorHouse = chartDisplaySettings.showBnnMajorHighlight ? bnnHouses.major : 0;
   const bnnMinorHouse = chartDisplaySettings.showBnnMinorHighlight ? bnnHouses.minor : 0;
 
-  const tabClass = (id: 'chart' | 'varga' | 'drishti') =>
+  const tabClass = (id: 'chart' | 'varga' | 'nadi' | 'drishti') =>
     `shrink-0 px-2.5 py-1.5 text-[10px] font-mono rounded-md ${view === id ? 'bg-white dark:bg-zinc-700 text-emerald-700 dark:text-green-400 shadow-sm' : 'text-zinc-500 dark:text-zinc-400'}`;
 
   return (
@@ -181,6 +182,7 @@ export default function ChartSection({
           <div className="inline-flex min-w-max gap-1 bg-zinc-100 dark:bg-zinc-800/50 rounded-lg p-1">
             <button type="button" onClick={() => setView('chart')} className={tabClass('chart')}>Chart</button>
             <button type="button" onClick={() => setView('varga')} className={tabClass('varga')}>Varga</button>
+            <button type="button" onClick={() => setView('nadi')} className={tabClass('nadi')}>Nāḍī</button>
             <button type="button" onClick={() => setView('drishti')} className={tabClass('drishti')}>Dṛṣṭi</button>
           </div>
         </div>
@@ -188,6 +190,8 @@ export default function ChartSection({
 
       {view === 'varga' ? (
         <div className="min-w-0 overflow-x-auto"><VargaMatrix chart={chart} /></div>
+      ) : view === 'nadi' ? (
+        <div className="min-w-0 overflow-x-auto"><NadiAmsaPanel chart={chart} /></div>
       ) : view === 'drishti' ? (
         <div className="min-w-0 overflow-x-auto"><DrishtiPanel chart={chart} showGrahaDrishti={chartDisplaySettings.showGrahaDrishti ?? true} showRashiDrishti={chartDisplaySettings.showRashiDrishti ?? true} /></div>
       ) : chartStyle === 'south' ? (

--- a/src/components/NadiAmsaPanel.tsx
+++ b/src/components/NadiAmsaPanel.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import type { ChartData } from '@/types';
+import { SIGN_ABBR } from '@/lib/varga';
+import { calculateDevaKeralamNadiAmsa, calculateSiddharNadiAmsa } from '@/lib/nadiAmsa';
+
+const BODY_ORDER = ['Lagna', 'Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn', 'Rahu', 'Ketu'];
+
+function formatLongitude(longitude: number): string {
+  const normalized = ((longitude % 360) + 360) % 360;
+  const signIndex = Math.floor(normalized / 30);
+  const degrees = normalized % 30;
+  const wholeDegrees = Math.floor(degrees);
+  const minutesFloat = (degrees - wholeDegrees) * 60;
+  const minutes = Math.floor(minutesFloat);
+  const seconds = Math.floor((minutesFloat - minutes) * 60 + 1e-7);
+  return `${SIGN_ABBR[signIndex]} ${wholeDegrees}°${String(minutes).padStart(2, '0')}′${String(seconds).padStart(2, '0')}″`;
+}
+
+export default function NadiAmsaPanel({ chart }: { chart: ChartData }) {
+  const longitudeByBody = new Map<string, number>();
+  longitudeByBody.set('Lagna', chart.ascendant.longitude);
+  chart.planets.forEach((planet) => longitudeByBody.set(planet.name, planet.longitude));
+
+  const rows = BODY_ORDER.flatMap((body) => {
+    const longitude = longitudeByBody.get(body);
+    if (typeof longitude !== 'number') return [];
+    return [{
+      body,
+      longitude,
+      devaKeralam: calculateDevaKeralamNadiAmsa(longitude),
+      siddhar: calculateSiddharNadiAmsa(longitude),
+    }];
+  });
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <div className="text-xs font-mono font-semibold text-zinc-700 dark:text-zinc-300">Nāḍī-aṁśa calculation</div>
+        <div className="mt-1 text-[10px] font-mono text-zinc-400 dark:text-zinc-600">
+          Sidereal longitude · 150 × 0°12′ divisions · Siddhar halves 0°06′
+        </div>
+      </div>
+
+      <div className="overflow-x-auto border border-zinc-200 dark:border-zinc-700 rounded-lg">
+        <table className="w-full min-w-[760px] border-collapse text-xs font-mono">
+          <thead>
+            <tr className="bg-zinc-100 dark:bg-zinc-800">
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Body</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Longitude</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Deva Keralam</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Siddhar D150</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Siddhar half</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ body, longitude, devaKeralam, siddhar }) => (
+              <tr key={body} className="border-b border-zinc-100 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-800/50">
+                <td className="p-2 border border-zinc-100 dark:border-zinc-800 font-bold text-emerald-700 dark:text-green-400">{body}</td>
+                <td className="p-2 border border-zinc-100 dark:border-zinc-800 whitespace-nowrap text-zinc-600 dark:text-zinc-300">{formatLongitude(longitude)}</td>
+                <td className="p-2 border border-zinc-100 dark:border-zinc-800 whitespace-nowrap">
+                  <span className="font-bold text-amber-700 dark:text-amber-300">#{devaKeralam.nadiNumber}</span>
+                  <span className="ml-1 text-[9px] text-zinc-400">{devaKeralam.modality}</span>
+                </td>
+                <td className="p-2 border border-zinc-100 dark:border-zinc-800 whitespace-nowrap font-bold text-cyan-700 dark:text-cyan-300">
+                  {SIGN_ABBR[siddhar.signIndex]} <span className="font-normal text-zinc-400">· part {siddhar.rawDivision}</span>
+                </td>
+                <td className="p-2 border border-zinc-100 dark:border-zinc-800 whitespace-nowrap text-zinc-600 dark:text-zinc-300">
+                  {siddhar.half === 'purva' ? 'Pūrva' : 'Para'} <span className="text-zinc-400">#{siddhar.halfNumber}/300</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="space-y-1 text-[10px] font-mono text-zinc-400 dark:text-zinc-600">
+        <p>Deva Keralam: movable 1→150; fixed 150→1; dual 76→150, then 1→75.</p>
+        <p>Siddhar: equal D150 harmonic sign with each nāḍī split into pūrva and para halves.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,14 @@
 export const CHANGELOG = [
   {
+    version: 'v1.57',
+    changes: [
+      'Added a dedicated Nāḍī tab for Lagna and graha calculations',
+      'Deva Keralam: 150 equal 0°12′ divisions with movable, fixed, and dual sign ordering',
+      'Siddhar: separate equal D150 harmonic placement with pūrva/para 0°06′ halves',
+      'Added boundary tests for sign modalities, 15° dual-sign reset, and nāḍī halves',
+    ],
+  },
+  {
     version: 'v1.56',
     changes: [
       'BNN simplified into single Event Detection module; removed standalone Jupiterian Rounds and Minor Progression panels',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.51';
+export const APP_VERSION = 'v1.57';

--- a/src/lib/nadiAmsa.test.ts
+++ b/src/lib/nadiAmsa.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { calculateDevaKeralamNadiAmsa, calculateSiddharNadiAmsa } from './nadiAmsa';
+
+const almostAt = (degrees: number) => degrees - 1e-9;
+
+// Deva Keralam modality ordering and exact 0°12′ boundaries.
+assert.equal(calculateDevaKeralamNadiAmsa(0).nadiNumber, 1);
+assert.equal(calculateDevaKeralamNadiAmsa(0.2).nadiNumber, 2);
+assert.equal(calculateDevaKeralamNadiAmsa(almostAt(30)).nadiNumber, 150);
+assert.equal(calculateDevaKeralamNadiAmsa(30).nadiNumber, 150);
+assert.equal(calculateDevaKeralamNadiAmsa(30.2).nadiNumber, 149);
+assert.equal(calculateDevaKeralamNadiAmsa(60).nadiNumber, 76);
+assert.equal(calculateDevaKeralamNadiAmsa(almostAt(75)).nadiNumber, 150);
+assert.equal(calculateDevaKeralamNadiAmsa(75).nadiNumber, 1);
+assert.equal(calculateDevaKeralamNadiAmsa(almostAt(90)).nadiNumber, 75);
+
+// Siddhar D150 sign cycle and 0°06′ halves.
+assert.deepEqual(calculateSiddharNadiAmsa(0), {
+  system: 'siddhar', rawDivision: 1, signIndex: 0, half: 'purva', halfNumber: 1, offsetDegrees: 0,
+});
+assert.equal(calculateSiddharNadiAmsa(0.1).half, 'para');
+assert.equal(calculateSiddharNadiAmsa(0.1).halfNumber, 2);
+assert.equal(calculateSiddharNadiAmsa(0.2).signIndex, 1);
+assert.equal(calculateSiddharNadiAmsa(30).signIndex, 6);
+assert.equal(calculateSiddharNadiAmsa(-0.1).halfNumber, 300);
+
+console.log('Nāḍī-aṁśa tests passed');

--- a/src/lib/nadiAmsa.ts
+++ b/src/lib/nadiAmsa.ts
@@ -1,0 +1,96 @@
+import { getDegreesInSign, getSignIndex, isDualSign, isFixedSign, normalizeLongitude } from './varga/utils';
+
+export const NADI_AMSA_COUNT = 150;
+export const NADI_AMSA_SIZE_DEGREES = 30 / NADI_AMSA_COUNT;
+export const NADI_HALF_SIZE_DEGREES = NADI_AMSA_SIZE_DEGREES / 2;
+
+export type NadiHalf = 'purva' | 'para';
+
+export interface DevaKeralamNadiAmsa {
+  system: 'deva-keralam';
+  rawDivision: number;
+  nadiNumber: number;
+  modality: 'movable' | 'fixed' | 'dual';
+  offsetDegrees: number;
+}
+
+export interface SiddharNadiAmsa {
+  system: 'siddhar';
+  rawDivision: number;
+  signIndex: number;
+  half: NadiHalf;
+  halfNumber: number;
+  offsetDegrees: number;
+}
+
+function getRawDivision(longitude: number): number {
+  const degrees = getDegreesInSign(longitude);
+  // The epsilon keeps exact decimal boundaries (for example 0.2°) from
+  // falling into the previous division because of binary floating point.
+  return Math.min(NADI_AMSA_COUNT - 1, Math.floor((degrees + 1e-10) / NADI_AMSA_SIZE_DEGREES));
+}
+
+/**
+ * Deva Keralam / Chandra Kala Nadi equal-division indexing.
+ *
+ * Each sign has 150 equal 0°12′ divisions. Names/numbers run forward in
+ * movable signs, backward in fixed signs, and 76..150 then 1..75 in dual signs.
+ */
+export function calculateDevaKeralamNadiAmsa(longitude: number): DevaKeralamNadiAmsa {
+  const normalized = normalizeLongitude(longitude);
+  const signIndex = getSignIndex(normalized);
+  const rawDivision = getRawDivision(normalized);
+  const degrees = getDegreesInSign(normalized);
+
+  if (isFixedSign(signIndex)) {
+    return {
+      system: 'deva-keralam',
+      rawDivision: rawDivision + 1,
+      nadiNumber: NADI_AMSA_COUNT - rawDivision,
+      modality: 'fixed',
+      offsetDegrees: degrees - rawDivision * NADI_AMSA_SIZE_DEGREES,
+    };
+  }
+
+  if (isDualSign(signIndex)) {
+    return {
+      system: 'deva-keralam',
+      rawDivision: rawDivision + 1,
+      nadiNumber: rawDivision < 75 ? rawDivision + 76 : rawDivision - 74,
+      modality: 'dual',
+      offsetDegrees: degrees - rawDivision * NADI_AMSA_SIZE_DEGREES,
+    };
+  }
+
+  return {
+    system: 'deva-keralam',
+    rawDivision: rawDivision + 1,
+    nadiNumber: rawDivision + 1,
+    modality: 'movable',
+    offsetDegrees: degrees - rawDivision * NADI_AMSA_SIZE_DEGREES,
+  };
+}
+
+/**
+ * Siddhar/Tamil equal D150 harmonic placement.
+ *
+ * The 150th harmonic maps each 0°12′ division cyclically into a D150 sign.
+ * Every division is also exposed as its 0°06′ purva/para half (300 half-nadis).
+ */
+export function calculateSiddharNadiAmsa(longitude: number): SiddharNadiAmsa {
+  const normalized = normalizeLongitude(longitude);
+  const signIndex = getSignIndex(normalized);
+  const degrees = getDegreesInSign(normalized);
+  const rawDivision = getRawDivision(normalized);
+  const offsetDegrees = degrees - rawDivision * NADI_AMSA_SIZE_DEGREES;
+  const halfIndex = offsetDegrees + 1e-10 >= NADI_HALF_SIZE_DEGREES ? 1 : 0;
+
+  return {
+    system: 'siddhar',
+    rawDivision: rawDivision + 1,
+    signIndex: (signIndex * NADI_AMSA_COUNT + rawDivision) % 12,
+    half: halfIndex === 0 ? 'purva' : 'para',
+    halfNumber: rawDivision * 2 + halfIndex + 1,
+    offsetDegrees,
+  };
+}


### PR DESCRIPTION
## What changed

- adds a dedicated Nāḍī tab beside Chart, Varga, and Dṛṣṭi
- calculates Deva Keralam equal nāḍī-aṁśa numbering for movable, fixed, and dual signs
- calculates a separate Siddhar/Tamil equal D150 harmonic sign
- splits the Siddhar result into 0°06′ pūrva/para halves
- shows results for Lagna and the grahas
- adds deterministic boundary tests and updates the app version/changelog to v1.57

## Validation

- `node --import tsx src/lib/nadiAmsa.test.ts`
- ESLint on the three new Nāḍī files
- `npm run build`
- `git diff --check`

The repository-wide lint command still reports pre-existing errors outside this change.