### PR TITLE
Add Deva Keralam Nadi amsa names

### DIFF
--- a/src/components/NadiAmsaPanel.tsx
+++ b/src/components/NadiAmsaPanel.tsx
@@ -48,7 +48,7 @@ export default function NadiAmsaPanel({ chart }: { chart: ChartData }) {
             <tr className="bg-zinc-100 dark:bg-zinc-800">
               <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Body</th>
               <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Longitude</th>
-              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Deva Keralam</th>
+              <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Deva Keralam name</th>
               <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Siddhar D150</th>
               <th className="text-left p-2 border border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400">Siddhar half</th>
             </tr>
@@ -59,8 +59,8 @@ export default function NadiAmsaPanel({ chart }: { chart: ChartData }) {
                 <td className="p-2 border border-zinc-100 dark:border-zinc-800 font-bold text-emerald-700 dark:text-green-400">{body}</td>
                 <td className="p-2 border border-zinc-100 dark:border-zinc-800 whitespace-nowrap text-zinc-600 dark:text-zinc-300">{formatLongitude(longitude)}</td>
                 <td className="p-2 border border-zinc-100 dark:border-zinc-800 whitespace-nowrap">
-                  <span className="font-bold text-amber-700 dark:text-amber-300">#{devaKeralam.nadiNumber}</span>
-                  <span className="ml-1 text-[9px] text-zinc-400">{devaKeralam.modality}</span>
+                  <span className="font-bold text-amber-700 dark:text-amber-300">{devaKeralam.nadiName}</span>
+                  <span className="ml-1 text-[9px] text-zinc-400">#{devaKeralam.nadiNumber} · {devaKeralam.modality}</span>
                 </td>
                 <td className="p-2 border border-zinc-100 dark:border-zinc-800 whitespace-nowrap font-bold text-cyan-700 dark:text-cyan-300">
                   {SIGN_ABBR[siddhar.signIndex]} <span className="font-normal text-zinc-400">· part {siddhar.rawDivision}</span>
@@ -75,7 +75,7 @@ export default function NadiAmsaPanel({ chart }: { chart: ChartData }) {
       </div>
 
       <div className="space-y-1 text-[10px] font-mono text-zinc-400 dark:text-zinc-600">
-        <p>Deva Keralam: movable 1→150; fixed 150→1; dual 76→150, then 1→75.</p>
+        <p>Deva Keralam: name and number; movable 1→150, fixed 150→1, dual 76→150 then 1→75.</p>
         <p>Siddhar: equal D150 harmonic sign with each nāḍī split into pūrva and para halves.</p>
       </div>
     </div>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,12 @@
 export const CHANGELOG = [
   {
+    version: 'v1.58',
+    changes: [
+      'Added all 150 Deva Keralam / Chandra Kala Nadi nāḍī-aṁśa names',
+      'Nāḍī table now shows the calculated name together with its number and sign modality',
+    ],
+  },
+  {
     version: 'v1.57',
     changes: [
       'Added a dedicated Nāḍī tab for Lagna and graha calculations',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.57';
+export const APP_VERSION = 'v1.58';

--- a/src/lib/nadiAmsa.test.ts
+++ b/src/lib/nadiAmsa.test.ts
@@ -5,11 +5,14 @@ const almostAt = (degrees: number) => degrees - 1e-9;
 
 // Deva Keralam modality ordering and exact 0°12′ boundaries.
 assert.equal(calculateDevaKeralamNadiAmsa(0).nadiNumber, 1);
+assert.equal(calculateDevaKeralamNadiAmsa(0).nadiName, 'Vasudhā');
 assert.equal(calculateDevaKeralamNadiAmsa(0.2).nadiNumber, 2);
 assert.equal(calculateDevaKeralamNadiAmsa(almostAt(30)).nadiNumber, 150);
+assert.equal(calculateDevaKeralamNadiAmsa(almostAt(30)).nadiName, 'Parameśvarī');
 assert.equal(calculateDevaKeralamNadiAmsa(30).nadiNumber, 150);
 assert.equal(calculateDevaKeralamNadiAmsa(30.2).nadiNumber, 149);
 assert.equal(calculateDevaKeralamNadiAmsa(60).nadiNumber, 76);
+assert.equal(calculateDevaKeralamNadiAmsa(60).nadiName, 'Mahāmārī');
 assert.equal(calculateDevaKeralamNadiAmsa(almostAt(75)).nadiNumber, 150);
 assert.equal(calculateDevaKeralamNadiAmsa(75).nadiNumber, 1);
 assert.equal(calculateDevaKeralamNadiAmsa(almostAt(90)).nadiNumber, 75);

--- a/src/lib/nadiAmsa.ts
+++ b/src/lib/nadiAmsa.ts
@@ -4,12 +4,33 @@ export const NADI_AMSA_COUNT = 150;
 export const NADI_AMSA_SIZE_DEGREES = 30 / NADI_AMSA_COUNT;
 export const NADI_HALF_SIZE_DEGREES = NADI_AMSA_SIZE_DEGREES / 2;
 
+// Deva Keralam / Chandra Kala Nadi names in their canonical movable-sign order.
+// Transliteration variants exist; these spellings are kept stable for lookup/export.
+export const DEVA_KERALAM_NADI_NAMES = [
+  'Vasudhā', 'Vaiṣṇavī', 'Brāhmī', 'Kālakūṭa', 'Śāṅkarī', 'Sudhākarī', 'Samā', 'Saumyā', 'Surā', 'Māyā',
+  'Manoharā', 'Mādhavī', 'Mañjusvanā', 'Ghorā', 'Kumbhinī', 'Kuṭilā', 'Prabhā', 'Parā', 'Payasvinī', 'Mālā',
+  'Jagatī', 'Jarjharā', 'Dhruvā', 'Musalā', 'Mudgarā', 'Pāśā', 'Campakā', 'Dāminī', 'Mahī', 'Kaluṣā',
+  'Kamalā', 'Kāntā', 'Kālā', 'Karikarā', 'Kṣamā', 'Durdharā', 'Durbhagā', 'Viśvā', 'Viśīrṇā', 'Vikaṭā',
+  'Āvilā', 'Vibhramā', 'Sukhadā', 'Snigdhā', 'Sodarā', 'Surasundarī', 'Amṛtaplāvinī', 'Karālā', 'Kāmadhuk', 'Karavīraṇī',
+  'Gahvarā', 'Kuṇḍinī', 'Raudrā', 'Viśākhyā', 'Viṣanāśinī', 'Narmadā', 'Śītalā', 'Nimnā', 'Prītā', 'Priyavardhinī',
+  'Mānaghnā', 'Durbhagā', 'Citrā', 'Citriṇī', 'Cirañjīvinī', 'Bhūpā', 'Gadāharā', 'Nālā', 'Nalinī', 'Nirmalā',
+  'Nadī', 'Sudhāmṛtāṁśu', 'Kālikā', 'Kaluṣāṅkurā', 'Trailokyamohanakarī', 'Mahāmārī', 'Suśītalā', 'Sukhadā', 'Suprabhā', 'Śobhā',
+  'Śobhanā', 'Śivadā', 'Śivā', 'Bālā', 'Jvālā', 'Gadā', 'Gāḍhā', 'Nūtanā', 'Sumanoharā', 'Somavallī',
+  'Somalatā', 'Maṅgalā', 'Mudrikā', 'Kṣudhā', 'Mokṣāpavargā', 'Valayā', 'Navanītā', 'Niśācarī', 'Nirṛti', 'Nigaḍā',
+  'Sārā', 'Saṅgītā', 'Samadā', 'Samā', 'Viśvambharā', 'Kumārī', 'Kokilā', 'Kuñjarākṛti', 'Aindrā', 'Svāhā',
+  'Svarā', 'Vahni', 'Prītā', 'Rakṣajalāplavā', 'Vāruṇī', 'Madirā', 'Maitrī', 'Hāriṇī', 'Hariṇī', 'Marut',
+  'Dhanañjayā', 'Dhanakarī', 'Dhanadā', 'Kacchapāmbujā', 'Māṁsānī', 'Śūlinī', 'Raudrī', 'Śivā', 'Śivakarī', 'Kalā',
+  'Kuṇḍā', 'Mukundā', 'Bharatā', 'Haritā', 'Kadalī', 'Smarā', 'Kandalā', 'Kokilā', 'Pāpā', 'Kāminī',
+  'Kalaśodbhavā', 'Vīraprasū', 'Saṅgarā', 'Śatayajñā', 'Śatāvarī', 'Prahvī', 'Pāṭalinī', 'Nāgā', 'Paṅkajā', 'Parameśvarī',
+] as const;
+
 export type NadiHalf = 'purva' | 'para';
 
 export interface DevaKeralamNadiAmsa {
   system: 'deva-keralam';
   rawDivision: number;
   nadiNumber: number;
+  nadiName: string;
   modality: 'movable' | 'fixed' | 'dual';
   offsetDegrees: number;
 }
@@ -47,6 +68,7 @@ export function calculateDevaKeralamNadiAmsa(longitude: number): DevaKeralamNadi
       system: 'deva-keralam',
       rawDivision: rawDivision + 1,
       nadiNumber: NADI_AMSA_COUNT - rawDivision,
+      nadiName: DEVA_KERALAM_NADI_NAMES[NADI_AMSA_COUNT - rawDivision - 1],
       modality: 'fixed',
       offsetDegrees: degrees - rawDivision * NADI_AMSA_SIZE_DEGREES,
     };
@@ -57,6 +79,7 @@ export function calculateDevaKeralamNadiAmsa(longitude: number): DevaKeralamNadi
       system: 'deva-keralam',
       rawDivision: rawDivision + 1,
       nadiNumber: rawDivision < 75 ? rawDivision + 76 : rawDivision - 74,
+      nadiName: DEVA_KERALAM_NADI_NAMES[(rawDivision < 75 ? rawDivision + 76 : rawDivision - 74) - 1],
       modality: 'dual',
       offsetDegrees: degrees - rawDivision * NADI_AMSA_SIZE_DEGREES,
     };
@@ -66,6 +89,7 @@ export function calculateDevaKeralamNadiAmsa(longitude: number): DevaKeralamNadi
     system: 'deva-keralam',
     rawDivision: rawDivision + 1,
     nadiNumber: rawDivision + 1,
+    nadiName: DEVA_KERALAM_NADI_NAMES[rawDivision],
     modality: 'movable',
     offsetDegrees: degrees - rawDivision * NADI_AMSA_SIZE_DEGREES,
   };


### PR DESCRIPTION
Adds all 150 Deva Keralam / Chandra Kala Nadi names to the Nāḍī calculation table. Each result now shows its name, number, and sign modality. Includes boundary/name tests and bumps the app to v1.58.

Validated with unit tests, focused ESLint, production build, and diff checks.