### PR TITLE
Fix Kalachakra birth balance

### DIFF
--- a/src/components/KalachakraPanel.tsx
+++ b/src/components/KalachakraPanel.tsx
@@ -54,7 +54,7 @@ export default function KalachakraPanel({ planets, birthDatetime }: { planets: P
           );
         })}
       </div>
-      <p className="text-[9px] font-mono leading-relaxed text-zinc-400 dark:text-zinc-600">Moon-pāda PVR/BPHS table method. Kālachakra is highly birth-time sensitive.</p>
+      <p className="text-[9px] font-mono leading-relaxed text-zinc-400 dark:text-zinc-600">Moon-pāda PVR/BPHS table method. Birth balance is the unelapsed portion of the first rāśi period.</p>
     </div>
   );
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.66',
+    date: '2026-08-10',
+    title: 'Kālachakra birth-balance fix',
+    changes: [
+      'Fixed Kālachakra birth balance so the elapsed Moon-pāda fraction applies only to the first rāśi period, not the whole life cycle.',
+      'Current mahādaśā periods now remain available for Moon positions near the end of a pada.',
+      'Corrected first-period antardaśā balance and repeated-sign cycle selection.',
+    ],
+  },
+  {
     version: 'v1.65',
     date: '2026-08-10',
     title: 'Public Charts directory',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.65';
+export const APP_VERSION = 'v1.66';

--- a/src/lib/kalachakra.test.ts
+++ b/src/lib/kalachakra.test.ts
@@ -15,11 +15,23 @@ assert.equal(rohiniStart.motion, 'apasavya');
 assert.deepEqual(rohiniStart.cycle, [8,9,10,11,0,1,2,4,3]);
 
 const halfway = calculateKalachakra(5 / 3, birth); // halfway through Ashwini pada 1
-assert.equal(halfway.entries[0].signName, 'Cancer');
-assert.ok(Math.abs(halfway.entries[0].durationYears - 3) < 1e-10);
+assert.equal(halfway.entries[0].signName, 'Aries');
+assert.ok(Math.abs(halfway.entries[0].durationYears - 3.5) < 1e-10);
+assert.equal(halfway.entries.length, 9);
+assert.ok(Math.abs(halfway.entries.reduce((sum, item) => sum + item.durationYears, 0) - 96.5) < 1e-10);
 
 const children = calculateKalachakraAntardashas(ashwiniStart.entries[0], ashwiniStart.cycle);
 assert.equal(children.length, 9);
 assert.ok(Math.abs(children.reduce((sum, item) => sum + item.durationYears, 0) - 7) < 1e-10);
+
+const halfwayChildren = calculateKalachakraAntardashas(halfway.entries[0], halfway.cycle);
+assert.ok(halfwayChildren[0].startDate.getTime() === birth.getTime());
+assert.ok(Math.abs(halfwayChildren.reduce((sum, item) => sum + item.durationYears, 0) - 3.5) < 1e-10);
+
+const lateMrigashira = calculateKalachakra(66 + 1 / 3 - 0.01, birth);
+assert.equal(lateMrigashira.nakshatra, 'Mrigashira');
+assert.equal(lateMrigashira.pada, 4);
+assert.equal(lateMrigashira.entries.length, 9);
+assert.ok(lateMrigashira.entries.at(-1)!.endDate.getFullYear() > 2080);
 
 console.log('Kālachakra Daśā tests passed');

--- a/src/lib/kalachakra.ts
+++ b/src/lib/kalachakra.ts
@@ -21,10 +21,18 @@ const CYCLES: number[][][] = [
   [[8,9,10,11,0,1,2,4,3], [5,6,7,11,10,9,8,7,6], [5,4,3,2,1,0,8,9,10], [11,0,1,2,4,3,5,6,7]],
   [[11,10,9,8,7,6,5,4,3], [2,1,0,8,9,10,11,0,1], [2,4,3,5,6,7,11,10,9], [8,7,6,5,4,3,2,1,0]],
 ];
-const PARAMAYUSH = [[100,85,83,86], [100,85,83,86], [86,83,85,100], [86,83,85,100]];
 const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
 
-export type KalachakraEntry = { sign: number; signName: string; startDate: Date; endDate: Date; durationYears: number };
+export type KalachakraEntry = {
+  sign: number;
+  signName: string;
+  startDate: Date;
+  endDate: Date;
+  durationYears: number;
+  cycleIndex: number;
+  fullDurationYears: number;
+  elapsedYears: number;
+};
 export type KalachakraResult = {
   nakshatra: string;
   pada: number;
@@ -43,8 +51,24 @@ function groupForNakshatra(index: number): number {
   return STAR_GROUPS.findIndex((group) => group.includes(index as never));
 }
 
-function entry(sign: number, startDate: Date, durationYears: number): KalachakraEntry {
-  return { sign: sign + 1, signName: SIGN_NAMES[sign], startDate, endDate: addYears(startDate, durationYears), durationYears };
+function entry(
+  sign: number,
+  startDate: Date,
+  durationYears: number,
+  cycleIndex: number,
+  fullDurationYears = durationYears,
+  elapsedYears = 0,
+): KalachakraEntry {
+  return {
+    sign: sign + 1,
+    signName: SIGN_NAMES[sign],
+    startDate,
+    endDate: addYears(startDate, durationYears),
+    durationYears,
+    cycleIndex,
+    fullDurationYears,
+    elapsedYears,
+  };
 }
 
 export function calculateKalachakra(moonLongitude: number, birthDate: Date): KalachakraResult {
@@ -57,23 +81,17 @@ export function calculateKalachakra(moonLongitude: number, birthDate: Date): Kal
   const fractionInPada = (positionInNakshatra - padaIndex * padaSpan) / padaSpan;
   const group = groupForNakshatra(nakshatraIndex);
   const cycle = CYCLES[group][padaIndex];
-  const paramayush = PARAMAYUSH[group][padaIndex];
-  const completedYears = fractionInPada * paramayush;
-
-  let accumulated = 0;
-  let activeIndex = 0;
-  for (let i = 0; i < cycle.length; i++) {
-    const next = accumulated + SIGN_YEARS[cycle[i]];
-    if (completedYears < next) { activeIndex = i; break; }
-    accumulated = next;
-  }
+  const firstSignYears = SIGN_YEARS[cycle[0]];
+  const elapsedFirstSignYears = fractionInPada * firstSignYears;
 
   const entries: KalachakraEntry[] = [];
   let cursor = birthDate;
-  for (let i = activeIndex; i < cycle.length; i++) {
+  for (let i = 0; i < cycle.length; i++) {
     const sign = cycle[i];
-    const duration = i === activeIndex ? accumulated + SIGN_YEARS[sign] - completedYears : SIGN_YEARS[sign];
-    const item = entry(sign, cursor, duration);
+    const fullDuration = SIGN_YEARS[sign];
+    const elapsed = i === 0 ? elapsedFirstSignYears : 0;
+    const duration = fullDuration - elapsed;
+    const item = entry(sign, cursor, duration, i, fullDuration, elapsed);
     entries.push(item);
     cursor = item.endDate;
   }
@@ -93,14 +111,22 @@ export function calculateKalachakra(moonLongitude: number, birthDate: Date): Kal
 }
 
 export function calculateKalachakraAntardashas(parent: KalachakraEntry, cycle: number[]): KalachakraEntry[] {
-  const parentIndex = cycle.indexOf(parent.sign - 1);
+  const parentIndex = parent.cycleIndex >= 0 ? parent.cycleIndex : cycle.indexOf(parent.sign - 1);
   const ordered = parentIndex < 0 ? cycle : [...cycle.slice(parentIndex), ...cycle.slice(0, parentIndex)];
   const totalWeight = ordered.reduce((sum, sign) => sum + SIGN_YEARS[sign], 0);
-  let cursor = parent.startDate;
-  return ordered.map((sign) => {
-    const duration = parent.durationYears * SIGN_YEARS[sign] / totalWeight;
-    const item = entry(sign, cursor, duration);
+  let cursor = addYears(parent.startDate, -parent.elapsedYears);
+  const fullEntries = ordered.map((sign, index) => {
+    const duration = parent.fullDurationYears * SIGN_YEARS[sign] / totalWeight;
+    const item = entry(sign, cursor, duration, index);
     cursor = item.endDate;
     return item;
   });
+
+  return fullEntries
+    .filter((item) => item.endDate > parent.startDate)
+    .map((item) => {
+      if (item.startDate >= parent.startDate) return item;
+      const durationYears = (item.endDate.getTime() - parent.startDate.getTime()) / YEAR_MS;
+      return entry(item.sign - 1, parent.startDate, durationYears, item.cycleIndex, item.fullDurationYears, item.fullDurationYears - durationYears);
+    });
 }


### PR DESCRIPTION
## Root cause
The elapsed Moon-pāda fraction was applied to the entire 83–100 year Kālachakra cycle. Near the end of a pada this incorrectly consumed almost every mahādaśā before birth, leaving no current period.

## Changes
- apply the birth balance only to the first rāśi mahādaśā
- preserve all later mahādaśās in the cycle
- calculate the first mahādaśā's antardaśā balance from its theoretical start
- identify repeated signs by cycle position instead of the first sign match
- bump the app to v1.66

## Verification
- `node --import tsx src/lib/kalachakra.test.ts`
- `npm run build`
- `git diff --check`