### PR TITLE
Add Public Charts directory

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -23,6 +23,7 @@ import BcpSummary from '@/components/BcpSummary';
 import BcpManualOverride from '@/components/BcpManualOverride';
 import BNNEventDetectionPanel from '@/components/BNNEventDetectionPanel';
 import WorkspaceView from '@/components/workspace/WorkspaceView';
+import PublicChartsPanel from '@/components/PublicChartsPanel';
 
 function ModeSwitcher({ mode, onChange, compact }: { mode: UiMode; onChange: (m: UiMode) => void; compact?: boolean }) {
   const modes: { id: UiMode; short: string; long: string }[] = [
@@ -84,7 +85,7 @@ function computeManualBcp(completedAge: number, month: number): BcpResult {
   };
 }
 
-type DesktopTab = 'data' | 'grahas' | 'dasha' | 'bnn' | 'workspace' | 'settings';
+type DesktopTab = 'data' | 'grahas' | 'dasha' | 'bnn' | 'public' | 'workspace' | 'settings';
 
 type CalculationOptions = {
   preserveCurrentPanel?: boolean;
@@ -816,9 +817,9 @@ export default function Home() {
       </header>
 
       {/* ── DESKTOP: 2-column grid (or full-width workspace) ────────── */}
-      <div className={`hidden lg:grid gap-4 items-start p-4 ${desktopTab === 'workspace' ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]'}`}>
+      <div className={`hidden lg:grid gap-4 items-start p-4 ${desktopTab === 'workspace' || desktopTab === 'public' ? 'lg:grid-cols-1' : 'lg:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]'}`}>
         {/* Left: Chart + optional BCP summary + optional Panchang (hidden in workspace mode) */}
-        <div className={`space-y-3 ${desktopTab === 'workspace' ? 'hidden' : ''}`}>
+        <div className={`space-y-3 ${desktopTab === 'workspace' || desktopTab === 'public' ? 'hidden' : ''}`}>
           <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg p-4">
             {uiMode !== 'simple' && (
               <div className="text-xs font-mono text-zinc-400 dark:text-zinc-500 mb-3">&gt; chart.render</div>
@@ -857,7 +858,7 @@ export default function Home() {
         {/* Right: tabbed panels */}
         <div className="space-y-3">
           <div className="flex gap-1 bg-zinc-100 dark:bg-zinc-800/50 rounded-lg p-1 overflow-x-auto">
-            {(['data', 'grahas', 'dasha', 'bnn', ...(chartDisplaySettings.showWorkspace ? ['workspace'] : []), 'settings'] as DesktopTab[]).map((tab) => (
+            {(['data', 'grahas', 'dasha', 'bnn', 'public', ...(chartDisplaySettings.showWorkspace ? ['workspace'] : []), 'settings'] as DesktopTab[]).map((tab) => (
               <button
                 key={tab}
                 onClick={() => setDesktopTab(tab)}
@@ -917,6 +918,7 @@ export default function Home() {
                   />
                 : <EmptyState message="Calculate a chart to see BNN analysis" />
             )}
+            {desktopTab === 'public' && <PublicChartsPanel />}
             {desktopTab === 'workspace' && (
               chartData && bcpResult
                 ? <WorkspaceView
@@ -1042,6 +1044,10 @@ export default function Home() {
               : <EmptyState message="Calculate a chart in Data to see BNN analysis" />
             }
           </Panel>
+        )}
+
+        {activeTab === 'public' && (
+          <Panel><PublicChartsPanel /></Panel>
         )}
 
         {activeTab === 'workspace' && (

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-export type TabId = 'chart' | 'data' | 'grahas' | 'dasha' | 'bnn' | 'settings' | 'workspace';
+export type TabId = 'chart' | 'data' | 'grahas' | 'dasha' | 'bnn' | 'public' | 'settings' | 'workspace';
 
 interface Tab {
   id: TabId;
@@ -13,6 +13,7 @@ const BASE_TABS: Tab[] = [
   { id: 'grahas',   label: 'Grahas' },
   { id: 'dasha',    label: 'Dasha' },
   { id: 'bnn',      label: 'BNN' },
+  { id: 'public',   label: 'Public' },
   { id: 'settings', label: 'Settings' },
 ];
 

--- a/src/components/PublicChartsPanel.tsx
+++ b/src/components/PublicChartsPanel.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { astroDatabankSearchUrl, PUBLIC_CHART_SERVICES } from '@/lib/publicCharts';
+
+export default function PublicChartsPanel() {
+  const [query, setQuery] = useState('');
+
+  const search = (event: FormEvent) => {
+    event.preventDefault();
+    window.open(astroDatabankSearchUrl(query), '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <div className="font-mono text-xs uppercase tracking-widest text-zinc-500 dark:text-zinc-400">&gt; public charts</div>
+        <h2 className="mt-2 text-lg font-semibold text-zinc-900 dark:text-zinc-100">Public-figure charts</h2>
+        <p className="mt-1 text-xs leading-relaxed text-zinc-500 dark:text-zinc-400">Search documented birth records and open the ready-made chart at its source.</p>
+      </div>
+
+      <form onSubmit={search} className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 dark:border-zinc-700 dark:bg-zinc-800/60">
+        <label htmlFor="public-chart-search" className="block text-[10px] font-mono uppercase tracking-widest text-zinc-500 dark:text-zinc-400">Search Astro-Databank by name</label>
+        <div className="mt-2 flex gap-2">
+          <input id="public-chart-search" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="e.g. Albert Einstein" className="min-w-0 flex-1 rounded-md border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-900 outline-none focus:border-emerald-500 dark:border-zinc-600 dark:bg-zinc-900 dark:text-zinc-100" />
+          <button type="submit" className="rounded-md bg-emerald-700 px-4 py-2 text-xs font-semibold text-white hover:bg-emerald-800 dark:bg-emerald-600 dark:hover:bg-emerald-500">Open</button>
+        </div>
+      </form>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        {PUBLIC_CHART_SERVICES.map((service) => (
+          <a key={service.name} href={service.url} target="_blank" rel="noopener noreferrer" className="group rounded-lg border border-zinc-200 p-4 transition-colors hover:border-emerald-400 hover:bg-emerald-50/50 dark:border-zinc-700 dark:hover:border-emerald-700 dark:hover:bg-emerald-950/20">
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-mono text-sm font-semibold text-zinc-800 group-hover:text-emerald-700 dark:text-zinc-100 dark:group-hover:text-emerald-400">{service.name}</span>
+              {'recommended' in service && service.recommended && <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[9px] font-mono text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">recommended</span>}
+            </div>
+            <p className="mt-2 text-xs leading-relaxed text-zinc-500 dark:text-zinc-400">{service.description}</p>
+            <div className="mt-3 text-[10px] font-mono text-emerald-700 dark:text-emerald-400">Open database ↗</div>
+          </a>
+        ))}
+      </div>
+
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-[11px] leading-relaxed text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-200">
+        Prefer Astro-Databank entries rated AA or A. A chart can look exact even when its recorded birth time is speculative; check the source notes and Rodden rating before interpreting houses, Lagna or daśās.
+      </div>
+    </div>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.65',
+    date: '2026-08-10',
+    title: 'Public Charts directory',
+    changes: [
+      'Added a dedicated Public tab for opening ready-made public-figure charts.',
+      'Added direct Astro-Databank name search plus Astro-Seek and Astrotheme directories.',
+      'Added source-quality guidance for Rodden ratings and uncertain birth times.',
+    ],
+  },
+  {
     version: 'v1.64',
     date: '2026-08-10',
     title: 'Chara Daśā timeline',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.64';
+export const APP_VERSION = 'v1.65';

--- a/src/lib/publicCharts.test.ts
+++ b/src/lib/publicCharts.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import { astroDatabankSearchUrl } from './publicCharts';
+
+assert.equal(astroDatabankSearchUrl(''), 'https://www.astro.com/astro-databank/Main_Page');
+const url = new URL(astroDatabankSearchUrl('Albert Einstein'));
+assert.equal(url.hostname, 'www.astro.com');
+assert.equal(url.searchParams.get('search'), 'Albert Einstein');
+assert.equal(url.searchParams.get('title'), 'Special:Search');
+
+console.log('Public Charts tests passed');

--- a/src/lib/publicCharts.ts
+++ b/src/lib/publicCharts.ts
@@ -1,0 +1,25 @@
+export function astroDatabankSearchUrl(query: string): string {
+  const search = query.trim();
+  if (!search) return 'https://www.astro.com/astro-databank/Main_Page';
+  const params = new URLSearchParams({ search, title: 'Special:Search', go: 'Go' });
+  return `https://www.astro.com/astro-databank/index.php?${params.toString()}`;
+}
+
+export const PUBLIC_CHART_SERVICES = [
+  {
+    name: 'Astro-Databank',
+    description: 'Documented public-figure birth data with source notes and Rodden ratings.',
+    url: 'https://www.astro.com/astro-databank/Main_Page',
+    recommended: true,
+  },
+  {
+    name: 'Astro-Seek',
+    description: 'Large searchable directory of ready-made celebrity charts.',
+    url: 'https://famouspeople.astro-seek.com/',
+  },
+  {
+    name: 'Astrotheme',
+    description: 'Public-figure chart directory with filters for profession, country and birth time.',
+    url: 'https://www.astrotheme.com/celestar/horoscope_celebrity_search_by_filters.php',
+  },
+] as const;


### PR DESCRIPTION
## Summary
- add a dedicated Public tab for ready-made public-figure charts
- add direct Astro-Databank name search
- link Astro-Databank, Astro-Seek and Astrotheme directories
- show source-quality and Rodden-rating guidance
- bump the app version to 1.65

## Verification
- `node --import tsx src/lib/publicCharts.test.ts`
- `npm run build`
- `git diff --check`