### PR TITLE
Add Parāśara and Varāhamihira Aṣṭakavarga systems

### DIFF
--- a/src/components/AshtakavargaPanel.tsx
+++ b/src/components/AshtakavargaPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import type { ChartData } from '@/types';
 import { buildAshtakavarga, mapAshtakavargaHousesToSigns } from '@/lib/ashtakavarga';
-import type { AshtakavargaPlanet } from '@/lib/ashtakavarga';
+import type { AshtakavargaPlanet, AshtakavargaSystem } from '@/lib/ashtakavarga';
 
 const SIGNS = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
 const PLANET_ABBR: Record<string, string> = {
@@ -17,6 +17,18 @@ const PLANET_ABBR: Record<string, string> = {
 };
 
 type AvSelection = 'SAV' | AshtakavargaPlanet;
+
+function numberColor(value: number, isSav: boolean): string {
+  const neutral = isSav ? value === 28 : value === 4;
+  if (neutral) return 'text-black dark:text-white';
+  const good = isSav ? value > 28 : value > 4;
+  return good ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400';
+}
+
+function svgNumberColor(value: number, isSav: boolean): string {
+  if (isSav ? value === 28 : value === 4) return 'currentColor';
+  return (isSav ? value > 28 : value > 4) ? '#16a34a' : '#dc2626';
+}
 
 const HOUSES = [
   { house: 1, points: '250,0 375,125 250,250 125,125', x: 250, y: 118, sx: 250, sy: 220 },
@@ -33,7 +45,7 @@ const HOUSES = [
   { house: 12, points: '500,0 375,125 250,0', x: 375, y: 54, sx: 375, sy: 96 },
 ];
 
-function NorthIndianAvChart({ houses, ascendantSign, label }: { houses: number[]; ascendantSign: number; label: string }) {
+function NorthIndianAvChart({ houses, ascendantSign, label, isSav }: { houses: number[]; ascendantSign: number; label: string; isSav: boolean }) {
   return (
     <div className="mx-auto w-full max-w-[560px]">
       <div className="mb-2 text-center text-xs font-mono font-semibold text-emerald-700 dark:text-emerald-400">{label}</div>
@@ -43,7 +55,7 @@ function NorthIndianAvChart({ houses, ascendantSign, label }: { houses: number[]
           return (
             <g key={item.house}>
               <polygon points={item.points} fill="transparent" stroke="currentColor" strokeOpacity="0.55" strokeWidth="2" />
-              <text x={item.x} y={item.y} textAnchor="middle" dominantBaseline="middle" fontSize="30" fontWeight="800" fill="currentColor">
+              <text x={item.x} y={item.y} textAnchor="middle" dominantBaseline="middle" fontSize="30" fontWeight="800" fill={svgNumberColor(houses[item.house - 1] ?? 0, isSav)}>
                 {houses[item.house - 1] ?? 0}
               </text>
               <text x={item.sx} y={item.sy} textAnchor="middle" dominantBaseline="middle" fontSize="12" fontWeight="600" fill="currentColor" opacity="0.55">
@@ -58,10 +70,11 @@ function NorthIndianAvChart({ houses, ascendantSign, label }: { houses: number[]
 }
 
 export default function AshtakavargaPanel({ chart }: { chart: ChartData }) {
-  const { bav, sav } = buildAshtakavarga(chart);
   const ascendantSign = chart.ascendant.sign;
   const [view, setView] = useState<'table' | 'north'>('table');
+  const [system, setSystem] = useState<AshtakavargaSystem>('parashara');
   const [selection, setSelection] = useState<AvSelection>('SAV');
+  const { bav, sav } = buildAshtakavarga(chart, system);
   const selectedRow = selection === 'SAV' ? null : bav.find((row) => row.planet === selection);
   const selectedHouses = selectedRow?.houses ?? sav.houses;
 
@@ -78,6 +91,11 @@ export default function AshtakavargaPanel({ chart }: { chart: ChartData }) {
         </div>
       </div>
 
+      <div className="mb-3 flex gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800">
+        <button type="button" onClick={() => setSystem('parashara')} className={`flex-1 rounded px-2.5 py-1.5 text-[10px] font-mono ${system === 'parashara' ? 'bg-white text-emerald-700 shadow-sm dark:bg-zinc-700 dark:text-emerald-400' : 'text-zinc-500'}`}>Parāśara</button>
+        <button type="button" onClick={() => setSystem('varahamihira')} className={`flex-1 rounded px-2.5 py-1.5 text-[10px] font-mono ${system === 'varahamihira' ? 'bg-white text-emerald-700 shadow-sm dark:bg-zinc-700 dark:text-emerald-400' : 'text-zinc-500'}`}>Varāhamihira</button>
+      </div>
+
       {view === 'north' ? (
         <div>
           <label className="mb-3 block text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
@@ -87,7 +105,7 @@ export default function AshtakavargaPanel({ chart }: { chart: ChartData }) {
               {bav.map((row) => <option key={row.planet} value={row.planet}>{row.planet} BAV</option>)}
             </select>
           </label>
-          <NorthIndianAvChart houses={selectedHouses} ascendantSign={ascendantSign} label={selection === 'SAV' ? 'SAV' : `${selection} BAV`} />
+          <NorthIndianAvChart houses={selectedHouses} ascendantSign={ascendantSign} label={`${system === 'parashara' ? 'Parāśara' : 'Varāhamihira'} · ${selection === 'SAV' ? 'SAV' : `${selection} BAV`}`} isSav={selection === 'SAV'} />
         </div>
       ) : (
       <div className="overflow-x-auto">
@@ -110,16 +128,16 @@ export default function AshtakavargaPanel({ chart }: { chart: ChartData }) {
                     {PLANET_ABBR[row.planet]}
                   </th>
                   {values.map((value, signIndex) => (
-                    <td key={SIGNS[signIndex]} className="border border-zinc-200 dark:border-zinc-700 px-2 py-2 tabular-nums">{value}</td>
+                    <td key={SIGNS[signIndex]} className={`border border-zinc-200 dark:border-zinc-700 px-2 py-2 font-semibold tabular-nums ${numberColor(value, false)}`}>{value}</td>
                   ))}
                   <td className="border border-zinc-200 dark:border-zinc-700 px-2 py-2 font-semibold tabular-nums">{row.total}</td>
                 </tr>
               );
             })}
-            <tr className="bg-emerald-50 dark:bg-emerald-950/30 text-emerald-800 dark:text-emerald-300">
-              <th scope="row" title="Sarva Ashtakavarga" className="sticky left-0 z-10 bg-emerald-50 dark:bg-emerald-950 border border-zinc-200 dark:border-zinc-700 px-2 py-2 text-left font-bold">SAV</th>
+            <tr>
+              <th scope="row" title="Sarva Ashtakavarga" className="sticky left-0 z-10 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 px-2 py-2 text-left font-bold">SAV</th>
               {mapAshtakavargaHousesToSigns(sav.houses, ascendantSign).map((value, signIndex) => (
-                <td key={SIGNS[signIndex]} className="border border-zinc-200 dark:border-zinc-700 px-2 py-2 font-bold tabular-nums">{value}</td>
+                <td key={SIGNS[signIndex]} className={`border border-zinc-200 dark:border-zinc-700 px-2 py-2 font-bold tabular-nums ${numberColor(value, true)}`}>{value}</td>
               ))}
               <td className="border border-zinc-200 dark:border-zinc-700 px-2 py-2 font-bold tabular-nums">{sav.total}</td>
             </tr>

--- a/src/lib/ashtakavarga.test.ts
+++ b/src/lib/ashtakavarga.test.ts
@@ -18,6 +18,14 @@ const chart = {
 const result = buildAshtakavarga(chart);
 assert.equal(result.sav.total, result.bav.reduce((sum, row) => sum + row.total, 0));
 
+const parashara = buildAshtakavarga(chart, 'parashara');
+const varahamihira = buildAshtakavarga(chart, 'varahamihira');
+assert.deepEqual(parashara.bav.map((row) => row.total), [50, 49, 42, 55, 56, 52, 39]);
+assert.deepEqual(varahamihira.bav.map((row) => row.total), [48, 49, 39, 54, 56, 52, 39]);
+assert.equal(parashara.sav.total, 343);
+assert.equal(varahamihira.sav.total, 337);
+assert.notDeepEqual(parashara.sav.houses, varahamihira.sav.houses);
+
 // Cancer ascendant: Aries is H10, Cancer is H1 and Pisces is H9.
 const houses = Array.from({ length: 12 }, (_, index) => index + 1);
 assert.deepEqual(

--- a/src/lib/ashtakavarga.ts
+++ b/src/lib/ashtakavarga.ts
@@ -1,4 +1,5 @@
 export type AshtakavargaPlanet = 'Sun' | 'Moon' | 'Mars' | 'Mercury' | 'Jupiter' | 'Venus' | 'Saturn';
+export type AshtakavargaSystem = 'parashara' | 'varahamihira';
 export type AvMode = 'off' | 'sav' | AshtakavargaPlanet;
 
 export type AshtakavargaChartPlanet = {
@@ -120,6 +121,16 @@ const PARASHARA_AV: Record<AshtakavargaPlanet, Record<Contributor, number[]>> = 
   },
 };
 
+// Brihat Jataka IX differs from the Parashara table in the entries below.
+// Unchanged contributor rows intentionally inherit the Parashara values.
+const VARAHAMIHIRA_AV: Record<AshtakavargaPlanet, Record<Contributor, number[]>> = {
+  ...PARASHARA_AV,
+  Sun: { ...PARASHARA_AV.Sun, Ascendant: [3, 4, 6, 10, 11, 12] },
+  Mars: { ...PARASHARA_AV.Mars, Ascendant: [1, 3, 6, 10, 11] },
+  Mercury: { ...PARASHARA_AV.Mercury, Ascendant: [1, 2, 4, 6, 8, 10, 11] },
+  Venus: { ...PARASHARA_AV.Venus, Mars: [3, 5, 6, 9, 11, 12] },
+};
+
 function getPlanet(chart: AshtakavargaChartLike, name: string): AshtakavargaChartPlanet | undefined {
   return chart.planets?.find((planet) => planet.name === name);
 }
@@ -155,9 +166,13 @@ function getSavStrength(bindu: number): AshtakavargaOverlayCell['strength'] {
   return 'low';
 }
 
-export function buildBhinnaAshtakavarga(chart: AshtakavargaChartLike): BhinnaAshtakavargaRow[] {
+export function buildBhinnaAshtakavarga(
+  chart: AshtakavargaChartLike,
+  system: AshtakavargaSystem = 'parashara',
+): BhinnaAshtakavargaRow[] {
+  const ruleSet = system === 'varahamihira' ? VARAHAMIHIRA_AV : PARASHARA_AV;
   return PLANETS.map((planetName) => {
-    const rules = PARASHARA_AV[planetName];
+    const rules = ruleSet[planetName];
 
     const houses = Array.from({ length: 12 }, (_, index) => {
       const house = index + 1;
@@ -215,8 +230,11 @@ export function buildSarvaAshtakavarga(chart: AshtakavargaChartLike, bav: Bhinna
   };
 }
 
-export function buildAshtakavarga(chart: AshtakavargaChartLike): AshtakavargaResult {
-  const bav = buildBhinnaAshtakavarga(chart);
+export function buildAshtakavarga(
+  chart: AshtakavargaChartLike,
+  system: AshtakavargaSystem = 'parashara',
+): AshtakavargaResult {
+  const bav = buildBhinnaAshtakavarga(chart, system);
   const sav = buildSarvaAshtakavarga(chart, bav);
   return { bav, sav };
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.62',
+    date: '2026-08-10',
+    title: 'Parāśara and Varāhamihira Aṣṭakavarga',
+    changes: [
+      'Added selectable Parāśara and Varāhamihira calculation tables.',
+      'Applied the selected system to both the numeric table and North Indian chart.',
+      'Colored only the point numbers: green above neutral, red below neutral, and black at neutral.',
+    ],
+  },
+  {
     version: 'v1.61',
     date: '2026-08-10',
     title: 'North Indian Aṣṭakavarga chart',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.61';
+export const APP_VERSION = 'v1.62';


### PR DESCRIPTION
Adds separate Parāśara and Varāhamihira bindu rule sets and applies the selected system to both the table and North Indian chart. Only point numbers are colored: green above neutral, red below neutral, and neutral black/white according to theme.

Validation: deterministic system totals/distribution tests and successful production build.