### PR TITLE
Add selectable Chara Karaka ranking

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -231,8 +231,8 @@ export default function Home() {
     !!birthDatetime && showCoords && !!manualLat && !!manualLng && effectiveTzOffset !== null;
 
   const charaKarakas: CharaKaraka[] = useMemo(
-    () => (chartData ? calculateCharaKarakas(chartData.planets) : []),
-    [chartData]
+    () => (chartData ? calculateCharaKarakas(chartData.planets, calculationSettings.charaKarakaRankMode) : []),
+    [chartData, calculationSettings.charaKarakaRankMode]
   );
 
   const karakaByPlanet = useMemo(() => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -170,6 +170,20 @@ export default function SettingsPanel(props: Props) {
                 <option value="true">True Node</option>
               </select>
             </div>
+            <div>
+              <label className="block text-xs font-mono text-zinc-500 dark:text-zinc-400 mb-1">chara karaka ranking</label>
+              <select
+                className={SELECT}
+                value={calculationSettings.charaKarakaRankMode ?? 'degree'}
+                onChange={(e) => onUpdateCalculationSettings({ charaKarakaRankMode: e.target.value as 'degree' | 'minute' })}
+              >
+                <option value="degree">Highest degree (classical)</option>
+                <option value="minute">Highest minute</option>
+              </select>
+              <div className="mt-1 text-[9px] font-mono text-zinc-400 dark:text-zinc-600">
+                Minute mode compares the minute–second remainder; Rahu is measured in reverse.
+              </div>
+            </div>
           </div>
 
           <div>

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,13 @@
 export const CHANGELOG = [
   {
+    version: 'v1.59',
+    changes: [
+      'Added selectable Chara Karaka ranking: classical highest degree or highest minute',
+      'Highest-minute mode compares the minute–second remainder and reverses Rahu before ranking',
+      'Added deterministic tests for both Chara Karaka ranking modes',
+    ],
+  },
+  {
     version: 'v1.58',
     changes: [
       'Added all 150 Deva Keralam / Chandra Kala Nadi nāḍī-aṁśa names',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.58';
+export const APP_VERSION = 'v1.59';

--- a/src/lib/karakas.test.ts
+++ b/src/lib/karakas.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import type { PlanetData } from '@/types';
+import { calculateCharaKarakas } from './karakas';
+
+function planet(name: string, degree: number): PlanetData {
+  return { name, degree, longitude: degree, sign: 1, house: 1 };
+}
+
+const planets = [
+  planet('Sun', 26 + 12 / 60),
+  planet('Moon', 6 + 54 / 60),
+  planet('Mars', 10 + 42 / 60),
+  planet('Mercury', 20 + 30 / 60),
+  planet('Jupiter', 3 + 48 / 60),
+  planet('Venus', 10 + 36 / 60),
+  planet('Saturn', 24 + 24 / 60),
+  planet('Rahu', 8 + 18 / 60), // reversed: 21°42′
+];
+
+const degreeRanking = calculateCharaKarakas(planets, 'degree');
+assert.equal(degreeRanking[0].planet, 'Sun');
+assert.equal(degreeRanking[0].karaka, 'AK');
+assert.equal(degreeRanking.at(-1)?.planet, 'Jupiter');
+
+const minuteRanking = calculateCharaKarakas(planets, 'minute');
+assert.equal(minuteRanking[0].planet, 'Moon');
+assert.equal(minuteRanking[0].karaka, 'AK');
+assert.equal(minuteRanking[1].planet, 'Jupiter');
+assert.equal(minuteRanking[2].planet, 'Rahu'); // Mars also has 42′; full effective degree breaks the tie.
+assert.equal(minuteRanking[3].planet, 'Mars');
+
+assert.deepEqual(
+  calculateCharaKarakas(planets).map((entry) => entry.planet),
+  degreeRanking.map((entry) => entry.planet),
+);
+
+console.log('Chara Karaka ranking tests passed');

--- a/src/lib/karakas.ts
+++ b/src/lib/karakas.ts
@@ -31,19 +31,33 @@ export interface CharaKaraka {
   degree: number;
 }
 
+export type CharaKarakaRankMode = 'degree' | 'minute';
+
 const RELEVANT_PLANETS = new Set([
   'Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn', 'Rahu',
 ]);
 
-export function calculateCharaKarakas(planets: PlanetData[]): CharaKaraka[] {
+export function calculateCharaKarakas(
+  planets: PlanetData[],
+  rankMode: CharaKarakaRankMode = 'degree',
+): CharaKaraka[] {
   const ranked = planets
     .filter((p) => RELEVANT_PLANETS.has(p.name))
-    .map((p) => ({
-      planet: p.name,
-      // Rahu moves retrograde; use distance from 30° end of sign
-      effectiveDegree: p.name === 'Rahu' ? 30 - p.degree : p.degree,
-    }))
-    .sort((a, b) => b.effectiveDegree - a.effectiveDegree);
+    .map((p) => {
+      // Rahu moves retrograde; use distance from the 30° end of the sign.
+      const effectiveDegree = p.name === 'Rahu' ? 30 - p.degree : p.degree;
+      const effectiveMinute = (effectiveDegree - Math.floor(effectiveDegree)) * 60;
+      return {
+        planet: p.name,
+        effectiveDegree,
+        rankValue: rankMode === 'minute' ? effectiveMinute : effectiveDegree,
+      };
+    })
+    .sort((a, b) =>
+      b.rankValue - a.rankValue
+      || b.effectiveDegree - a.effectiveDegree
+      || a.planet.localeCompare(b.planet)
+    );
 
   return ranked.map((entry, i) => ({
     karaka: KARAKA_ABBR[i],

--- a/src/types.ts
+++ b/src/types.ts
@@ -170,12 +170,14 @@ export interface CalculationSettings {
   ayanamsa: string;
   nodeMode: string;
   nakshatraMode: 'sidereal' | 'tropical';
+  charaKarakaRankMode: 'degree' | 'minute';
 }
 
 export const DEFAULT_CALCULATION_SETTINGS: CalculationSettings = {
   ayanamsa: 'lahiri',
   nodeMode: 'mean',
   nakshatraMode: 'sidereal',
+  charaKarakaRankMode: 'degree',
 };
 
 export interface CharaOptions {


### PR DESCRIPTION
## What changed

- adds a Chara Karaka ranking selector under Settings → Display → Calculations
- keeps classical highest-degree ranking as the default
- adds highest-minute ranking using the minute–second remainder
- applies Rahu's reverse measurement before either ranking
- recalculates displayed/exported Chara Karakas immediately when the setting changes
- adds deterministic tests and bumps the app to v1.59

## Validation

- `node --import tsx src/lib/karakas.test.ts`
- focused ESLint for the calculation and test files
- `npm run build`
- `git diff --check`

SettingsPanel still has a pre-existing React effect lint error unrelated to this change.