### PR TITLE
Add separate Aṣṭakavarga table

### DIFF
--- a/src/components/AshtakavargaPanel.tsx
+++ b/src/components/AshtakavargaPanel.tsx
@@ -1,12 +1,66 @@
 'use client';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export default function AshtakavargaPanel(_props: { chart?: unknown }) {
+import type { ChartData } from '@/types';
+import { buildAshtakavarga, mapAshtakavargaHousesToSigns } from '@/lib/ashtakavarga';
+
+const SIGNS = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
+const PLANET_ABBR: Record<string, string> = {
+  Sun: 'Su',
+  Moon: 'Mo',
+  Mars: 'Ma',
+  Mercury: 'Me',
+  Jupiter: 'Ju',
+  Venus: 'Ve',
+  Saturn: 'Sa',
+};
+
+export default function AshtakavargaPanel({ chart }: { chart: ChartData }) {
+  const { bav, sav } = buildAshtakavarga(chart);
+  const ascendantSign = chart.ascendant.sign;
+
   return (
-    <div className="rounded-md border border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-900/50 px-3 py-4 text-center">
-      <p className="text-xs font-mono text-zinc-400 dark:text-zinc-600">
-        Ashtakavarga not available yet
-      </p>
+    <div className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-3">
+      <div className="mb-3">
+        <h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Aṣṭakavarga</h3>
+        <p className="text-[10px] font-mono text-zinc-400 dark:text-zinc-500">Bhinna &amp; Sarva · signs Ar–Pi</p>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[680px] border-collapse text-center font-mono text-xs">
+          <thead>
+            <tr className="text-zinc-500 dark:text-zinc-400">
+              <th scope="col" className="sticky left-0 z-10 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 px-2 py-2 text-left">Graha</th>
+              {SIGNS.map((sign) => (
+                <th scope="col" key={sign} className="border border-zinc-200 dark:border-zinc-700 px-2 py-2 font-semibold">{sign}</th>
+              ))}
+              <th scope="col" className="border border-zinc-200 dark:border-zinc-700 px-2 py-2">Σ</th>
+            </tr>
+          </thead>
+          <tbody>
+            {bav.map((row) => {
+              const values = mapAshtakavargaHousesToSigns(row.houses, ascendantSign);
+              return (
+                <tr key={row.planet} className="text-zinc-700 dark:text-zinc-200">
+                  <th scope="row" title={row.planet} className="sticky left-0 z-10 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 px-2 py-2 text-left font-semibold">
+                    {PLANET_ABBR[row.planet]}
+                  </th>
+                  {values.map((value, signIndex) => (
+                    <td key={SIGNS[signIndex]} className="border border-zinc-200 dark:border-zinc-700 px-2 py-2 tabular-nums">{value}</td>
+                  ))}
+                  <td className="border border-zinc-200 dark:border-zinc-700 px-2 py-2 font-semibold tabular-nums">{row.total}</td>
+                </tr>
+              );
+            })}
+            <tr className="bg-emerald-50 dark:bg-emerald-950/30 text-emerald-800 dark:text-emerald-300">
+              <th scope="row" title="Sarva Ashtakavarga" className="sticky left-0 z-10 bg-emerald-50 dark:bg-emerald-950 border border-zinc-200 dark:border-zinc-700 px-2 py-2 text-left font-bold">SAV</th>
+              {mapAshtakavargaHousesToSigns(sav.houses, ascendantSign).map((value, signIndex) => (
+                <td key={SIGNS[signIndex]} className="border border-zinc-200 dark:border-zinc-700 px-2 py-2 font-bold tabular-nums">{value}</td>
+              ))}
+              <td className="border border-zinc-200 dark:border-zinc-700 px-2 py-2 font-bold tabular-nums">{sav.total}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/components/ChartSection.tsx
+++ b/src/components/ChartSection.tsx
@@ -6,8 +6,7 @@ import NorthIndianChart from './NorthIndianChart';
 import SouthIndianChart from './SouthIndianChart';
 import VargaMatrix from '@/pages/VargaMatrix';
 import DrishtiPanel from '@/components/DrishtiPanel';
-import { getAshtakavargaOverlay } from '@/lib/ashtakavarga';
-import type { AvMode } from '@/lib/ashtakavarga';
+import AshtakavargaPanel from '@/components/AshtakavargaPanel';
 import { calculateJupiterianRounds } from '@/lib/bnn/jupiterianRounds';
 import { calculateMinorProgression } from '@/lib/bnn/jupiterMinorProgression';
 import TransitDateControls from './TransitDateControls';
@@ -88,7 +87,7 @@ export default function ChartSection({
 }: ChartSectionProps) {
   const [chartStyle, setChartStyle] = useState<ChartStyle>(chartDisplaySettings.chartStyle ?? 'north');
   const [showBcpHighlights, setShowBcpHighlights] = useState<boolean>(isBcpEnabled());
-  const [view, setView] = useState<'chart' | 'varga' | 'nadi' | 'drishti'>('chart');
+  const [view, setView] = useState<'chart' | 'varga' | 'nadi' | 'ashtakavarga' | 'drishti'>('chart');
 
   const bnnHouses = useMemo(() => {
     // Use parent-provided houses when available (keeps age override in sync with chart highlights)
@@ -159,13 +158,10 @@ export default function ChartSection({
 
   const yearHouse = showBcpHighlights ? bcp.activeYearHouse : 0;
   const monthHouse = showBcpHighlights ? bcp.activeMonthHouse : 0;
-  const avMode: AvMode = chartDisplaySettings.avMode ?? 'off';
-  const ashtakavargaOverlay = avMode !== 'off' ? getAshtakavargaOverlay(chart, avMode) : [];
-  const avOverlayLabel = avMode === 'sav' ? 'SAV' : avMode !== 'off' ? `${avMode} BAV` : undefined;
   const bnnMajorHouse = chartDisplaySettings.showBnnMajorHighlight ? bnnHouses.major : 0;
   const bnnMinorHouse = chartDisplaySettings.showBnnMinorHighlight ? bnnHouses.minor : 0;
 
-  const tabClass = (id: 'chart' | 'varga' | 'nadi' | 'drishti') =>
+  const tabClass = (id: 'chart' | 'varga' | 'nadi' | 'ashtakavarga' | 'drishti') =>
     `shrink-0 px-2.5 py-1.5 text-[10px] font-mono rounded-md ${view === id ? 'bg-white dark:bg-zinc-700 text-emerald-700 dark:text-green-400 shadow-sm' : 'text-zinc-500 dark:text-zinc-400'}`;
 
   return (
@@ -183,6 +179,7 @@ export default function ChartSection({
             <button type="button" onClick={() => setView('chart')} className={tabClass('chart')}>Chart</button>
             <button type="button" onClick={() => setView('varga')} className={tabClass('varga')}>Varga</button>
             <button type="button" onClick={() => setView('nadi')} className={tabClass('nadi')}>Nāḍī</button>
+            <button type="button" onClick={() => setView('ashtakavarga')} className={tabClass('ashtakavarga')}>Aṣṭakavarga</button>
             <button type="button" onClick={() => setView('drishti')} className={tabClass('drishti')}>Dṛṣṭi</button>
           </div>
         </div>
@@ -192,6 +189,8 @@ export default function ChartSection({
         <div className="min-w-0 overflow-x-auto"><VargaMatrix chart={chart} /></div>
       ) : view === 'nadi' ? (
         <div className="min-w-0 overflow-x-auto"><NadiAmsaPanel chart={chart} /></div>
+      ) : view === 'ashtakavarga' ? (
+        <div className="min-w-0 overflow-x-auto"><AshtakavargaPanel chart={chart} /></div>
       ) : view === 'drishti' ? (
         <div className="min-w-0 overflow-x-auto"><DrishtiPanel chart={chart} showGrahaDrishti={chartDisplaySettings.showGrahaDrishti ?? true} showRashiDrishti={chartDisplaySettings.showRashiDrishti ?? true} /></div>
       ) : chartStyle === 'south' ? (
@@ -202,8 +201,6 @@ export default function ChartSection({
           planets={chart.planets}
           specialLagnas={chart.specialLagnas ?? []}
           transitPlanets={transitPlanets}
-          ashtakavargaOverlay={ashtakavargaOverlay}
-          avOverlayLabel={avOverlayLabel}
           showSigns={chartDisplaySettings.showSigns}
           showNatalPlanets={chartDisplaySettings.showNatalPlanets}
           showTransitPlanets={chartDisplaySettings.showTransitPlanets}
@@ -225,8 +222,6 @@ export default function ChartSection({
           planets={chart.planets}
           specialLagnas={chart.specialLagnas ?? []}
           transitPlanets={transitPlanets}
-          ashtakavargaOverlay={ashtakavargaOverlay}
-          avOverlayLabel={avOverlayLabel}
           showSigns={chartDisplaySettings.showSigns}
           showNatalPlanets={chartDisplaySettings.showNatalPlanets}
           showTransitPlanets={chartDisplaySettings.showTransitPlanets}

--- a/src/components/NorthIndianChart.tsx
+++ b/src/components/NorthIndianChart.tsx
@@ -4,12 +4,10 @@ import { useEffect, useState } from 'react';
 import { useTheme } from 'next-themes';
 import { PlanetData, SpecialLagna } from '@/types';
 import { type DegreePrecision, formatDegree } from '@/lib/formatDegree';
-import type { AshtakavargaOverlayCell } from '@/lib/ashtakavarga';
 
 const OUTER_PLANETS = ['Uranus', 'Neptune', 'Pluto'];
 const SPECIAL_LAGNA_COLOR = '#d97706';
 const TRANSIT_COLOR = '#f43f5e';
-const ASHTAKAVARGA_COLOR = '#06b6d4';
 
 const BNN_MAJOR_LIGHT = '#ea580c';
 const BNN_MAJOR_DARK  = '#f97316';
@@ -23,7 +21,6 @@ interface Props {
   planets: PlanetData[];
   specialLagnas?: SpecialLagna[];
   transitPlanets?: PlanetData[];
-  ashtakavargaOverlay?: AshtakavargaOverlayCell[];
   showNatalPlanets?: boolean;
   showTransitPlanets?: boolean;
   showSigns?: boolean;
@@ -38,7 +35,6 @@ interface Props {
   nakshatraAdjust?: number;
   bnnMajorHouse?: number;
   bnnMinorHouse?: number;
-  avOverlayLabel?: string;
   legendLayers?: { bcp?: boolean; bnn?: boolean; transit?: boolean };
 }
 
@@ -155,7 +151,6 @@ export default function NorthIndianChart({
   planets,
   specialLagnas = [],
   transitPlanets = [],
-  ashtakavargaOverlay = [],
   showNatalPlanets = true,
   showTransitPlanets = false,
   showSigns = true,
@@ -170,7 +165,6 @@ export default function NorthIndianChart({
   nakshatraAdjust = 0,
   bnnMajorHouse = 0,
   bnnMinorHouse = 0,
-  avOverlayLabel,
   legendLayers,
 }: Props) {
   const { resolvedTheme } = useTheme();
@@ -194,7 +188,6 @@ export default function NorthIndianChart({
       <svg viewBox="-25 -25 550 550" className="w-full h-auto overflow-visible" role="img" aria-label="North Indian Jyotish chart">
         {HOUSES.map((item) => {
           const sign = getSignForHouse(ascendantSign, item.house);
-          const avCell = ashtakavargaOverlay.find((cell) => cell.house === item.house);
           type MergedPlanet = PlanetData & { isTransit: boolean };
 
           const natalInHouse: MergedPlanet[] = showNatalPlanets
@@ -253,19 +246,6 @@ export default function NorthIndianChart({
               {showHouseNumbers && (
                 <text x={item.sign.x} y={item.sign.y + 14} textAnchor="middle" dominantBaseline="middle" fontSize="9" fontWeight="600" fill={hNumFill}>
                   H{item.house}
-                </text>
-              )}
-              {avCell && (
-                <text
-                  x={item.sign.x}
-                  y={item.sign.y - 16}
-                  textAnchor="middle"
-                  dominantBaseline="middle"
-                  fontSize="11"
-                  fontWeight="800"
-                  fill={ASHTAKAVARGA_COLOR}
-                >
-                  AV {avCell.bindu}
                 </text>
               )}
               {/* BNN label — sits below the sign abbreviation */}
@@ -332,7 +312,7 @@ export default function NorthIndianChart({
         })}
       </svg>
 
-      {(showBcpHighlights || showTransitPlanets || showSpecialLagnas || ashtakavargaOverlay.length > 0 || hasBnn) && (
+      {(showBcpHighlights || showTransitPlanets || showSpecialLagnas || hasBnn) && (
         <div className="mt-3 flex justify-center gap-4 text-[11px] font-mono flex-wrap">
           {showBcpHighlights && legendLayers?.bcp !== false && <span className="text-cyan-600 dark:text-cyan-400 font-semibold">■ BCP Year</span>}
           {showBcpHighlights && legendLayers?.bcp !== false && <span className="text-emerald-700 dark:text-green-400 font-semibold">■ BCP Month</span>}
@@ -341,7 +321,6 @@ export default function NorthIndianChart({
           {bnnMinorHouse > 0 && legendLayers?.bnn !== false && <span style={{ color: isDark ? BNN_MINOR_DARK : BNN_MINOR_LIGHT }} className="font-semibold">╌ BNN Minor</span>}
           {showTransitPlanets && legendLayers?.transit !== false && <span style={{ color: TRANSIT_COLOR }} className="font-semibold">■ Transit</span>}
           {showSpecialLagnas && <span style={{ color: SPECIAL_LAGNA_COLOR }} className="font-semibold">■ Special</span>}
-          {ashtakavargaOverlay.length > 0 && <span style={{ color: ASHTAKAVARGA_COLOR }} className="font-semibold">AV / {avOverlayLabel ?? 'Ashtakavarga'}</span>}
         </div>
       )}
     </div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { ChartDisplaySettings, CalculationSettings, DashaSettings, DEFAULT_DASHA_SETTINGS } from '@/types';
-import type { AvMode } from '@/lib/ashtakavarga';
 import { type DegreePrecision } from '@/lib/formatDegree';
 import { APP_NAME, APP_VERSION } from '@/lib/config';
 import { DASHA_REGISTRY, DashaKey } from '@/lib/dashaRegistry';
@@ -43,18 +42,6 @@ const ADVANCED_TOGGLES: { key: keyof ChartDisplaySettings; label: string }[] = [
   { key: 'showGrahaDrishti', label: 'graha dṛṣṭi' },
   { key: 'showRashiDrishti', label: 'rāśi dṛṣṭi' },
   { key: 'showBnnAlpha', label: 'BNN alpha (research)' },
-];
-
-const AV_MODE_OPTIONS: { value: AvMode; label: string }[] = [
-  { value: 'off', label: 'Off' },
-  { value: 'sav', label: 'SAV — Sarvashtakavarga (total)' },
-  { value: 'Sun', label: 'Sun BAV' },
-  { value: 'Moon', label: 'Moon BAV' },
-  { value: 'Mars', label: 'Mars BAV' },
-  { value: 'Mercury', label: 'Mercury BAV' },
-  { value: 'Jupiter', label: 'Jupiter BAV' },
-  { value: 'Venus', label: 'Venus BAV' },
-  { value: 'Saturn', label: 'Saturn BAV' },
 ];
 
 const CORE_DASHAS = DASHA_REGISTRY.filter(d => d.group === 'Core');
@@ -223,20 +210,6 @@ export default function SettingsPanel(props: Props) {
                   }}
                 />
               </div>
-            </div>
-            <div className="mt-3">
-              <label className="block text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600 mb-1">
-                AV / Ashtakavarga
-              </label>
-              <select
-                className={SELECT}
-                value={chartDisplaySettings.avMode ?? 'off'}
-                onChange={(e) => onUpdateChartDisplay?.({ avMode: e.target.value as AvMode })}
-              >
-                {AV_MODE_OPTIONS.map(({ value, label }) => (
-                  <option key={value} value={value}>{label}</option>
-                ))}
-              </select>
             </div>
             <div className="mt-2 flex items-center justify-between gap-2">
               <span className="text-xs font-mono text-zinc-600 dark:text-zinc-300 shrink-0">degrees</span>

--- a/src/components/SouthIndianChart.tsx
+++ b/src/components/SouthIndianChart.tsx
@@ -4,12 +4,10 @@ import { useEffect, useState } from 'react';
 import { useTheme } from 'next-themes';
 import { PlanetData, SpecialLagna } from '@/types';
 import { type DegreePrecision, formatDegree } from '@/lib/formatDegree';
-import type { AshtakavargaOverlayCell } from '@/lib/ashtakavarga';
 
 const OUTER_PLANETS = ['Uranus', 'Neptune', 'Pluto'];
 const SPECIAL_LAGNA_COLOR = '#d97706';
 const TRANSIT_COLOR = '#f43f5e';
-const ASHTAKAVARGA_COLOR = '#06b6d4';
 
 const BNN_MAJOR_LIGHT = '#ea580c';
 const BNN_MAJOR_DARK  = '#f97316';
@@ -23,7 +21,6 @@ interface Props {
   planets: PlanetData[];
   specialLagnas?: SpecialLagna[];
   transitPlanets?: PlanetData[];
-  ashtakavargaOverlay?: AshtakavargaOverlayCell[];
   showNatalPlanets?: boolean;
   showTransitPlanets?: boolean;
   showSigns?: boolean;
@@ -36,7 +33,6 @@ interface Props {
   nakshatraAdjust?: number;
   bnnMajorHouse?: number;
   bnnMinorHouse?: number;
-  avOverlayLabel?: string;
   legendLayers?: { bcp?: boolean; bnn?: boolean; transit?: boolean };
 }
 
@@ -112,7 +108,6 @@ export default function SouthIndianChart({
   planets,
   specialLagnas = [],
   transitPlanets = [],
-  ashtakavargaOverlay = [],
   showNatalPlanets = true,
   showTransitPlanets = false,
   showSigns = true,
@@ -125,7 +120,6 @@ export default function SouthIndianChart({
   nakshatraAdjust = 0,
   bnnMajorHouse = 0,
   bnnMinorHouse = 0,
-  avOverlayLabel,
   legendLayers,
 }: Props) {
   const { resolvedTheme } = useTheme();
@@ -183,7 +177,6 @@ export default function SouthIndianChart({
           const house = getHouse(sign, ascendantSign);
           const planetsHere = bySign[sign] ?? [];
           const specialHere = specialBySign[sign] ?? [];
-          const avCell = ashtakavargaOverlay.find((cell) => cell.house === house);
 
           const isBnnMaj = bnnMajorHouse > 0 && house === bnnMajorHouse;
           const isBnnMin = bnnMinorHouse > 0 && house === bnnMinorHouse;
@@ -232,11 +225,6 @@ export default function SouthIndianChart({
                 {sign === ascendantSign ? (
                   <span className="font-bold text-emerald-700 dark:text-green-400">ASC</span>
                 ) : <span />}
-                {avCell && (
-                  <span className="font-extrabold" style={{ color: ASHTAKAVARGA_COLOR }}>
-                    AV {avCell.bindu}
-                  </span>
-                )}
               </div>
 
               <div className="mt-1 flex flex-col gap-0.5 text-[11px] leading-tight font-bold text-zinc-800 dark:text-zinc-100">
@@ -283,7 +271,7 @@ export default function SouthIndianChart({
         })}
       </div>
 
-      {(activeYearHouse > 0 || activeMonthHouse > 0 || showTransitPlanets || showSpecialLagnas || ashtakavargaOverlay.length > 0 || hasBnn) && (
+      {(activeYearHouse > 0 || activeMonthHouse > 0 || showTransitPlanets || showSpecialLagnas || hasBnn) && (
         <div className="mt-3 flex justify-center gap-4 text-[11px] font-mono flex-wrap">
           {(activeYearHouse > 0 || activeMonthHouse > 0) && legendLayers?.bcp !== false && (
             <>
@@ -296,7 +284,6 @@ export default function SouthIndianChart({
           {bnnMinorHouse > 0 && legendLayers?.bnn !== false && <span style={{ color: bnnMinColor }} className="font-semibold">╌ BNN Minor</span>}
           {showTransitPlanets && legendLayers?.transit !== false && <span style={{ color: TRANSIT_COLOR }} className="font-semibold">■ Transit</span>}
           {showSpecialLagnas && <span style={{ color: SPECIAL_LAGNA_COLOR }} className="font-semibold">■ Special</span>}
-          {ashtakavargaOverlay.length > 0 && <span style={{ color: ASHTAKAVARGA_COLOR }} className="font-semibold">AV / {avOverlayLabel ?? 'Ashtakavarga'}</span>}
         </div>
       )}
     </div>

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -5,7 +5,6 @@ import type {
   ChartData, BcpResult, PlanetData, ChartDisplaySettings,
   DashaSettings, WorkspacePanel, WorkspacePanelType,
 } from '@/types';
-import { getAshtakavargaOverlay } from '@/lib/ashtakavarga';
 import NorthIndianChart from '../NorthIndianChart';
 import SouthIndianChart from '../SouthIndianChart';
 import TransitDateControls from '../TransitDateControls';
@@ -198,9 +197,6 @@ export default function WorkspaceView({
 
   // ── Chart rendering helper ──
   const chartStyle = chartDisplaySettings.chartStyle ?? 'north';
-  const avMode = chartDisplaySettings.avMode ?? 'off';
-  const ashtakavargaOverlay = avMode !== 'off' ? getAshtakavargaOverlay(chart, avMode) : [];
-  const avOverlayLabel = avMode === 'sav' ? 'SAV' : avMode !== 'off' ? `${avMode} BAV` : undefined;
 
   function renderChart(opts: {
     yearHouse?: number;
@@ -238,8 +234,6 @@ export default function WorkspaceView({
       bnnMinorHouse: bnnMin,
       transitPlanets: showTransit ? transitPlanets : [],
       showTransitPlanets: showTransit,
-      ashtakavargaOverlay,
-      avOverlayLabel,
       legendLayers,
     };
 

--- a/src/lib/ashtakavarga.test.ts
+++ b/src/lib/ashtakavarga.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { buildAshtakavarga, mapAshtakavargaHousesToSigns } from './ashtakavarga';
+
+const chart = {
+  ascendant: { sign: 4 }, // Cancer
+  planets: [
+    { name: 'Sun', sign: 1 },
+    { name: 'Moon', sign: 2 },
+    { name: 'Mars', sign: 3 },
+    { name: 'Mercury', sign: 4 },
+    { name: 'Jupiter', sign: 5 },
+    { name: 'Venus', sign: 6 },
+    { name: 'Saturn', sign: 7 },
+  ],
+};
+
+// SAV must remain the exact sum of all displayed BAV cells.
+const result = buildAshtakavarga(chart);
+assert.equal(result.sav.total, result.bav.reduce((sum, row) => sum + row.total, 0));
+
+// Cancer ascendant: Aries is H10, Cancer is H1 and Pisces is H9.
+const houses = Array.from({ length: 12 }, (_, index) => index + 1);
+assert.deepEqual(
+  mapAshtakavargaHousesToSigns(houses, 4),
+  [10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+);
+
+console.log('Aṣṭakavarga tests passed');

--- a/src/lib/ashtakavarga.ts
+++ b/src/lib/ashtakavarga.ts
@@ -221,6 +221,15 @@ export function buildAshtakavarga(chart: AshtakavargaChartLike): AshtakavargaRes
   return { bav, sav };
 }
 
+/** Convert a house-indexed AV row (H1..H12) to fixed zodiac order (Aries..Pisces). */
+export function mapAshtakavargaHousesToSigns(houses: number[], ascendantSign: number): number[] {
+  return Array.from({ length: 12 }, (_, signIndex) => {
+    const sign = signIndex + 1;
+    const house = ((sign - ascendantSign + 12) % 12) + 1;
+    return houses[house - 1] ?? 0;
+  });
+}
+
 function bavRowToOverlayCells(chart: AshtakavargaChartLike, row: BhinnaAshtakavargaRow): AshtakavargaOverlayCell[] {
   return row.houses.map((bindu, index) => {
     const house = index + 1;

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.60',
+    date: '2026-08-10',
+    title: 'Separate Aṣṭakavarga table',
+    changes: [
+      'Moved Bhinna and Sarva Aṣṭakavarga values into their own chart tab.',
+      'Removed the AV overlay and its setting from natal charts.',
+      'Aligned house-based bindu values to fixed zodiac-sign columns; cells now show numbers only.',
+    ],
+  },
+  {
     version: 'v1.59',
     changes: [
       'Added selectable Chara Karaka ranking: classical highest degree or highest minute',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.59';
+export const APP_VERSION = 'v1.60';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,5 @@
 import type { DegreePrecision } from '@/lib/formatDegree';
 export type { DegreePrecision };
-import type { AvMode } from '@/lib/ashtakavarga';
-export type { AvMode };
 
 export interface GeoResult {
   name: string;
@@ -130,7 +128,6 @@ export interface ChartDisplaySettings {
   showGrahaDrishti: boolean;
   showRashiDrishti: boolean;
   showBnnAlpha: boolean;
-  avMode: AvMode;
   showBnnJupiterianRounds: boolean;
   showBnnJupiterMinor: boolean;
   showBnnEventDetection: boolean;
@@ -157,7 +154,6 @@ export const DEFAULT_CHART_DISPLAY: ChartDisplaySettings = {
   showGrahaDrishti: false,
   showRashiDrishti: false,
   showBnnAlpha: false,
-  avMode: 'off',
   showBnnJupiterianRounds: false,
   showBnnJupiterMinor: false,
   showBnnEventDetection: true,


### PR DESCRIPTION
Moves Bhinna and Sarva Aṣṭakavarga values into a dedicated chart tab, removes the AV overlay and setting, and aligns house-indexed values to fixed zodiac-sign columns. Table cells contain numbers only.

Verified with the Aṣṭakavarga alignment test and a successful production build.