### PR TITLE
Add planetary Avasthas

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -880,7 +880,7 @@ export default function Home() {
             {desktopTab === 'grahas' && (
               <>
                 {chartData
-                  ? <GrahasPanel chart={chartData} karakaByPlanet={karakaByPlanet} chartDisplaySettings={chartDisplaySettings} nakshatraAdjust={nakshatraAdjust} />
+                  ? <GrahasPanel chart={chartData} karakaByPlanet={karakaByPlanet} chartDisplaySettings={chartDisplaySettings} nakshatraAdjust={nakshatraAdjust} birthDatetime={birthDatetime} />
                   : <EmptyState message="Calculate a chart to see graha positions" />
                 }
                 {uiMode !== 'simple' && chartData?.debug && (
@@ -999,7 +999,7 @@ export default function Home() {
         {activeTab === 'grahas' && (
           <Panel>
             {chartData
-              ? <GrahasPanel chart={chartData} karakaByPlanet={karakaByPlanet} chartDisplaySettings={chartDisplaySettings} nakshatraAdjust={nakshatraAdjust} />
+              ? <GrahasPanel chart={chartData} karakaByPlanet={karakaByPlanet} chartDisplaySettings={chartDisplaySettings} nakshatraAdjust={nakshatraAdjust} birthDatetime={birthDatetime} />
               : <EmptyState message="Calculate a chart in Data to see graha positions" />
             }
             {uiMode !== 'simple' && chartData?.debug && (

--- a/src/components/AvasthaPanel.tsx
+++ b/src/components/AvasthaPanel.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { ChartData } from '@/types';
+import { calculateAvasthas } from '@/lib/avasthas';
+
+const ABBR: Record<string, string> = { Sun: 'Su', Moon: 'Mo', Mars: 'Ma', Mercury: 'Me', Jupiter: 'Ju', Venus: 'Ve', Saturn: 'Sa', Rahu: 'Ra', Ketu: 'Ke' };
+
+export default function AvasthaPanel({ chart, birthDatetime }: { chart: ChartData; birthDatetime: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const rows = useMemo(() => calculateAvasthas(chart, birthDatetime), [chart, birthDatetime]);
+
+  return (
+    <div className="border-t border-zinc-100 pt-3 dark:border-zinc-800">
+      <button type="button" onClick={() => setExpanded((value) => !value)} className="flex w-full items-center justify-between text-left">
+        <span className="text-xs font-mono text-zinc-500 dark:text-zinc-500">&gt; planetary.avasthas</span>
+        <span className="text-[10px] font-mono text-zinc-400">{expanded ? 'collapse' : 'expand'}</span>
+      </button>
+      {expanded && (
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full min-w-[760px] border-collapse text-[10px] font-mono">
+            <thead><tr className="border-b border-zinc-200 text-left text-zinc-400 dark:border-zinc-700">
+              <th className="p-2">Graha</th><th className="p-2">Bālādi</th><th className="p-2">Dīptādi</th><th className="p-2">Jāgratādi</th><th className="p-2">Lajjitādi</th><th className="p-2">Śayanādi</th>
+            </tr></thead>
+            <tbody>{rows.map((row) => (
+              <tr key={row.planet} className="border-b border-zinc-100 align-top text-zinc-700 dark:border-zinc-800 dark:text-zinc-300">
+                <td className="p-2 font-bold">{ABBR[row.planet]}</td>
+                <td className="p-2" title={row.reasons.baladi}>{row.baladi}</td>
+                <td className="p-2" title={row.reasons.deeptadi}>{row.deeptadi}</td>
+                <td className="p-2" title={row.reasons.jagratadi}>{row.jagratadi}</td>
+                <td className="p-2" title={row.reasons.lajjitadi}>{row.lajjitadi.join(', ') || '—'}</td>
+                <td className="p-2" title={row.reasons.sayanadi}>{row.sayanadi}</td>
+              </tr>
+            ))}</tbody>
+          </table>
+          <p className="mt-2 text-[9px] leading-relaxed text-zinc-400">Hover a value to see its calculation basis. Śayanādi shows the primary 12-fold state; sub-states are not included.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/GrahasPanel.tsx
+++ b/src/components/GrahasPanel.tsx
@@ -2,12 +2,14 @@ import { ChartData, ChartDisplaySettings, DEFAULT_CHART_DISPLAY } from '@/types'
 import JyotishGrahaTable from './JyotishGrahaTable';
 import DrishtiPanel from './DrishtiPanel';
 import YogaTable from './YogaTable';
+import AvasthaPanel from './AvasthaPanel';
 
 interface Props {
   chart: ChartData;
   karakaByPlanet: Record<string, string>;
   chartDisplaySettings?: ChartDisplaySettings;
   nakshatraAdjust?: number;
+  birthDatetime?: string;
 }
 
 function readChartDisplaySettings(fallback?: ChartDisplaySettings): ChartDisplaySettings {
@@ -21,7 +23,7 @@ function readChartDisplaySettings(fallback?: ChartDisplaySettings): ChartDisplay
   }
 }
 
-export default function GrahasPanel({ chart, karakaByPlanet, chartDisplaySettings, nakshatraAdjust = 0 }: Props) {
+export default function GrahasPanel({ chart, karakaByPlanet, chartDisplaySettings, nakshatraAdjust = 0, birthDatetime = '' }: Props) {
   const settings = readChartDisplaySettings(chartDisplaySettings);
 
   return (
@@ -46,6 +48,7 @@ export default function GrahasPanel({ chart, karakaByPlanet, chartDisplaySetting
           showRashiDrishti={settings.showRashiDrishti}
         />
       )}
+      <AvasthaPanel chart={chart} birthDatetime={birthDatetime} />
       <div className="border-t border-zinc-100 dark:border-zinc-800 pt-3">
         <YogaTable chart={chart} />
       </div>

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -336,6 +336,7 @@ export default function WorkspaceView({
             karakaByPlanet={karakaByPlanet}
             chartDisplaySettings={chartDisplaySettings}
             nakshatraAdjust={nakshatraAdjust}
+            birthDatetime={birthDatetime}
           />
         );
 

--- a/src/lib/avasthas.test.ts
+++ b/src/lib/avasthas.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import type { ChartData, PlanetData } from '@/types';
+import { calculateAvasthas, calculateBaladi, calculateJagratadi } from './avasthas';
+
+function planet(sign: number, degree: number): PlanetData {
+  return { name: 'Mars', sign, degree, longitude: (sign - 1) * 30 + degree, house: 1 };
+}
+
+assert.equal(calculateBaladi(planet(1, 2)).value, 'Bāla');
+assert.equal(calculateBaladi(planet(2, 2)).value, 'Mṛta');
+assert.equal(calculateBaladi(planet(1, 28)).value, 'Mṛta');
+assert.equal(calculateBaladi(planet(2, 28)).value, 'Bāla');
+assert.equal(calculateJagratadi(planet(1, 5)).value, 'Jāgrat');
+assert.equal(calculateJagratadi(planet(2, 5)).value, 'Suṣupta');
+
+const planets: PlanetData[] = [
+  { name: 'Sun', sign: 1, degree: 10, longitude: 10, house: 1 },
+  { name: 'Moon', sign: 2, degree: 10, longitude: 40, house: 2 },
+  { name: 'Mars', sign: 10, degree: 10, longitude: 280, house: 10 },
+  { name: 'Mercury', sign: 1, degree: 12, longitude: 12, house: 1 },
+  { name: 'Jupiter', sign: 9, degree: 10, longitude: 250, house: 9 },
+  { name: 'Venus', sign: 12, degree: 10, longitude: 340, house: 12 },
+  { name: 'Saturn', sign: 1, degree: 20, longitude: 20, house: 1 },
+  { name: 'Rahu', sign: 5, degree: 5, longitude: 125, house: 5 },
+  { name: 'Ketu', sign: 11, degree: 5, longitude: 305, house: 11 },
+];
+const chart: ChartData = {
+  ascendant: { sign: 1, degree: 0, longitude: 0 }, planets,
+  debug: { julianDay: 2451545, ayanamsa: 24, utcOffset: 2, ascendantDegree: 0, ascendantSign: 1, ephemerisEngine: 'test', inputDateTime: '2000-01-01T12:00', latitude: 60, longitude: 25 },
+};
+const results = calculateAvasthas(chart, '2000-01-01T12:00');
+assert.equal(results.find((row) => row.planet === 'Sun')?.deeptadi, 'Dīpta');
+assert.equal(results.find((row) => row.planet === 'Mars')?.deeptadi, 'Dīpta');
+assert.equal(results.find((row) => row.planet === 'Mercury')?.deeptadi, 'Vikala');
+assert.notEqual(results.find((row) => row.planet === 'Jupiter')?.sayanadi, '—');
+
+console.log('Planetary Avastha tests passed');

--- a/src/lib/avasthas.ts
+++ b/src/lib/avasthas.ts
@@ -1,0 +1,159 @@
+import type { ChartData, PlanetData } from '@/types';
+import { calculateGrahaDrishti } from './drishti';
+import { calcSolarTimes } from './panchang/solar';
+
+const CLASSICAL = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn'] as const;
+const PLANET_NUMBER: Record<string, number> = { Sun: 1, Moon: 2, Mars: 3, Mercury: 4, Jupiter: 5, Venus: 6, Saturn: 7, Rahu: 8, Ketu: 9 };
+const EXALTATION: Record<string, number> = { Sun: 1, Moon: 2, Mars: 10, Mercury: 6, Jupiter: 4, Venus: 12, Saturn: 7 };
+const DEBILITATION: Record<string, number> = { Sun: 7, Moon: 8, Mars: 4, Mercury: 12, Jupiter: 10, Venus: 6, Saturn: 1 };
+const OWN_SIGNS: Record<string, number[]> = { Sun: [5], Moon: [4], Mars: [1, 8], Mercury: [3, 6], Jupiter: [9, 12], Venus: [2, 7], Saturn: [10, 11] };
+const MOOLATRIKONA: Record<string, number> = { Sun: 5, Moon: 2, Mars: 1, Mercury: 6, Jupiter: 9, Venus: 7, Saturn: 11 };
+const SIGN_LORD = ['', 'Mars', 'Venus', 'Mercury', 'Moon', 'Sun', 'Mercury', 'Venus', 'Mars', 'Jupiter', 'Saturn', 'Saturn', 'Jupiter'];
+const FRIENDS: Record<string, string[]> = {
+  Sun: ['Moon', 'Mars', 'Jupiter'], Moon: ['Sun', 'Mercury'], Mars: ['Sun', 'Moon', 'Jupiter'],
+  Mercury: ['Sun', 'Venus'], Jupiter: ['Sun', 'Moon', 'Mars'], Venus: ['Mercury', 'Saturn'], Saturn: ['Mercury', 'Venus'],
+};
+const ENEMIES: Record<string, string[]> = {
+  Sun: ['Venus', 'Saturn'], Moon: [], Mars: ['Mercury'], Mercury: ['Moon'],
+  Jupiter: ['Mercury', 'Venus'], Venus: ['Sun', 'Moon'], Saturn: ['Sun', 'Moon', 'Mars'],
+};
+const COMBUST_ORB: Record<string, number> = { Moon: 12, Mars: 17, Mercury: 14, Jupiter: 11, Venus: 10, Saturn: 15 };
+const SAYANADI = ['Śayana', 'Upaveśana', 'Netrāṇi', 'Prakāśa', 'Gamana', 'Āgamana', 'Sabhā', 'Āgama', 'Bhojana', 'Nṛtyalipsā', 'Kautuka', 'Nidrā'];
+
+export type AvasthaResult = {
+  planet: string;
+  baladi: string;
+  jagratadi: string;
+  deeptadi: string;
+  lajjitadi: string[];
+  sayanadi: string;
+  reasons: { baladi: string; jagratadi: string; deeptadi: string; lajjitadi: string; sayanadi: string };
+};
+
+function angularDistance(a: number, b: number): number {
+  const d = Math.abs(a - b) % 360;
+  return Math.min(d, 360 - d);
+}
+
+function relationship(planet: string, sign: number): 'friend' | 'enemy' | 'neutral' {
+  const lord = SIGN_LORD[sign];
+  if (FRIENDS[planet]?.includes(lord)) return 'friend';
+  if (ENEMIES[planet]?.includes(lord)) return 'enemy';
+  return 'neutral';
+}
+
+export function calculateBaladi(planet: PlanetData): { value: string; reason: string } {
+  const odd = planet.sign % 2 === 1;
+  const segment = Math.min(4, Math.floor(planet.degree / 6));
+  const names = ['Bāla', 'Kumāra', 'Yuva', 'Vṛddha', 'Mṛta'];
+  const index = odd ? segment : 4 - segment;
+  return { value: names[index], reason: `${odd ? 'odd' : 'even'} sign · ${planet.degree.toFixed(2)}°` };
+}
+
+export function calculateJagratadi(planet: PlanetData): { value: string; reason: string } {
+  const odd = planet.sign % 2 === 1;
+  const third = Math.min(2, Math.floor(planet.degree / 10));
+  const names = ['Jāgrat', 'Svapna', 'Suṣupta'];
+  const index = odd ? third : 2 - third;
+  return { value: names[index], reason: `${odd ? 'odd' : 'even'} sign · ${planet.degree.toFixed(2)}°` };
+}
+
+function calculateDeeptadi(planet: PlanetData, sun: PlanetData | undefined): { value: string; reason: string } {
+  if (!CLASSICAL.includes(planet.name as typeof CLASSICAL[number])) return { value: '—', reason: 'Classical dignity state is shown for Sun–Saturn.' };
+  if (planet.name !== 'Sun' && sun && angularDistance(planet.longitude, sun.longitude) <= (COMBUST_ORB[planet.name] ?? 0)) {
+    return { value: 'Vikala', reason: `combust · ${angularDistance(planet.longitude, sun.longitude).toFixed(2)}° from Sun` };
+  }
+  if (planet.sign === EXALTATION[planet.name]) return { value: 'Dīpta', reason: 'exaltation sign' };
+  if (planet.sign === DEBILITATION[planet.name]) return { value: 'Duḥkhita', reason: 'debilitation sign' };
+  if (OWN_SIGNS[planet.name]?.includes(planet.sign)) return { value: 'Svastha', reason: 'own sign' };
+  const relation = relationship(planet.name, planet.sign);
+  if (relation === 'friend') return { value: 'Mudita', reason: `friend's sign (${SIGN_LORD[planet.sign]})` };
+  if (relation === 'enemy') return { value: 'Dīna', reason: `enemy's sign (${SIGN_LORD[planet.sign]})` };
+  return { value: 'Śānta', reason: `neutral sign (${SIGN_LORD[planet.sign]})` };
+}
+
+function calculateLajjitadi(planet: PlanetData, planets: PlanetData[]): { values: string[]; reason: string } {
+  if (!CLASSICAL.includes(planet.name as typeof CLASSICAL[number])) return { values: [], reason: 'Classical states are evaluated for Sun–Saturn; nodes act as afflictors.' };
+  const conjunct = planets.filter((p) => p.name !== planet.name && p.sign === planet.sign).map((p) => p.name);
+  const aspecting = calculateGrahaDrishti(planets)
+    .filter((a) => a.aspectedPlanets.includes(planet.name))
+    .map((a) => a.planet);
+  const values: string[] = [];
+  const why: string[] = [];
+  const malefics = ['Sun', 'Mars', 'Saturn', 'Rahu', 'Ketu'];
+  const enemies = ENEMIES[planet.name] ?? [];
+  const benefics = ['Moon', 'Mercury', 'Jupiter', 'Venus'];
+
+  if (planet.house === 5 && conjunct.some((name) => malefics.includes(name))) { values.push('Lajjita'); why.push('5th house with a malefic/node'); }
+  if (planet.sign === EXALTATION[planet.name] || planet.sign === MOOLATRIKONA[planet.name]) { values.push('Garvita'); why.push('exaltation/mūlatrikoṇa'); }
+  if (relationship(planet.name, planet.sign) === 'enemy' || conjunct.some((name) => enemies.includes(name)) || aspecting.includes('Saturn')) { values.push('Kṣudhita'); why.push('enemy sign/conjunction or Saturn aspect'); }
+  if ([4, 8, 12].includes(planet.sign) && aspecting.some((name) => enemies.includes(name)) && !aspecting.some((name) => benefics.includes(name))) { values.push('Tṛṣita'); why.push('water sign with enemy aspect and no benefic aspect'); }
+  if (relationship(planet.name, planet.sign) === 'friend' || conjunct.includes('Jupiter') || aspecting.some((name) => FRIENDS[planet.name]?.includes(name))) { values.push('Mudita'); why.push('friend sign/contact or Jupiter conjunction'); }
+  if (conjunct.includes('Sun') && (aspecting.some((name) => malefics.includes(name)) || conjunct.some((name) => enemies.includes(name)))) { values.push('Kṣobhita'); why.push('Sun conjunction plus malefic/enemy affliction'); }
+  return { values, reason: why.join('; ') || 'no Lajjitādi condition triggered' };
+}
+
+function parseBirth(value: string) {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?/);
+  if (!match) return null;
+  return { year: +match[1], month: +match[2], day: +match[3], hours: +match[4] + +match[5] / 60 + +(match[6] ?? 0) / 3600 };
+}
+
+function previousDate(year: number, month: number, day: number) {
+  const date = new Date(Date.UTC(year, month - 1, day - 1));
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1, day: date.getUTCDate() };
+}
+
+function ghatiAtBirth(chart: ChartData, birthDatetime: string): number | null {
+  const birth = parseBirth(birthDatetime);
+  const debug = chart.debug;
+  if (!birth || !debug) return null;
+  const offset = debug.utcOffset;
+  let sunrise = calcSolarTimes(birth.year, birth.month, birth.day, debug.latitude, debug.longitude).sunrise;
+  if (sunrise === null) return null;
+  sunrise = ((sunrise + offset) % 24 + 24) % 24;
+  let elapsed = birth.hours - sunrise;
+  if (elapsed < 0) {
+    const prev = previousDate(birth.year, birth.month, birth.day);
+    const prevSunriseUtc = calcSolarTimes(prev.year, prev.month, prev.day, debug.latitude, debug.longitude).sunrise;
+    if (prevSunriseUtc === null) return null;
+    const prevSunrise = ((prevSunriseUtc + offset) % 24 + 24) % 24;
+    elapsed = birth.hours + 24 - prevSunrise;
+  }
+  return Math.max(1, Math.min(60, Math.floor(elapsed * 2.5) + 1));
+}
+
+function calculateSayanadi(planet: PlanetData, chart: ChartData, birthDatetime: string): { value: string; reason: string } {
+  const planetNumber = PLANET_NUMBER[planet.name];
+  const moon = chart.planets.find((p) => p.name === 'Moon');
+  const ghati = ghatiAtBirth(chart, birthDatetime);
+  if (!planetNumber || !moon || ghati === null) return { value: '—', reason: 'Birth time, coordinates and sunrise are required.' };
+  const planetNakshatra = Math.floor(planet.longitude / (360 / 27)) + 1;
+  const birthNakshatra = Math.floor(moon.longitude / (360 / 27)) + 1;
+  const navamsa = Math.min(9, Math.floor(planet.degree / (30 / 9)) + 1);
+  const total = planetNakshatra * planetNumber * navamsa + birthNakshatra + ghati + chart.ascendant.sign;
+  const index = ((total - 1) % 12 + 12) % 12;
+  return { value: SAYANADI[index], reason: `(${planetNakshatra}×${planetNumber}×${navamsa} + ${birthNakshatra} + ghati ${ghati} + lagna ${chart.ascendant.sign}) mod 12` };
+}
+
+export function calculateAvasthas(chart: ChartData, birthDatetime: string): AvasthaResult[] {
+  const sun = chart.planets.find((p) => p.name === 'Sun');
+  return chart.planets
+    .filter((planet) => PLANET_NUMBER[planet.name])
+    .map((planet) => {
+      const baladi = calculateBaladi(planet);
+      const jagratadi = calculateJagratadi(planet);
+      const deeptadi = calculateDeeptadi(planet, sun);
+      const lajjitadi = calculateLajjitadi(planet, chart.planets);
+      const sayanadi = calculateSayanadi(planet, chart, birthDatetime);
+      return {
+        planet: planet.name,
+        baladi: baladi.value,
+        jagratadi: jagratadi.value,
+        deeptadi: deeptadi.value,
+        lajjitadi: lajjitadi.values,
+        sayanadi: sayanadi.value,
+        reasons: { baladi: baladi.reason, jagratadi: jagratadi.reason, deeptadi: deeptadi.reason, lajjitadi: lajjitadi.reason, sayanadi: sayanadi.reason },
+      };
+    });
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.67',
+    date: '2026-08-10',
+    title: 'Planetary Avasthas',
+    changes: [
+      'Added a separate expandable Planetary Avasthas table under Grahas.',
+      'Added Bālādi, Dīptādi, Jāgratādi, Lajjitādi and primary Śayanādi states with calculation details.',
+      'Śayanādi uses the birth nakshatra, planetary nakshatra/navāṁśa, sunrise ghati and Lagna.',
+    ],
+  },
+  {
     version: 'v1.66',
     date: '2026-08-10',
     title: 'Kālachakra birth-balance fix',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.66';
+export const APP_VERSION = 'v1.67';


### PR DESCRIPTION
## Summary
- add an expandable Planetary Avasthas table under Grahas
- calculate Bālādi and Jāgratādi from sign parity and intra-sign degree
- calculate Dīptādi from combustion and classical sign dignity
- calculate applicable Lajjitādi states from house, dignity, conjunction and graha-dṛṣṭi conditions
- calculate the primary 12-fold Śayanādi state from planetary nakshatra/navāṁśa, birth nakshatra, sunrise ghati and Lagna
- show calculation reasons as cell tooltips
- bump the app to v1.67

## Scope
Śayanādi ceṣṭā/dṛṣṭi sub-states are intentionally excluded; the panel shows the requested primary Avastha only.

## Verification
- `node --import tsx src/lib/avasthas.test.ts`
- `npm run build`
- `git diff --check`