### PR TITLE
Expand ayanamsa choices

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,6 +24,7 @@ import BcpManualOverride from '@/components/BcpManualOverride';
 import BNNEventDetectionPanel from '@/components/BNNEventDetectionPanel';
 import WorkspaceView from '@/components/workspace/WorkspaceView';
 import PublicChartsPanel from '@/components/PublicChartsPanel';
+import { ayanamsaLabel } from '@/lib/ayanamsas';
 
 function ModeSwitcher({ mode, onChange, compact }: { mode: UiMode; onChange: (m: UiMode) => void; compact?: boolean }) {
   const modes: { id: UiMode; short: string; long: string }[] = [
@@ -134,10 +135,6 @@ function Panel({ children }: { children: React.ReactNode }) {
   );
 }
 
-const AYANAMSA_LABELS: Record<string, string> = {
-  tropical: 'Tropical', lahiri: 'Lahiri', raman: 'Raman', krishnamurti: 'KP',
-};
-
 function CalcSummaryBar({ ayanamsa, nodeMode, ianaTimezone }: {
   ayanamsa: string;
   nodeMode: string;
@@ -145,7 +142,7 @@ function CalcSummaryBar({ ayanamsa, nodeMode, ianaTimezone }: {
 }) {
   return (
     <div className="mt-3 pt-3 border-t border-zinc-100 dark:border-zinc-800 flex flex-wrap gap-x-4 gap-y-1 text-[10px] font-mono text-zinc-400 dark:text-zinc-500">
-      <span>{AYANAMSA_LABELS[ayanamsa] ?? ayanamsa} ayanamsa</span>
+      <span>{ayanamsaLabel(ayanamsa, true)} ayanamsa</span>
       <span>{nodeMode === 'true' ? 'true node' : 'mean node'}</span>
       {ianaTimezone && <span>{ianaTimezone}</span>}
     </div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -5,6 +5,7 @@ import { ChartDisplaySettings, CalculationSettings, DashaSettings, DEFAULT_DASHA
 import { type DegreePrecision } from '@/lib/formatDegree';
 import { APP_NAME, APP_VERSION } from '@/lib/config';
 import { DASHA_REGISTRY, DashaKey } from '@/lib/dashaRegistry';
+import { AYANAMSA_OPTIONS } from '@/lib/ayanamsas';
 import UpdatesPanel from './UpdatesPanel';
 
 interface Props {
@@ -133,10 +134,11 @@ export default function SettingsPanel(props: Props) {
             <div>
               <label className="block text-xs font-mono text-zinc-500 dark:text-zinc-400 mb-1">ayanamsa</label>
               <select className={SELECT} value={calculationSettings.ayanamsa} onChange={(e) => onUpdateCalculationSettings({ ayanamsa: e.target.value })}>
-                <option value="tropical">Tropical (Sayana)</option>
-                <option value="lahiri">Lahiri</option>
-                <option value="raman">Raman</option>
-                <option value="krishnamurti">Krishnamurti / KP</option>
+                {['Zodiac', 'Requested', 'Common'].map((group) => (
+                  <optgroup key={group} label={group}>
+                    {AYANAMSA_OPTIONS.filter((option) => option.group === group).map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                  </optgroup>
+                ))}
               </select>
             </div>
             <div>

--- a/src/lib/ayanamsas.test.ts
+++ b/src/lib/ayanamsas.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { AYANAMSA_OPTIONS, ayanamsaModeNumber, resolveAyanamsaMode } from './ayanamsas';
+import { sweGetAyanamsa, sweJulday } from './ephemerisAdapter';
+
+assert.equal(AYANAMSA_OPTIONS.filter((option) => option.group === 'Common').length, 10);
+assert.equal(ayanamsaModeNumber('chandra-hari'), 35);
+assert.equal(ayanamsaModeNumber('wilhelm-mula'), 36);
+assert.equal(ayanamsaModeNumber('mardyks'), 34);
+assert.equal(ayanamsaModeNumber('babylonian-britton'), 38);
+assert.equal(ayanamsaModeNumber('ushashashi'), 4);
+assert.equal(resolveAyanamsaMode('unknown'), 'lahiri');
+
+async function main() {
+  const jd = await sweJulday(2000, 1, 1, 12);
+  const modes = ['lahiri', 'chandra-hari', 'wilhelm-mula', 'mardyks', 'babylonian-britton', 'ushashashi'] as const;
+  const values = await Promise.all(modes.map((mode) => sweGetAyanamsa(jd, mode)));
+  values.forEach((value) => assert.ok(Number.isFinite(value) && value > 15 && value < 40));
+  assert.equal(new Set(values.map((value) => value.toFixed(7))).size, values.length);
+  console.log('Ayanamsa tests passed');
+}
+
+main().catch((error) => { console.error(error); process.exitCode = 1; });

--- a/src/lib/ayanamsas.ts
+++ b/src/lib/ayanamsas.ts
@@ -1,0 +1,37 @@
+export const AYANAMSA_OPTIONS = [
+  { value: 'tropical', label: 'Tropical (Sāyana)', shortLabel: 'Tropical', mode: null, group: 'Zodiac' },
+
+  { value: 'lahiri', label: 'Lahiri / Chitrapaksha', shortLabel: 'Lahiri', mode: 1, group: 'Common' },
+  { value: 'raman', label: 'B.V. Raman', shortLabel: 'Raman', mode: 3, group: 'Common' },
+  { value: 'krishnamurti', label: 'Krishnamurti / KP', shortLabel: 'KP', mode: 5, group: 'Common' },
+  { value: 'fagan-bradley', label: 'Fagan–Bradley', shortLabel: 'Fagan–Bradley', mode: 0, group: 'Common' },
+  { value: 'yukteshwar', label: 'Sri Yukteshwar', shortLabel: 'Yukteshwar', mode: 7, group: 'Common' },
+  { value: 'jn-bhasin', label: 'J.N. Bhasin', shortLabel: 'J.N. Bhasin', mode: 8, group: 'Common' },
+  { value: 'de-luce', label: 'De Luce', shortLabel: 'De Luce', mode: 2, group: 'Common' },
+  { value: 'djwhal-khul', label: 'Djwhal Khul', shortLabel: 'Djwhal Khul', mode: 6, group: 'Common' },
+  { value: 'true-chitra', label: 'True Chitra', shortLabel: 'True Chitra', mode: 27, group: 'Common' },
+  { value: 'true-revati', label: 'True Revati', shortLabel: 'True Revati', mode: 28, group: 'Common' },
+
+  { value: 'chandra-hari', label: 'Chandra-Hari (True Mūla)', shortLabel: 'Chandra-Hari', mode: 35, group: 'Requested' },
+  { value: 'wilhelm-mula', label: 'Wilhelm (Dhruva / Galactic Center / Mūla)', shortLabel: 'Wilhelm Mūla', mode: 36, group: 'Requested' },
+  { value: 'mardyks', label: 'Skydram / Mardyks (Galactic Alignment)', shortLabel: 'Mardyks', mode: 34, group: 'Requested' },
+  { value: 'babylonian-britton', label: 'Babylonian (Britton)', shortLabel: 'Babylonian Britton', mode: 38, group: 'Requested' },
+  { value: 'ushashashi', label: 'Ushāśaśi (Usha-Shashi)', shortLabel: 'Ushāśaśi', mode: 4, group: 'Requested' },
+] as const;
+
+export type AyanamsaMode = typeof AYANAMSA_OPTIONS[number]['value'];
+
+const BY_VALUE = new Map<string, typeof AYANAMSA_OPTIONS[number]>(AYANAMSA_OPTIONS.map((option) => [option.value, option]));
+
+export function resolveAyanamsaMode(value: string): AyanamsaMode {
+  return (BY_VALUE.has(value) ? value : 'lahiri') as AyanamsaMode;
+}
+
+export function ayanamsaModeNumber(value: AyanamsaMode): number | null {
+  return BY_VALUE.get(value)?.mode ?? 1;
+}
+
+export function ayanamsaLabel(value: string, short = false): string {
+  const option = BY_VALUE.get(value) ?? BY_VALUE.get('lahiri')!;
+  return short ? option.shortLabel : option.label;
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.69',
+    date: '2026-08-10',
+    title: 'Expanded ayanamsas',
+    changes: [
+      'Added Chandra-Hari/True Mūla, Wilhelm Mūla, Mardyks, Babylonian Britton and Ushāśaśi ayanamsas.',
+      'Added ten common systems: Lahiri, Raman, KP, Fagan–Bradley, Yukteshwar, J.N. Bhasin, De Luce, Djwhal Khul, True Chitra and True Revati.',
+      'All sidereal choices use their native Swiss Ephemeris mode and apply consistently to planets, nodes and Lagna.',
+    ],
+  },
+  {
     version: 'v1.68',
     date: '2026-08-10',
     title: 'Sahams',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.68';
+export const APP_VERSION = 'v1.69';

--- a/src/lib/ephemeris.ts
+++ b/src/lib/ephemeris.ts
@@ -5,6 +5,7 @@ import {
   SE_MEAN_NODE, SE_TRUE_NODE,
   sweJulday, sweGetAyanamsa, sweCalcUt, sweGetAscendant,
 } from "./ephemerisAdapter";
+import { resolveAyanamsaMode } from './ayanamsas';
 
 const PLANET_NAMES: Record<number, string> = {
   [SE_SUN]: "Sun",
@@ -26,11 +27,6 @@ const PLANET_IDS = [
 
 function normalize(value: number): number {
   return ((value % 360) + 360) % 360;
-}
-
-function resolveAyanamsaMode(value: string): 'tropical' | 'lahiri' | 'raman' | 'krishnamurti' {
-  if (value === 'tropical' || value === 'raman' || value === 'krishnamurti') return value;
-  return 'lahiri';
 }
 
 function resolveNodeMode(value: string): 'mean' | 'true' {

--- a/src/lib/ephemerisAdapter.ts
+++ b/src/lib/ephemerisAdapter.ts
@@ -1,3 +1,5 @@
+import { ayanamsaModeNumber, type AyanamsaMode } from './ayanamsas';
+
 interface SweInstance {
   initSwissEph(): Promise<void>;
   set_sid_mode(mode: number, t0: number, ayan_t0: number): void;
@@ -11,6 +13,7 @@ interface SweInstance {
 let _swe: SweInstance | null = null;
 let _initPromise: Promise<void> | null = null;
 let _sidMode = 1;
+let _ayanamsaQueue: Promise<void> = Promise.resolve();
 
 async function getSwe(): Promise<SweInstance> {
   if (_swe) return _swe;
@@ -40,14 +43,6 @@ export const SE_PLUTO     = 9;
 export const SE_MEAN_NODE = 10;
 export const SE_TRUE_NODE = 11;
 
-export type AyanamsaMode = 'tropical' | 'lahiri' | 'raman' | 'krishnamurti';
-
-const SIDEREAL_MODE_BY_AYANAMSA: Record<Exclude<AyanamsaMode, 'tropical'>, number> = {
-  lahiri: 1,
-  raman: 3,
-  krishnamurti: 5,
-};
-
 async function setSiderealMode(mode: number): Promise<void> {
   const swe = await getSwe();
   if (_sidMode !== mode) {
@@ -60,10 +55,14 @@ export async function sweJulday(year: number, month: number, day: number, hour: 
   return (await getSwe()).julday(year, month, day, hour);
 }
 
-export async function sweGetAyanamsa(jd: number, ayanamsa: AyanamsaMode = 'lahiri'): Promise<number> {
-  if (ayanamsa === 'tropical') return 0;
-  await setSiderealMode(SIDEREAL_MODE_BY_AYANAMSA[ayanamsa] ?? SIDEREAL_MODE_BY_AYANAMSA.lahiri);
-  return (await getSwe()).get_ayanamsa_ut(jd);
+export function sweGetAyanamsa(jd: number, ayanamsa: AyanamsaMode = 'lahiri'): Promise<number> {
+  if (ayanamsa === 'tropical') return Promise.resolve(0);
+  const task = _ayanamsaQueue.then(async () => {
+    await setSiderealMode(ayanamsaModeNumber(ayanamsa) ?? 1);
+    return (await getSwe()).get_ayanamsa_ut(jd);
+  });
+  _ayanamsaQueue = task.then(() => undefined, () => undefined);
+  return task;
 }
 
 export async function sweCalcUt(jd: number, planetId: number): Promise<{ longitude: number; speed: number }> {


### PR DESCRIPTION
## Summary
- add Chandra-Hari (True Mūla), Wilhelm Mūla, Mardyks, Babylonian Britton and Ushāśaśi
- offer ten common sidereal systems: Lahiri, Raman, KP, Fagan–Bradley, Yukteshwar, J.N. Bhasin, De Luce, Djwhal Khul, True Chitra and True Revati
- group the Settings selector into requested and common choices
- drive planets, nodes and Lagna from the selected native Swiss Ephemeris mode
- serialize stateful Swiss ayanamsa lookups so concurrent requests cannot interfere
- bump the app to v1.69

## Verification
- `node --import tsx src/lib/ayanamsas.test.ts`
- `npm run build`
- `git diff --check`