### PR TITLE
Add Saturn and nodal Nadi progressions

### DIFF
--- a/src/components/BNNEventDetectionPanel.tsx
+++ b/src/components/BNNEventDetectionPanel.tsx
@@ -6,6 +6,7 @@ import { SIGN_NAMES } from '@/lib/varga/index';
 import { calculateJupiterianRounds } from '@/lib/bnn/jupiterianRounds';
 import { calculateMinorProgression } from '@/lib/bnn/jupiterMinorProgression';
 import { detectBNNEventWindows, type BNNEventWindow } from '@/lib/bnn/eventDetection';
+import { calculateNadiParaya, type ParayaPeriod } from '@/lib/bnn/nadiParaya';
 
 const SIGN_ABBR: Record<number, string> = {
   1: 'Ar', 2: 'Ta', 3: 'Ge', 4: 'Cn', 5: 'Le', 6: 'Vi',
@@ -151,6 +152,22 @@ function EventGroup({
   );
 }
 
+function ParayaCard({ symbol, period, retrograde }: { symbol: string; period: ParayaPeriod; retrograde?: boolean }) {
+  return (
+    <div className="rounded border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-900/50 px-2.5 py-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] font-mono text-zinc-500 dark:text-zinc-400">
+          {symbol} {period.body}{retrograde ? ' ℞' : ''}
+        </span>
+        <span className="text-xs font-mono font-semibold text-violet-600 dark:text-violet-400">{period.signName}</span>
+      </div>
+      <div className="mt-1 text-[9px] font-mono text-zinc-400 dark:text-zinc-600">
+        age {period.startAge}–{period.endAge} · {period.durationYears}y · cycle {period.cycleNumber}
+      </div>
+    </div>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 interface Props {
@@ -167,6 +184,8 @@ const INPUT =
 
 export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDate, bnnOverrideStr, onBnnOverrideStrChange }: Props) {
   const natalJupiter = chart.planets.find(p => p.name === 'Jupiter');
+  const natalSaturn = chart.planets.find(p => p.name === 'Saturn');
+  const natalRahu = chart.planets.find(p => p.name === 'Rahu');
   const natalJupiterSignIndex = natalJupiter ? natalJupiter.sign - 1 : 0;
   const natalJupiterDegree = natalJupiter ? natalJupiter.degree : 0;
 
@@ -219,6 +238,15 @@ export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDat
     () => detectBNNEventWindows({ roundsResult, minorProgression, natalPlanets }),
     [roundsResult, minorProgression, natalPlanets],
   );
+
+  const nadiParaya = useMemo(() => calculateNadiParaya({
+    ageYears: effectiveAge,
+    natalJupiterSignIndex,
+    natalSaturnSignIndex: (natalSaturn?.sign ?? 1) - 1,
+    natalRahuSignIndex: (natalRahu?.sign ?? 1) - 1,
+    jupiterRetrograde: Boolean(natalJupiter?.isRetrograde),
+    saturnRetrograde: Boolean(natalSaturn?.isRetrograde),
+  }), [effectiveAge, natalJupiterSignIndex, natalJupiter?.isRetrograde, natalSaturn?.sign, natalSaturn?.isRetrograde, natalRahu?.sign]);
 
   // All hooks above — early return after
   if (!natalJupiter) {
@@ -337,6 +365,22 @@ export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDat
                 </button>
               )}
             </div>
+          </div>
+
+          {/* Nadi paraya progressions */}
+          <div className="space-y-2">
+            <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600">
+              Nadi Paraya Progressions
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <ParayaCard symbol="♃" period={nadiParaya.jupiter} retrograde={Boolean(natalJupiter.isRetrograde)} />
+              <ParayaCard symbol="♄" period={nadiParaya.saturn} retrograde={Boolean(natalSaturn?.isRetrograde)} />
+              <ParayaCard symbol="☊" period={nadiParaya.rahu} />
+              <ParayaCard symbol="☋" period={nadiParaya.ketu} />
+            </div>
+            <p className="text-[9px] font-mono text-zinc-400 dark:text-zinc-600 leading-relaxed">
+              Jupiter: 1y/sign forward · Saturn: 3–2 forward · Rahu/Ketu: 2–1 backward. Retrograde Jupiter or Saturn starts one sign earlier.
+            </p>
           </div>
 
           {/* Strong event windows */}

--- a/src/lib/bnn/nadiParaya.test.ts
+++ b/src/lib/bnn/nadiParaya.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { buildParayaTimeline, calculateNadiParaya } from './nadiParaya';
+
+const atBirth = calculateNadiParaya({
+  ageYears: 0,
+  natalJupiterSignIndex: 0,
+  natalSaturnSignIndex: 7,
+  natalRahuSignIndex: 11,
+});
+assert.equal(atBirth.jupiter.signIndex, 0);
+assert.equal(atBirth.saturn.signIndex, 7);
+assert.equal(atBirth.saturn.endAge, 3);
+assert.equal(atBirth.rahu.signIndex, 11);
+assert.equal(atBirth.rahu.endAge, 2);
+assert.equal(atBirth.ketu.signIndex, 5);
+
+const boundaries = calculateNadiParaya({
+  ageYears: 3,
+  natalJupiterSignIndex: 0,
+  natalSaturnSignIndex: 7,
+  natalRahuSignIndex: 11,
+});
+assert.equal(boundaries.saturn.signIndex, 8);
+assert.equal(boundaries.saturn.startAge, 3);
+assert.equal(boundaries.saturn.endAge, 5);
+assert.equal(boundaries.rahu.signIndex, 9);
+assert.equal(boundaries.rahu.startAge, 3);
+assert.equal(boundaries.rahu.endAge, 5);
+
+const retrograde = calculateNadiParaya({
+  ageYears: 0,
+  natalJupiterSignIndex: 0,
+  natalSaturnSignIndex: 7,
+  natalRahuSignIndex: 11,
+  jupiterRetrograde: true,
+  saturnRetrograde: true,
+});
+assert.equal(retrograde.jupiter.signIndex, 11);
+assert.equal(retrograde.saturn.signIndex, 6);
+assert.equal(retrograde.rahu.signIndex, 11);
+
+const saturnCycle = buildParayaTimeline({ body: 'Saturn', natalSignIndex: 0, maxAge: 30 });
+const rahuCycle = buildParayaTimeline({ body: 'Rahu', natalSignIndex: 0, maxAge: 18 });
+assert.equal(saturnCycle.length, 12);
+assert.equal(saturnCycle.at(-1)?.endAge, 30);
+assert.equal(rahuCycle.length, 12);
+assert.equal(rahuCycle.at(-1)?.endAge, 18);
+
+console.log('Nadi paraya tests passed');

--- a/src/lib/bnn/nadiParaya.ts
+++ b/src/lib/bnn/nadiParaya.ts
@@ -1,0 +1,132 @@
+import { SIGN_NAMES } from '@/lib/varga/index';
+
+export type ParayaBody = 'Jupiter' | 'Saturn' | 'Rahu' | 'Ketu';
+
+export type ParayaPeriod = {
+  body: ParayaBody;
+  signIndex: number;
+  signName: string;
+  startAge: number;
+  endAge: number;
+  durationYears: number;
+  cycleNumber: number;
+};
+
+export type NadiParayaResult = {
+  ageYears: number;
+  jupiter: ParayaPeriod;
+  saturn: ParayaPeriod;
+  rahu: ParayaPeriod;
+  ketu: ParayaPeriod;
+};
+
+function normalizeSign(signIndex: number): number {
+  return ((Math.floor(signIndex) % 12) + 12) % 12;
+}
+
+function periodAtAge(params: {
+  body: ParayaBody;
+  natalSignIndex: number;
+  ageYears: number;
+  durations: readonly number[];
+  direction: 1 | -1;
+  retrogradeStartShift?: boolean;
+}): ParayaPeriod {
+  const ageYears = Math.max(0, params.ageYears);
+  const startSign = normalizeSign(params.natalSignIndex - (params.retrogradeStartShift ? 1 : 0));
+  const cycleLength = params.durations.reduce((sum, duration) => sum + duration, 0) * (12 / params.durations.length);
+  const completedCycles = Math.floor(ageYears / cycleLength);
+  const ageInCycle = ageYears - completedCycles * cycleLength;
+
+  let startAgeInCycle = 0;
+  for (let step = 0; step < 12; step++) {
+    const durationYears = params.durations[step % params.durations.length];
+    const endAgeInCycle = startAgeInCycle + durationYears;
+    if (ageInCycle < endAgeInCycle || step === 11) {
+      const signIndex = normalizeSign(startSign + params.direction * step);
+      return {
+        body: params.body,
+        signIndex,
+        signName: SIGN_NAMES[signIndex],
+        startAge: completedCycles * cycleLength + startAgeInCycle,
+        endAge: completedCycles * cycleLength + endAgeInCycle,
+        durationYears,
+        cycleNumber: completedCycles + 1,
+      };
+    }
+    startAgeInCycle = endAgeInCycle;
+  }
+
+  throw new Error('Unable to resolve Nadi paraya period');
+}
+
+export function calculateNadiParaya(params: {
+  ageYears: number;
+  natalJupiterSignIndex: number;
+  natalSaturnSignIndex: number;
+  natalRahuSignIndex: number;
+  jupiterRetrograde?: boolean;
+  saturnRetrograde?: boolean;
+}): NadiParayaResult {
+  const ageYears = Math.max(0, params.ageYears);
+  const jupiter = periodAtAge({
+    body: 'Jupiter',
+    natalSignIndex: params.natalJupiterSignIndex,
+    ageYears,
+    durations: [1],
+    direction: 1,
+    retrogradeStartShift: params.jupiterRetrograde,
+  });
+  const saturn = periodAtAge({
+    body: 'Saturn',
+    natalSignIndex: params.natalSaturnSignIndex,
+    ageYears,
+    durations: [3, 2],
+    direction: 1,
+    retrogradeStartShift: params.saturnRetrograde,
+  });
+  const rahu = periodAtAge({
+    body: 'Rahu',
+    natalSignIndex: params.natalRahuSignIndex,
+    ageYears,
+    durations: [2, 1],
+    direction: -1,
+  });
+  const ketuSignIndex = normalizeSign(rahu.signIndex + 6);
+  const ketu: ParayaPeriod = {
+    ...rahu,
+    body: 'Ketu',
+    signIndex: ketuSignIndex,
+    signName: SIGN_NAMES[ketuSignIndex],
+  };
+
+  return { ageYears, jupiter, saturn, rahu, ketu };
+}
+
+export function buildParayaTimeline(params: {
+  body: Exclude<ParayaBody, 'Ketu'>;
+  natalSignIndex: number;
+  maxAge: number;
+  retrograde?: boolean;
+}): ParayaPeriod[] {
+  const config = params.body === 'Jupiter'
+    ? { durations: [1] as const, direction: 1 as const }
+    : params.body === 'Saturn'
+      ? { durations: [3, 2] as const, direction: 1 as const }
+      : { durations: [2, 1] as const, direction: -1 as const };
+  const periods: ParayaPeriod[] = [];
+  let age = 0;
+  while (age < params.maxAge) {
+    const period = periodAtAge({
+      body: params.body,
+      natalSignIndex: params.natalSignIndex,
+      ageYears: age,
+      durations: config.durations,
+      direction: config.direction,
+      retrogradeStartShift: params.body !== 'Rahu' && params.retrograde,
+    });
+    periods.push(period);
+    age = period.endAge;
+  }
+  return periods;
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.71',
+    date: '2026-08-10',
+    title: 'Nadi paraya progressions',
+    changes: [
+      'Added unified Nadi paraya cards for Jupiter, Saturn, Rahu and Ketu in the BNN panel.',
+      'Saturn follows the repeating 3–2 year pattern; Rahu and Ketu move backward with the repeating 2–1 year pattern.',
+      'Retrograde natal Jupiter and Saturn begin their paraya activation one sign earlier.',
+    ],
+  },
+  {
     version: 'v1.70',
     date: '2026-08-10',
     title: 'Custom Lahiri ayanamsa',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.70';
+export const APP_VERSION = 'v1.71';


### PR DESCRIPTION
## Summary
- add a unified Nadi Paraya section for Jupiter, Saturn, Rahu, and Ketu
- implement Saturn's repeating 3–2 year forward progression
- implement Rahu/Ketu's repeating 2–1 year backward progression
- apply the one-sign-earlier start rule to retrograde Jupiter and Saturn
- show current sign, active age interval, duration, and cycle in the BNN panel

## Verification
- Nadi paraya boundary and full-cycle regression tests pass
- `npm run build` passes