### PR TITLE
Add Saham calculations

### DIFF
--- a/src/components/GrahasPanel.tsx
+++ b/src/components/GrahasPanel.tsx
@@ -3,6 +3,7 @@ import JyotishGrahaTable from './JyotishGrahaTable';
 import DrishtiPanel from './DrishtiPanel';
 import YogaTable from './YogaTable';
 import AvasthaPanel from './AvasthaPanel';
+import SahamPanel from './SahamPanel';
 
 interface Props {
   chart: ChartData;
@@ -49,6 +50,7 @@ export default function GrahasPanel({ chart, karakaByPlanet, chartDisplaySetting
         />
       )}
       <AvasthaPanel chart={chart} birthDatetime={birthDatetime} />
+      <SahamPanel chart={chart} birthDatetime={birthDatetime} />
       <div className="border-t border-zinc-100 dark:border-zinc-800 pt-3">
         <YogaTable chart={chart} />
       </div>

--- a/src/components/SahamPanel.tsx
+++ b/src/components/SahamPanel.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { ChartData } from '@/types';
+import { calculateSahams } from '@/lib/sahams';
+
+const SIGN_ABBR = ['', 'Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
+
+function position(degree: number, sign: number) {
+  const d = Math.floor(degree);
+  const minutesFloat = (degree - d) * 60;
+  const m = Math.floor(minutesFloat);
+  const s = Math.round((minutesFloat - m) * 60);
+  return `${SIGN_ABBR[sign]} ${d}°${String(m).padStart(2, '0')}′${String(s).padStart(2, '0')}″`;
+}
+
+export default function SahamPanel({ chart, birthDatetime }: { chart: ChartData; birthDatetime: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const result = useMemo(() => calculateSahams(chart, birthDatetime), [chart, birthDatetime]);
+  return (
+    <div className="border-t border-zinc-100 pt-3 dark:border-zinc-800">
+      <button type="button" onClick={() => setExpanded((value) => !value)} className="flex w-full items-center justify-between text-left">
+        <span className="text-xs font-mono text-zinc-500 dark:text-zinc-500">&gt; sahams</span>
+        <span className="text-[10px] font-mono text-zinc-400">{expanded ? 'collapse' : 'expand'}</span>
+      </button>
+      {expanded && (
+        <div className="mt-3 space-y-2">
+          <div className="text-[10px] font-mono text-zinc-400">{result.night ? 'night' : 'day'} formula · Tajika 30° correction</div>
+          <div className="max-h-[560px] overflow-auto rounded-md border border-zinc-200 dark:border-zinc-700">
+            <table className="w-full min-w-[720px] border-collapse text-[10px] font-mono">
+              <thead className="sticky top-0 bg-zinc-50 text-left text-zinc-400 dark:bg-zinc-900"><tr>
+                <th className="p-2">Saham</th><th className="p-2">Position</th><th className="p-2">Nakshatra</th><th className="p-2">H</th><th className="p-2">Meaning</th>
+              </tr></thead>
+              <tbody>{result.rows.map((row) => (
+                <tr key={row.key} title={row.formula} className="border-t border-zinc-100 text-zinc-700 dark:border-zinc-800 dark:text-zinc-300">
+                  <td className="p-2 font-semibold">{row.name}</td><td className="p-2">{position(row.degree, row.sign)}</td><td className="p-2">{row.nakshatra} {row.pada}</td><td className="p-2">{row.house}</td><td className="p-2 text-zinc-500 dark:text-zinc-400">{row.meaning}</td>
+                </tr>
+              ))}</tbody>
+            </table>
+          </div>
+          <p className="text-[9px] leading-relaxed text-zinc-400">Hover a row to see its formula. Sahams refine chart themes; they do not create a promise independently.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.68',
+    date: '2026-08-10',
+    title: 'Sahams',
+    changes: [
+      'Added a separate expandable table of 36 Tajika Sahams under Grahas.',
+      'Shows exact position, nakshatra/pada, whole-sign house, meaning and formula.',
+      'Uses local sunrise/sunset for day/night formulas and applies the classical 30° correction.',
+    ],
+  },
+  {
     version: 'v1.67',
     date: '2026-08-10',
     title: 'Planetary Avasthas',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.67';
+export const APP_VERSION = 'v1.68';

--- a/src/lib/sahams.test.ts
+++ b/src/lib/sahams.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import type { ChartData, PlanetData } from '@/types';
+import { calculateSahams } from './sahams';
+
+const positions: Record<string, number> = { Sun: 10, Moon: 40, Mars: 80, Mercury: 110, Jupiter: 140, Venus: 170, Saturn: 200, Rahu: 230, Ketu: 50 };
+const planets: PlanetData[] = Object.entries(positions).map(([name, longitude]) => ({ name, longitude, sign: Math.floor(longitude / 30) + 1, degree: longitude % 30, house: Math.floor(longitude / 30) + 1 }));
+const chart: ChartData = {
+  ascendant: { longitude: 0, sign: 1, degree: 0 }, planets,
+  debug: { julianDay: 2451545, ayanamsa: 24, utcOffset: 0, ascendantDegree: 0, ascendantSign: 1, ephemerisEngine: 'test', inputDateTime: '2000-03-20T12:00', latitude: 0, longitude: 0 },
+};
+
+const day = calculateSahams(chart, '2000-03-20T12:00');
+assert.equal(day.night, false);
+assert.equal(day.rows.length, 36);
+assert.equal(day.rows.find((row) => row.key === 'punya')?.longitude, 60);
+assert.equal(day.rows.find((row) => row.key === 'vidya')?.longitude, 330);
+assert.equal(day.rows.find((row) => row.key === 'rajya')?.longitude, day.rows.find((row) => row.key === 'pitri')?.longitude);
+assert.equal(day.rows.find((row) => row.key === 'vyapara')?.longitude, 240);
+
+const night = calculateSahams(chart, '2000-03-20T00:00');
+assert.equal(night.night, true);
+assert.equal(night.rows.find((row) => row.key === 'punya')?.longitude, 330);
+assert.notEqual(night.rows.find((row) => row.key === 'satru')?.longitude, day.rows.find((row) => row.key === 'satru')?.longitude);
+assert.equal(night.rows.find((row) => row.key === 'vyapara')?.longitude, day.rows.find((row) => row.key === 'vyapara')?.longitude);
+
+console.log('Saham tests passed');

--- a/src/lib/sahams.ts
+++ b/src/lib/sahams.ts
@@ -1,0 +1,156 @@
+import type { ChartData } from '@/types';
+import { calcSolarTimes } from './panchang/solar';
+
+const SIGN_NAMES = ['Aries', 'Taurus', 'Gemini', 'Cancer', 'Leo', 'Virgo', 'Libra', 'Scorpio', 'Sagittarius', 'Capricorn', 'Aquarius', 'Pisces'];
+const SIGN_LORDS = ['Mars', 'Venus', 'Mercury', 'Moon', 'Sun', 'Mercury', 'Venus', 'Mars', 'Jupiter', 'Saturn', 'Saturn', 'Jupiter'];
+const NAKSHATRAS = ['Aśvinī', 'Bharaṇī', 'Kṛttikā', 'Rohiṇī', 'Mṛgaśīrṣa', 'Ārdrā', 'Punarvasu', 'Puṣya', 'Āśleṣā', 'Maghā', 'Pūrvaphālgunī', 'Uttaraphālgunī', 'Hasta', 'Citrā', 'Svātī', 'Viśākhā', 'Anurādhā', 'Jyeṣṭhā', 'Mūla', 'Pūrvāṣāḍhā', 'Uttarāṣāḍhā', 'Śravaṇa', 'Dhaniṣṭhā', 'Śatabhiṣaj', 'Pūrvabhādrapadā', 'Uttarabhādrapadā', 'Revatī'];
+
+export type SahamResult = {
+  key: string;
+  name: string;
+  meaning: string;
+  longitude: number;
+  sign: number;
+  signName: string;
+  degree: number;
+  house: number;
+  nakshatra: string;
+  pada: number;
+  formula: string;
+};
+
+type Context = {
+  asc: number;
+  night: boolean;
+  planet: (name: string) => number;
+  house: (number: number) => number;
+  lord: (sign: number) => number;
+  part: (a: number, b: number, c: number, reverseAtNight?: boolean) => number;
+};
+
+type Definition = { key: string; name: string; meaning: string; formula: string; calculate: (ctx: Context, values: Record<string, number>) => number };
+
+function norm360(value: number): number { return ((value % 360) + 360) % 360; }
+
+// Tajika correction: add 30° when C is not encountered while moving zodiacally
+// from B toward A. The comparison is made by rāśi, as in the classical method.
+function isCBetweenBToA(a: number, b: number, c: number): boolean {
+  const aSign = Math.floor(norm360(a) / 30);
+  const bSign = Math.floor(norm360(b) / 30);
+  const cSign = Math.floor(norm360(c) / 30);
+  for (let n = bSign; n < bSign + 11; n++) {
+    const next = (n + 1) % 12;
+    if (next === cSign) return true;
+    if (next === aSign) return false;
+  }
+  return false;
+}
+
+function correctedPart(a: number, b: number, c: number): number {
+  return norm360(a - b + c + (isCBetweenBToA(a, b, c) ? 0 : 30));
+}
+
+function parseBirth(value: string) {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?/);
+  if (!match) return null;
+  return { year: +match[1], month: +match[2], day: +match[3], hours: +match[4] + +match[5] / 60 + +(match[6] ?? 0) / 3600 };
+}
+
+export function isNightBirth(chart: ChartData, birthDatetime: string): boolean {
+  const birth = parseBirth(birthDatetime);
+  const debug = chart.debug;
+  if (!birth || !debug) {
+    const sun = chart.planets.find((planet) => planet.name === 'Sun');
+    return sun ? sun.house < 7 : false;
+  }
+  const solar = calcSolarTimes(birth.year, birth.month, birth.day, debug.latitude, debug.longitude);
+  if (solar.sunrise === null || solar.sunset === null) {
+    const sun = chart.planets.find((planet) => planet.name === 'Sun');
+    return sun ? sun.house < 7 : false;
+  }
+  const local = (utc: number) => ((utc + debug.utcOffset) % 24 + 24) % 24;
+  const sunrise = local(solar.sunrise);
+  const sunset = local(solar.sunset);
+  return birth.hours < sunrise || birth.hours >= sunset;
+}
+
+const DEFINITIONS: Definition[] = [
+  { key: 'punya', name: 'Puṇya', meaning: 'Fortune, good deeds', formula: 'Moon − Sun + Lagna', calculate: (c) => c.part(c.planet('Moon'), c.planet('Sun'), c.asc) },
+  { key: 'vidya', name: 'Vidyā', meaning: 'Learning, education', formula: 'Sun − Moon + Lagna', calculate: (c) => c.part(c.planet('Sun'), c.planet('Moon'), c.asc) },
+  { key: 'yasas', name: 'Yaśas', meaning: 'Fame, recognition', formula: 'Jupiter − Puṇya + Lagna', calculate: (c, v) => c.part(c.planet('Jupiter'), v.punya, c.asc) },
+  { key: 'mitra', name: 'Mitra', meaning: 'Friends, allies', formula: 'Jupiter − Puṇya + Venus', calculate: (c, v) => c.part(c.planet('Jupiter'), v.punya, c.planet('Venus')) },
+  { key: 'mahatmya', name: 'Māhātmya', meaning: 'Greatness, eminence', formula: 'Puṇya − Mars + Lagna', calculate: (c, v) => c.part(v.punya, c.planet('Mars'), c.asc) },
+  { key: 'asha', name: 'Āśā', meaning: 'Hope, desire', formula: 'Saturn − Mars + Lagna', calculate: (c) => c.part(c.planet('Saturn'), c.planet('Mars'), c.asc) },
+  { key: 'samartha', name: 'Samartha', meaning: 'Ability, enterprise', formula: 'Mars − Lagna lord + Lagna', calculate: (c) => {
+    const lordName = SIGN_LORDS[Math.floor(c.asc / 30)];
+    const useJupiter = lordName === 'Mars';
+    const a = c.planet('Mars');
+    const b = c.planet(useJupiter ? 'Jupiter' : lordName);
+    return useJupiter ? c.part(b, a, c.asc) : c.part(a, b, c.asc);
+  } },
+  { key: 'bhratri', name: 'Bhrātṛ', meaning: 'Siblings', formula: 'Jupiter − Saturn + Lagna', calculate: (c) => c.part(c.planet('Jupiter'), c.planet('Saturn'), c.asc, false) },
+  { key: 'gaurava', name: 'Gaurava', meaning: 'Respect, regard', formula: 'Jupiter − Moon + Sun', calculate: (c) => c.part(c.planet('Jupiter'), c.planet('Moon'), c.planet('Sun')) },
+  { key: 'pitri', name: 'Pitṛ', meaning: 'Father', formula: 'Saturn − Sun + Lagna', calculate: (c) => c.part(c.planet('Saturn'), c.planet('Sun'), c.asc) },
+  { key: 'rajya', name: 'Rājya', meaning: 'Position, authority', formula: 'Saturn − Sun + Lagna', calculate: (c) => c.part(c.planet('Saturn'), c.planet('Sun'), c.asc) },
+  { key: 'matri', name: 'Mātṛ', meaning: 'Mother', formula: 'Moon − Venus + Lagna', calculate: (c) => c.part(c.planet('Moon'), c.planet('Venus'), c.asc) },
+  { key: 'putra', name: 'Putra', meaning: 'Children', formula: 'Jupiter − Moon + Lagna', calculate: (c) => c.part(c.planet('Jupiter'), c.planet('Moon'), c.asc) },
+  { key: 'jeeva', name: 'Jīva', meaning: 'Life, vitality', formula: 'Saturn − Jupiter + Lagna', calculate: (c) => c.part(c.planet('Saturn'), c.planet('Jupiter'), c.asc) },
+  { key: 'karma', name: 'Karma', meaning: 'Work, action', formula: 'Mars − Mercury + Lagna', calculate: (c) => c.part(c.planet('Mars'), c.planet('Mercury'), c.asc) },
+  { key: 'roga', name: 'Roga', meaning: 'Disease', formula: 'Lagna − Moon + Lagna', calculate: (c) => norm360(c.asc - c.planet('Moon') + c.asc) },
+  { key: 'kali', name: 'Kālī', meaning: 'Great misfortune', formula: 'Jupiter − Mars + Lagna', calculate: (c) => c.part(c.planet('Jupiter'), c.planet('Mars'), c.asc) },
+  { key: 'sastra', name: 'Śāstra', meaning: 'Sciences, scripture', formula: 'Jupiter − Saturn + Mercury', calculate: (c) => c.part(c.planet('Jupiter'), c.planet('Saturn'), c.planet('Mercury')) },
+  { key: 'bandhu', name: 'Bandhu', meaning: 'Relatives, kin', formula: 'Mercury − Moon + Lagna', calculate: (c) => c.part(c.planet('Mercury'), c.planet('Moon'), c.asc) },
+  { key: 'mrityu', name: 'Mṛtyu', meaning: 'Death, ending', formula: '8th house − Moon + Lagna', calculate: (c) => correctedPart(c.house(8), c.planet('Moon'), c.asc) },
+  { key: 'paradesa', name: 'Paradeśa', meaning: 'Foreign lands', formula: '9th house − 9th lord + Lagna', calculate: (c) => correctedPart(c.house(9), c.lord(Math.floor(c.house(9) / 30)), c.asc) },
+  { key: 'artha', name: 'Artha', meaning: 'Money, resources', formula: '2nd house − 2nd lord + Lagna', calculate: (c) => correctedPart(c.house(2), c.lord(Math.floor(c.house(2) / 30)), c.asc) },
+  { key: 'paradara', name: 'Paradāra', meaning: 'Other relationships', formula: 'Venus − Sun + Lagna', calculate: (c) => c.part(c.planet('Venus'), c.planet('Sun'), c.asc) },
+  { key: 'vanika', name: 'Vaṇik', meaning: 'Commerce, trade', formula: 'Moon − Mercury + Lagna', calculate: (c) => c.part(c.planet('Moon'), c.planet('Mercury'), c.asc) },
+  { key: 'karyasiddhi', name: 'Kāryasiddhi', meaning: 'Success in endeavours', formula: 'Saturn − luminary + its sign lord', calculate: (c) => {
+    const luminary = c.night ? 'Moon' : 'Sun';
+    const lon = c.planet(luminary);
+    return correctedPart(c.planet('Saturn'), lon, c.lord(Math.floor(lon / 30)));
+  } },
+  { key: 'vivaha', name: 'Vivāha', meaning: 'Marriage', formula: 'Venus − Saturn + Lagna', calculate: (c) => c.part(c.planet('Venus'), c.planet('Saturn'), c.asc) },
+  { key: 'santapa', name: 'Santāpa', meaning: 'Sorrow, distress', formula: 'Saturn − Moon + 6th house', calculate: (c) => c.part(c.planet('Saturn'), c.planet('Moon'), c.house(6)) },
+  { key: 'sraddha', name: 'Śraddhā', meaning: 'Devotion, sincerity', formula: 'Venus − Mars + Lagna', calculate: (c) => c.part(c.planet('Venus'), c.planet('Mars'), c.asc) },
+  { key: 'preeti', name: 'Prīti', meaning: 'Love, attachment', formula: 'Śāstra − Puṇya + Lagna', calculate: (c, v) => c.part(v.sastra, v.punya, c.asc) },
+  { key: 'jadya', name: 'Jāḍya', meaning: 'Chronic disease, inertia', formula: 'Mars − Saturn + Mercury', calculate: (c) => c.part(c.planet('Mars'), c.planet('Saturn'), c.planet('Mercury')) },
+  { key: 'vyapara', name: 'Vyāpāra', meaning: 'Business, occupation', formula: 'Mars − Saturn + Lagna', calculate: (c) => c.part(c.planet('Mars'), c.planet('Saturn'), c.asc, false) },
+  { key: 'satru', name: 'Śatru', meaning: 'Enemies, opposition', formula: 'Mars − Saturn + Lagna', calculate: (c) => c.part(c.planet('Mars'), c.planet('Saturn'), c.asc) },
+  { key: 'jalapatana', name: 'Jalapatana', meaning: 'Ocean crossing, sea travel', formula: 'Cancer 15° − Saturn + Lagna', calculate: (c) => c.part(105, c.planet('Saturn'), c.asc) },
+  { key: 'bandhana', name: 'Bandhana', meaning: 'Confinement, imprisonment', formula: 'Puṇya − Saturn + Lagna', calculate: (c, v) => c.part(v.punya, c.planet('Saturn'), c.asc) },
+  { key: 'apamrityu', name: 'Apamṛtyu', meaning: 'Untimely death, danger', formula: '8th house − Mars + Lagna', calculate: (c) => c.part(c.house(8), c.planet('Mars'), c.asc) },
+  { key: 'labha', name: 'Lābha', meaning: 'Material gains', formula: '11th house − 11th lord + Lagna', calculate: (c) => c.part(c.house(11), c.lord(Math.floor(c.house(11) / 30)), c.asc) },
+];
+
+export function calculateSahams(chart: ChartData, birthDatetime: string): { night: boolean; rows: SahamResult[] } {
+  const night = isNightBirth(chart, birthDatetime);
+  const asc = chart.ascendant.longitude;
+  const planetMap = new Map(chart.planets.map((planet) => [planet.name, planet.longitude]));
+  const planet = (name: string) => {
+    const longitude = planetMap.get(name);
+    if (longitude === undefined) throw new Error(`Missing ${name} for Saham calculation`);
+    return longitude;
+  };
+  const house = (number: number) => asc + (number - 1) * 30;
+  const lord = (sign: number) => planet(SIGN_LORDS[((sign % 12) + 12) % 12]);
+  const part = (a: number, b: number, c: number, reverseAtNight = true) => night && reverseAtNight ? correctedPart(b, a, c) : correctedPart(a, b, c);
+  const context: Context = { asc, night, planet, house, lord, part };
+  const values: Record<string, number> = {};
+
+  const rows = DEFINITIONS.map((definition) => {
+    const longitude = norm360(definition.calculate(context, values));
+    values[definition.key] = longitude;
+    const signIndex = Math.floor(longitude / 30);
+    const degree = longitude % 30;
+    const nakshatraIndex = Math.floor(longitude / (360 / 27));
+    const pada = Math.floor((longitude % (360 / 27)) / (360 / 108)) + 1;
+    return {
+      key: definition.key, name: definition.name, meaning: definition.meaning, longitude,
+      sign: signIndex + 1, signName: SIGN_NAMES[signIndex], degree,
+      house: ((signIndex - (chart.ascendant.sign - 1) + 12) % 12) + 1,
+      nakshatra: NAKSHATRAS[nakshatraIndex], pada, formula: definition.formula,
+    };
+  });
+  return { night, rows };
+}


### PR DESCRIPTION
## Summary
- add a separate expandable table of 36 Tajika Sahams under Grahas
- show exact sign position, nakshatra/pada, whole-sign house and meaning
- expose each row's formula as a tooltip
- select day/night formulas from local sunrise and sunset
- apply the classical sign-based 30° correction
- bump the app to v1.68

## Verification
- `node --import tsx src/lib/sahams.test.ts`
- `npm run build`
- `git diff --check`