### PR TITLE
Add Kālachakra Daśā

### DIFF
--- a/src/components/KalachakraPanel.tsx
+++ b/src/components/KalachakraPanel.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { PlanetData } from '@/types';
+import { parseDateTime } from '@/lib/bcp';
+import { calculateKalachakra, calculateKalachakraAntardashas, type KalachakraEntry } from '@/lib/kalachakra';
+
+const ABBR: Record<string, string> = { Aries:'Ar', Taurus:'Ta', Gemini:'Ge', Cancer:'Cn', Leo:'Le', Virgo:'Vi', Libra:'Li', Scorpio:'Sc', Sagittarius:'Sg', Capricorn:'Cp', Aquarius:'Aq', Pisces:'Pi' };
+
+function fmt(date: Date) {
+  return `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${date.getFullYear()}`;
+}
+
+function active(entry: KalachakraEntry, now: Date) {
+  return entry.startDate <= now && now < entry.endDate;
+}
+
+export default function KalachakraPanel({ planets, birthDatetime }: { planets: PlanetData[]; birthDatetime: string }) {
+  const [selected, setSelected] = useState<KalachakraEntry | null>(null);
+  const now = useMemo(() => new Date(), []);
+  const result = useMemo(() => {
+    const moon = planets.find((planet) => planet.name === 'Moon');
+    const birth = parseDateTime(birthDatetime);
+    if (!moon || moon.longitude == null || !birth) return null;
+    return calculateKalachakra(moon.longitude, birth);
+  }, [planets, birthDatetime]);
+
+  if (!result) return <div className="text-xs font-mono text-zinc-400 italic">Moon longitude and valid birth datetime required.</div>;
+
+  const current = result.entries.find((item) => active(item, now)) ?? null;
+  const rows = selected ? calculateKalachakraAntardashas(selected, result.cycle) : result.entries;
+
+  return (
+    <div className="space-y-3 min-w-0">
+      <div className="flex items-center justify-between gap-2">
+        <div className="font-mono text-xs uppercase tracking-widest text-zinc-500 dark:text-zinc-400">&gt; kālachakra daśā</div>
+        {selected && <button type="button" onClick={() => setSelected(null)} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono dark:border-zinc-700">← MD</button>}
+      </div>
+      <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-[10px] font-mono text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
+        <div>{result.nakshatra} · pada {result.pada} · {result.motion}</div>
+        <div>Deha: {ABBR[result.dehaSign]} · Jīva: {ABBR[result.jeevaSign]}</div>
+        {current && <div className="mt-1 text-cyan-700 dark:text-cyan-300">Now: {ABBR[current.signName]} MD · {fmt(current.startDate)}–{fmt(current.endDate)}</div>}
+      </div>
+      <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400">{selected ? `${ABBR[selected.signName]} antardaśā` : 'mahādaśā'}</div>
+      <div className="space-y-1">
+        {rows.map((item) => {
+          const isNow = active(item, now);
+          return (
+            <button key={`${item.sign}-${item.startDate.getTime()}`} type="button" onClick={() => !selected && setSelected(item)} className={`w-full rounded-md border px-3 py-2 text-left font-mono text-xs ${isNow ? 'border-cyan-400 bg-cyan-50 text-cyan-800 dark:border-cyan-600 dark:bg-cyan-950/30 dark:text-cyan-300' : 'border-zinc-200 text-zinc-700 dark:border-zinc-700 dark:text-zinc-200'}`}>
+              <span className="inline-block w-8 font-bold">{ABBR[item.signName]}</span>
+              <span>{fmt(item.startDate)}–{fmt(item.endDate)}</span>
+              <span className="float-right text-zinc-400">{item.durationYears.toFixed(2)} y</span>
+            </button>
+          );
+        })}
+      </div>
+      <p className="text-[9px] font-mono leading-relaxed text-zinc-400 dark:text-zinc-600">Moon-pāda PVR/BPHS table method. Kālachakra is highly birth-time sensitive.</p>
+    </div>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.63',
+    date: '2026-08-10',
+    title: 'Kālachakra Daśā',
+    changes: [
+      'Added the Moon-pāda based Kālachakra rāśi-daśā using the classical savya/apasavya tables.',
+      'Shows birth balance, mahādaśā and drill-down antardaśā dates, plus Deha and Jīva signs.',
+      'Removed the duplicate Kaal Chakra/Kalachakra placeholders from settings.',
+    ],
+  },
+  {
     version: 'v1.62',
     date: '2026-08-10',
     title: 'Parāśara and Varāhamihira Aṣṭakavarga',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.62';
+export const APP_VERSION = 'v1.63';

--- a/src/lib/dashaRegistry.ts
+++ b/src/lib/dashaRegistry.ts
@@ -2,7 +2,7 @@ import { DashaSettings } from '@/types';
 
 export type DashaKey = keyof DashaSettings['dashas'];
 export type DashaStatus = 'implemented' | 'beta' | 'placeholder';
-export type DashaRendererKey = 'bcp' | 'vimshottari' | 'vds' | 'chara';
+export type DashaRendererKey = 'bcp' | 'vimshottari' | 'vds' | 'chara' | 'kalachakra';
 
 export type DashaRegistryItem = {
   key: DashaKey;
@@ -18,6 +18,7 @@ export const DASHA_REGISTRY: DashaRegistryItem[] = [
   { key: 'vds', label: 'Vimsottari Original', group: 'Core', status: 'implemented', renderer: 'vds' },
 
   { key: 'chara', label: 'Chara Dasha', group: 'Experimental', status: 'beta', renderer: 'chara' },
+  { key: 'kalaChakra', label: 'Kālachakra Daśā', group: 'Experimental', status: 'beta', renderer: 'kalachakra' },
 
   { key: 'tara', label: 'Tara Dasha', group: 'Other systems', status: 'placeholder' },
   { key: 'yogini', label: 'Yogini Dasha', group: 'Other systems', status: 'placeholder' },
@@ -32,8 +33,6 @@ export const DASHA_REGISTRY: DashaRegistryItem[] = [
   { key: 'shattrimshaSama', label: 'Shattrimsha Sama Dasha', group: 'Other systems', status: 'placeholder' },
   { key: 'charaBeta', label: 'Chara Dasha old beta', group: 'Other systems', status: 'placeholder' },
   { key: 'narayana', label: 'Narayana Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'kaalChakra', label: 'Kaal Chakra Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'kalaChakra', label: 'Kalachakra Dasha', group: 'Other systems', status: 'placeholder' },
   { key: 'sudarshanaChakra', label: 'Sudarshana Chakra Dasha', group: 'Other systems', status: 'placeholder' },
   { key: 'moola', label: 'Moola Dasha', group: 'Other systems', status: 'placeholder' },
   { key: 'naisargika', label: 'Naisargika Dasha', group: 'Other systems', status: 'placeholder' },

--- a/src/lib/dashaRenderers.tsx
+++ b/src/lib/dashaRenderers.tsx
@@ -5,6 +5,7 @@ import BcpSummary from '@/components/BcpSummary';
 import VimshottariPanel from '@/components/VimshottariPanel';
 import VdsPanel from '@/components/VdsPanel';
 import CharaCleanPanel from '@/components/CharaCleanPanel';
+import KalachakraPanel from '@/components/KalachakraPanel';
 
 export type DashaRendererContext = {
   bcp: BcpResult;
@@ -26,6 +27,9 @@ const RENDERERS: Record<DashaRendererKey, (ctx: DashaRendererContext) => ReactNo
   ),
   chara: ({ planets, ascendant, birthDatetime, charaOptions }) => (
     <CharaCleanPanel planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} settings={charaOptions} />
+  ),
+  kalachakra: ({ planets, birthDatetime }) => (
+    <KalachakraPanel planets={planets} birthDatetime={birthDatetime} />
   ),
 };
 

--- a/src/lib/kalachakra.test.ts
+++ b/src/lib/kalachakra.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { calculateKalachakra, calculateKalachakraAntardashas } from './kalachakra';
+
+const birth = new Date(2000, 0, 1);
+const ashwiniStart = calculateKalachakra(0, birth);
+assert.equal(ashwiniStart.nakshatra, 'Ashwini');
+assert.equal(ashwiniStart.pada, 1);
+assert.equal(ashwiniStart.motion, 'savya');
+assert.deepEqual(ashwiniStart.cycle, [0,1,2,3,4,5,6,7,8]);
+assert.deepEqual(ashwiniStart.entries.map((entry) => entry.durationYears), [7,16,9,21,5,9,16,7,10]);
+
+const rohiniStart = calculateKalachakra(40, birth);
+assert.equal(rohiniStart.nakshatra, 'Rohini');
+assert.equal(rohiniStart.motion, 'apasavya');
+assert.deepEqual(rohiniStart.cycle, [8,9,10,11,0,1,2,4,3]);
+
+const halfway = calculateKalachakra(5 / 3, birth); // halfway through Ashwini pada 1
+assert.equal(halfway.entries[0].signName, 'Cancer');
+assert.ok(Math.abs(halfway.entries[0].durationYears - 3) < 1e-10);
+
+const children = calculateKalachakraAntardashas(ashwiniStart.entries[0], ashwiniStart.cycle);
+assert.equal(children.length, 9);
+assert.ok(Math.abs(children.reduce((sum, item) => sum + item.durationYears, 0) - 7) < 1e-10);
+
+console.log('Kālachakra Daśā tests passed');

--- a/src/lib/kalachakra.ts
+++ b/src/lib/kalachakra.ts
@@ -1,0 +1,106 @@
+const SIGN_NAMES = ['Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo', 'Libra', 'Scorpio', 'Sagittarius', 'Capricorn', 'Aquarius', 'Pisces'] as const;
+const SIGN_YEARS = [7, 16, 9, 21, 5, 9, 16, 7, 10, 4, 4, 10] as const;
+const NAKSHATRA_NAMES = [
+  'Ashwini', 'Bharani', 'Krittika', 'Rohini', 'Mrigashira', 'Ardra',
+  'Punarvasu', 'Pushya', 'Ashlesha', 'Magha', 'Purva Phalguni', 'Uttara Phalguni',
+  'Hasta', 'Chitra', 'Swati', 'Vishakha', 'Anuradha', 'Jyeshtha',
+  'Mula', 'Purva Ashadha', 'Uttara Ashadha', 'Shravana', 'Dhanistha',
+  'Shatabhisha', 'Purva Bhadrapada', 'Uttara Bhadrapada', 'Revati',
+] as const;
+
+const STAR_GROUPS = [
+  [0, 2, 6, 8, 12, 14, 18, 20, 24],
+  [1, 7, 13, 19, 25, 26],
+  [3, 9, 15, 21],
+  [4, 5, 10, 11, 16, 17, 22, 23],
+] as const;
+
+const CYCLES: number[][][] = [
+  [[0,1,2,3,4,5,6,7,8], [9,10,11,7,6,5,3,4,2], [1,0,11,10,9,8,0,1,2], [3,4,5,6,7,8,9,10,11]],
+  [[7,6,5,3,4,2,1,0,11], [10,9,8,0,1,2,3,4,5], [6,7,8,9,10,11,7,6,5], [3,4,2,1,0,11,10,9,8]],
+  [[8,9,10,11,0,1,2,4,3], [5,6,7,11,10,9,8,7,6], [5,4,3,2,1,0,8,9,10], [11,0,1,2,4,3,5,6,7]],
+  [[11,10,9,8,7,6,5,4,3], [2,1,0,8,9,10,11,0,1], [2,4,3,5,6,7,11,10,9], [8,7,6,5,4,3,2,1,0]],
+];
+const PARAMAYUSH = [[100,85,83,86], [100,85,83,86], [86,83,85,100], [86,83,85,100]];
+const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
+
+export type KalachakraEntry = { sign: number; signName: string; startDate: Date; endDate: Date; durationYears: number };
+export type KalachakraResult = {
+  nakshatra: string;
+  pada: number;
+  motion: 'savya' | 'apasavya';
+  dehaSign: string;
+  jeevaSign: string;
+  entries: KalachakraEntry[];
+  cycle: number[];
+};
+
+function addYears(date: Date, years: number) {
+  return new Date(date.getTime() + years * YEAR_MS);
+}
+
+function groupForNakshatra(index: number): number {
+  return STAR_GROUPS.findIndex((group) => group.includes(index as never));
+}
+
+function entry(sign: number, startDate: Date, durationYears: number): KalachakraEntry {
+  return { sign: sign + 1, signName: SIGN_NAMES[sign], startDate, endDate: addYears(startDate, durationYears), durationYears };
+}
+
+export function calculateKalachakra(moonLongitude: number, birthDate: Date): KalachakraResult {
+  const longitude = ((moonLongitude % 360) + 360) % 360;
+  const nakshatraSpan = 360 / 27;
+  const padaSpan = 360 / 108;
+  const nakshatraIndex = Math.floor(longitude / nakshatraSpan);
+  const positionInNakshatra = longitude - nakshatraIndex * nakshatraSpan;
+  const padaIndex = Math.min(3, Math.floor(positionInNakshatra / padaSpan));
+  const fractionInPada = (positionInNakshatra - padaIndex * padaSpan) / padaSpan;
+  const group = groupForNakshatra(nakshatraIndex);
+  const cycle = CYCLES[group][padaIndex];
+  const paramayush = PARAMAYUSH[group][padaIndex];
+  const completedYears = fractionInPada * paramayush;
+
+  let accumulated = 0;
+  let activeIndex = 0;
+  for (let i = 0; i < cycle.length; i++) {
+    const next = accumulated + SIGN_YEARS[cycle[i]];
+    if (completedYears < next) { activeIndex = i; break; }
+    accumulated = next;
+  }
+
+  const entries: KalachakraEntry[] = [];
+  let cursor = birthDate;
+  for (let i = activeIndex; i < cycle.length; i++) {
+    const sign = cycle[i];
+    const duration = i === activeIndex ? accumulated + SIGN_YEARS[sign] - completedYears : SIGN_YEARS[sign];
+    const item = entry(sign, cursor, duration);
+    entries.push(item);
+    cursor = item.endDate;
+  }
+
+  const motion = group < 2 ? 'savya' : 'apasavya';
+  const dehaIndex = motion === 'savya' ? cycle[0] : cycle[cycle.length - 1];
+  const jeevaIndex = motion === 'savya' ? cycle[cycle.length - 1] : cycle[0];
+  return {
+    nakshatra: NAKSHATRA_NAMES[nakshatraIndex],
+    pada: padaIndex + 1,
+    motion,
+    dehaSign: SIGN_NAMES[dehaIndex],
+    jeevaSign: SIGN_NAMES[jeevaIndex],
+    entries,
+    cycle: [...cycle],
+  };
+}
+
+export function calculateKalachakraAntardashas(parent: KalachakraEntry, cycle: number[]): KalachakraEntry[] {
+  const parentIndex = cycle.indexOf(parent.sign - 1);
+  const ordered = parentIndex < 0 ? cycle : [...cycle.slice(parentIndex), ...cycle.slice(0, parentIndex)];
+  const totalWeight = ordered.reduce((sum, sign) => sum + SIGN_YEARS[sign], 0);
+  let cursor = parent.startDate;
+  return ordered.map((sign) => {
+    const duration = parent.durationYears * SIGN_YEARS[sign] / totalWeight;
+    const item = entry(sign, cursor, duration);
+    cursor = item.endDate;
+    return item;
+  });
+}


### PR DESCRIPTION
Implements the Moon-nakshatra-pada Kālachakra rāśi-daśā using the classical savya/apasavya PVR/BPHS tables. The panel shows birth balance, active mahādaśā, drill-down antardaśā dates, and Deha/Jīva signs. It also replaces the two duplicate placeholder entries with one working experimental system.

Validation: deterministic Ashwini/Rohini, birth-balance and antardaśā tests; successful production build.