### PR TITLE
Show Nadi paraya activations on charts

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { GeoResult, BcpResult, ChartData, PlanetData, ChartDisplaySettings, Calc
 import { calculateBcp, parseDateTime } from '@/lib/bcp';
 import { calculateJupiterianRounds } from '@/lib/bnn/jupiterianRounds';
 import { calculateMinorProgression } from '@/lib/bnn/jupiterMinorProgression';
+import { calculateNadiParaya, type NadiParayaHouseActivation } from '@/lib/bnn/nadiParaya';
 import { calculateCharaKarakas, CharaKaraka } from '@/lib/karakas';
 import { getUtcOffsetHours, parseBirthDatetimeForTz } from '@/lib/timezone';
 import { APP_NAME, APP_VERSION } from '@/lib/config';
@@ -282,6 +283,27 @@ export default function Home() {
         : 0,
       minor: ((minorResult.minorSignIndex + 1 - asc + 12) % 12) + 1,
     };
+  }, [chartData, effectiveBnnAge]);
+
+  const effectiveNadiParayaHouses = useMemo<NadiParayaHouseActivation[]>(() => {
+    if (!chartData) return [];
+    const jupiter = chartData.planets.find(p => p.name === 'Jupiter');
+    const saturn = chartData.planets.find(p => p.name === 'Saturn');
+    const rahu = chartData.planets.find(p => p.name === 'Rahu');
+    if (!jupiter || !saturn || !rahu) return [];
+    const paraya = calculateNadiParaya({
+      ageYears: effectiveBnnAge,
+      natalJupiterSignIndex: jupiter.sign - 1,
+      natalSaturnSignIndex: saturn.sign - 1,
+      natalRahuSignIndex: rahu.sign - 1,
+      jupiterRetrograde: Boolean(jupiter.isRetrograde),
+      saturnRetrograde: Boolean(saturn.isRetrograde),
+    });
+    const asc = chartData.ascendant.sign;
+    return [paraya.jupiter, paraya.saturn, paraya.rahu, paraya.ketu].map(period => ({
+      body: period.body,
+      house: ((period.signIndex + 1 - asc + 12) % 12) + 1,
+    }));
   }, [chartData, effectiveBnnAge]);
 
   useEffect(() => {
@@ -710,6 +732,7 @@ export default function Home() {
     targetDate,
     bnnMajorHouseFromParent: effectiveBnnHouses.major,
     bnnMinorHouseFromParent: effectiveBnnHouses.minor,
+    nadiParayaHousesFromParent: effectiveNadiParayaHouses,
     bcpEnabled: dashaSettings.dashas.bcp,
     useManualBcpMode,
     onUseManualBcpModeChange: setUseManualBcpMode,
@@ -939,6 +962,7 @@ export default function Home() {
                     nakshatraAdjust={nakshatraAdjust}
                     dashaSettings={dashaSettings}
                     effectiveBnnHouses={effectiveBnnHouses}
+                    effectiveNadiParayaHouses={effectiveNadiParayaHouses}
                     bnnOverrideStr={bnnOverrideStr}
                     onBnnOverrideStrChange={setBnnOverrideStr}
                     bcpEnabled={dashaSettings.dashas.bcp}
@@ -1072,6 +1096,7 @@ export default function Home() {
                   nakshatraAdjust={nakshatraAdjust}
                   dashaSettings={dashaSettings}
                   effectiveBnnHouses={effectiveBnnHouses}
+                  effectiveNadiParayaHouses={effectiveNadiParayaHouses}
                   bnnOverrideStr={bnnOverrideStr}
                   onBnnOverrideStrChange={setBnnOverrideStr}
                   bcpEnabled={dashaSettings.dashas.bcp}

--- a/src/components/ChartSection.tsx
+++ b/src/components/ChartSection.tsx
@@ -12,6 +12,7 @@ import { calculateMinorProgression } from '@/lib/bnn/jupiterMinorProgression';
 import TransitDateControls from './TransitDateControls';
 import BCPAgeControls from './BCPAgeControls';
 import NadiAmsaPanel from './NadiAmsaPanel';
+import type { NadiParayaHouseActivation } from '@/lib/bnn/nadiParaya';
 
 function parseBirthDt(dt: string): Date | null {
   const m = dt.trim().match(/^(\d{2})\.(\d{2})\.(\d{4})\s(\d{2})\.(\d{2})\.(\d{2})$/);
@@ -42,6 +43,7 @@ export interface ChartSectionProps {
   targetDate?: string;
   bnnMajorHouseFromParent?: number;
   bnnMinorHouseFromParent?: number;
+  nadiParayaHousesFromParent?: NadiParayaHouseActivation[];
   bcpEnabled?: boolean;
   useManualBcpMode?: boolean;
   onUseManualBcpModeChange?: (v: boolean) => void;
@@ -77,6 +79,7 @@ export default function ChartSection({
   targetDate,
   bnnMajorHouseFromParent,
   bnnMinorHouseFromParent,
+  nadiParayaHousesFromParent = [],
   bcpEnabled,
   useManualBcpMode,
   onUseManualBcpModeChange,
@@ -213,6 +216,7 @@ export default function ChartSection({
           nakshatraAdjust={nakshatraAdjust}
           bnnMajorHouse={bnnMajorHouse}
           bnnMinorHouse={bnnMinorHouse}
+          nadiParayaHouses={nadiParayaHousesFromParent}
         />
       ) : (
         <NorthIndianChart
@@ -235,6 +239,7 @@ export default function ChartSection({
           nakshatraAdjust={nakshatraAdjust}
           bnnMajorHouse={bnnMajorHouse}
           bnnMinorHouse={bnnMinorHouse}
+          nadiParayaHouses={nadiParayaHousesFromParent}
         />
       )}
 

--- a/src/components/NorthIndianChart.tsx
+++ b/src/components/NorthIndianChart.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useTheme } from 'next-themes';
 import { PlanetData, SpecialLagna } from '@/types';
 import { type DegreePrecision, formatDegree } from '@/lib/formatDegree';
+import type { NadiParayaHouseActivation, ParayaBody } from '@/lib/bnn/nadiParaya';
 
 const OUTER_PLANETS = ['Uranus', 'Neptune', 'Pluto'];
 const SPECIAL_LAGNA_COLOR = '#d97706';
@@ -13,6 +14,10 @@ const BNN_MAJOR_LIGHT = '#ea580c';
 const BNN_MAJOR_DARK  = '#f97316';
 const BNN_MINOR_LIGHT = '#7c3aed';
 const BNN_MINOR_DARK  = '#a78bfa';
+const PARAYA_COLORS: Record<ParayaBody, string> = {
+  Jupiter: '#d97706', Saturn: '#2563eb', Rahu: '#7c3aed', Ketu: '#ea580c',
+};
+const PARAYA_CODES: Record<ParayaBody, string> = { Jupiter: 'Ju', Saturn: 'Sa', Rahu: 'Ra', Ketu: 'Ke' };
 
 interface Props {
   activeYearHouse: number;
@@ -35,6 +40,7 @@ interface Props {
   nakshatraAdjust?: number;
   bnnMajorHouse?: number;
   bnnMinorHouse?: number;
+  nadiParayaHouses?: NadiParayaHouseActivation[];
   legendLayers?: { bcp?: boolean; bnn?: boolean; transit?: boolean };
 }
 
@@ -165,6 +171,7 @@ export default function NorthIndianChart({
   nakshatraAdjust = 0,
   bnnMajorHouse = 0,
   bnnMinorHouse = 0,
+  nadiParayaHouses = [],
   legendLayers,
 }: Props) {
   const { resolvedTheme } = useTheme();
@@ -182,6 +189,7 @@ export default function NorthIndianChart({
   const bnnMinColor = isDark ? BNN_MINOR_DARK : BNN_MINOR_LIGHT;
 
   const hasBnn = bnnMajorHouse > 0 || bnnMinorHouse > 0;
+  const hasParaya = nadiParayaHouses.length > 0;
 
   return (
     <div className="w-full max-w-[620px] mx-auto">
@@ -210,6 +218,7 @@ export default function NorthIndianChart({
           const isBnnMin = bnnMinorHouse > 0 && item.house === bnnMinorHouse;
           const bnnLabel = (isBnnMaj && isBnnMin) ? 'BNN Maj+Min' : isBnnMaj ? 'BNN Maj' : isBnnMin ? 'BNN Min' : null;
           const bnnLabelColor = (isBnnMaj && isBnnMin) ? (isDark ? '#e879f9' : '#a21caf') : isBnnMaj ? bnnMajColor : bnnMinColor;
+          const parayaHere = nadiParayaHouses.filter(activation => activation.house === item.house);
 
           return (
             <g key={item.house}>
@@ -238,6 +247,17 @@ export default function NorthIndianChart({
                   strokeDasharray="8,5"
                 />
               )}
+              {parayaHere.map((activation, index) => (
+                <polygon
+                  key={`paraya-border-${activation.body}`}
+                  points={item.points}
+                  fill="none"
+                  stroke={PARAYA_COLORS[activation.body]}
+                  strokeWidth="4"
+                  strokeDasharray="12,36"
+                  strokeDashoffset={String(index * -12)}
+                />
+              ))}
               {showSigns && (
                 <text x={item.sign.x} y={item.sign.y} textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={signFill}>
                   {SIGN_ABBR[sign]}
@@ -260,6 +280,22 @@ export default function NorthIndianChart({
                   fill={bnnLabelColor}
                 >
                   {bnnLabel}
+                </text>
+              )}
+              {parayaHere.length > 0 && (
+                <text
+                  x={item.sign.x}
+                  y={item.sign.y + (showSigns ? 24 : 10)}
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  fontSize="8"
+                  fontWeight="800"
+                >
+                  {parayaHere.map((activation, index) => (
+                    <tspan key={activation.body} fill={PARAYA_COLORS[activation.body]} dx={index === 0 ? 0 : 4}>
+                      {PARAYA_CODES[activation.body]}
+                    </tspan>
+                  ))}
                 </text>
               )}
               {allPlanets.map((planet, index) => {
@@ -312,13 +348,14 @@ export default function NorthIndianChart({
         })}
       </svg>
 
-      {(showBcpHighlights || showTransitPlanets || showSpecialLagnas || hasBnn) && (
+      {(showBcpHighlights || showTransitPlanets || showSpecialLagnas || hasBnn || hasParaya) && (
         <div className="mt-3 flex justify-center gap-4 text-[11px] font-mono flex-wrap">
           {showBcpHighlights && legendLayers?.bcp !== false && <span className="text-cyan-600 dark:text-cyan-400 font-semibold">■ BCP Year</span>}
           {showBcpHighlights && legendLayers?.bcp !== false && <span className="text-emerald-700 dark:text-green-400 font-semibold">■ BCP Month</span>}
           {showBcpHighlights && legendLayers?.bcp !== false && <span className="text-purple-600 dark:text-purple-400 font-semibold">■ BCP Both</span>}
           {bnnMajorHouse > 0 && legendLayers?.bnn !== false && <span style={{ color: isDark ? BNN_MAJOR_DARK : BNN_MAJOR_LIGHT }} className="font-semibold">■ BNN Major</span>}
           {bnnMinorHouse > 0 && legendLayers?.bnn !== false && <span style={{ color: isDark ? BNN_MINOR_DARK : BNN_MINOR_LIGHT }} className="font-semibold">╌ BNN Minor</span>}
+          {hasParaya && <span className="font-semibold"><span style={{ color: PARAYA_COLORS.Jupiter }}>Ju</span> <span style={{ color: PARAYA_COLORS.Saturn }}>Sa</span> <span style={{ color: PARAYA_COLORS.Rahu }}>Ra</span> <span style={{ color: PARAYA_COLORS.Ketu }}>Ke</span> Paraya</span>}
           {showTransitPlanets && legendLayers?.transit !== false && <span style={{ color: TRANSIT_COLOR }} className="font-semibold">■ Transit</span>}
           {showSpecialLagnas && <span style={{ color: SPECIAL_LAGNA_COLOR }} className="font-semibold">■ Special</span>}
         </div>

--- a/src/components/SouthIndianChart.tsx
+++ b/src/components/SouthIndianChart.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useTheme } from 'next-themes';
 import { PlanetData, SpecialLagna } from '@/types';
 import { type DegreePrecision, formatDegree } from '@/lib/formatDegree';
+import type { NadiParayaHouseActivation, ParayaBody } from '@/lib/bnn/nadiParaya';
 
 const OUTER_PLANETS = ['Uranus', 'Neptune', 'Pluto'];
 const SPECIAL_LAGNA_COLOR = '#d97706';
@@ -13,6 +14,10 @@ const BNN_MAJOR_LIGHT = '#ea580c';
 const BNN_MAJOR_DARK  = '#f97316';
 const BNN_MINOR_LIGHT = '#7c3aed';
 const BNN_MINOR_DARK  = '#a78bfa';
+const PARAYA_COLORS: Record<ParayaBody, string> = {
+  Jupiter: '#d97706', Saturn: '#2563eb', Rahu: '#7c3aed', Ketu: '#ea580c',
+};
+const PARAYA_CODES: Record<ParayaBody, string> = { Jupiter: 'Ju', Saturn: 'Sa', Rahu: 'Ra', Ketu: 'Ke' };
 
 interface Props {
   activeYearHouse: number;
@@ -33,6 +38,7 @@ interface Props {
   nakshatraAdjust?: number;
   bnnMajorHouse?: number;
   bnnMinorHouse?: number;
+  nadiParayaHouses?: NadiParayaHouseActivation[];
   legendLayers?: { bcp?: boolean; bnn?: boolean; transit?: boolean };
 }
 
@@ -120,6 +126,7 @@ export default function SouthIndianChart({
   nakshatraAdjust = 0,
   bnnMajorHouse = 0,
   bnnMinorHouse = 0,
+  nadiParayaHouses = [],
   legendLayers,
 }: Props) {
   const { resolvedTheme } = useTheme();
@@ -159,6 +166,7 @@ export default function SouthIndianChart({
   }
 
   const hasBnn = bnnMajorHouse > 0 || bnnMinorHouse > 0;
+  const hasParaya = nadiParayaHouses.length > 0;
 
   return (
     <div className="w-full max-w-[520px] mx-auto">
@@ -180,6 +188,7 @@ export default function SouthIndianChart({
 
           const isBnnMaj = bnnMajorHouse > 0 && house === bnnMajorHouse;
           const isBnnMin = bnnMinorHouse > 0 && house === bnnMinorHouse;
+          const parayaHere = nadiParayaHouses.filter(activation => activation.house === house);
 
           // BNN background tint — only when BCP is not active on this house
           const isBcpActive = house === activeYearHouse || house === activeMonthHouse;
@@ -214,6 +223,19 @@ export default function SouthIndianChart({
                   className="absolute inset-0 rounded-md pointer-events-none"
                   style={{ border: `2px dashed ${bnnMinColor}`, zIndex: 11 }}
                 />
+              )}
+              {parayaHere.length > 0 && (
+                <div className="absolute inset-x-1 bottom-1 flex gap-0.5 pointer-events-none" style={{ zIndex: 12 }}>
+                  {parayaHere.map(activation => (
+                    <span
+                      key={activation.body}
+                      className="flex-1 rounded-sm text-center text-[8px] leading-3 font-bold text-white"
+                      style={{ backgroundColor: PARAYA_COLORS[activation.body] }}
+                    >
+                      {PARAYA_CODES[activation.body]}
+                    </span>
+                  ))}
+                </div>
               )}
 
               <div className="flex items-start justify-between gap-1 text-[10px] leading-none text-zinc-500 dark:text-zinc-400">
@@ -271,7 +293,7 @@ export default function SouthIndianChart({
         })}
       </div>
 
-      {(activeYearHouse > 0 || activeMonthHouse > 0 || showTransitPlanets || showSpecialLagnas || hasBnn) && (
+      {(activeYearHouse > 0 || activeMonthHouse > 0 || showTransitPlanets || showSpecialLagnas || hasBnn || hasParaya) && (
         <div className="mt-3 flex justify-center gap-4 text-[11px] font-mono flex-wrap">
           {(activeYearHouse > 0 || activeMonthHouse > 0) && legendLayers?.bcp !== false && (
             <>
@@ -282,6 +304,7 @@ export default function SouthIndianChart({
           )}
           {bnnMajorHouse > 0 && legendLayers?.bnn !== false && <span style={{ color: bnnMajColor }} className="font-semibold">■ BNN Major</span>}
           {bnnMinorHouse > 0 && legendLayers?.bnn !== false && <span style={{ color: bnnMinColor }} className="font-semibold">╌ BNN Minor</span>}
+          {hasParaya && <span className="font-semibold"><span style={{ color: PARAYA_COLORS.Jupiter }}>Ju</span> <span style={{ color: PARAYA_COLORS.Saturn }}>Sa</span> <span style={{ color: PARAYA_COLORS.Rahu }}>Ra</span> <span style={{ color: PARAYA_COLORS.Ketu }}>Ke</span> Paraya</span>}
           {showTransitPlanets && legendLayers?.transit !== false && <span style={{ color: TRANSIT_COLOR }} className="font-semibold">■ Transit</span>}
           {showSpecialLagnas && <span style={{ color: SPECIAL_LAGNA_COLOR }} className="font-semibold">■ Special</span>}
         </div>

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -9,6 +9,7 @@ import NorthIndianChart from '../NorthIndianChart';
 import SouthIndianChart from '../SouthIndianChart';
 import TransitDateControls from '../TransitDateControls';
 import BNNEventDetectionPanel from '../BNNEventDetectionPanel';
+import type { NadiParayaHouseActivation } from '@/lib/bnn/nadiParaya';
 import BCPAgeControls from '../BCPAgeControls';
 import GrahasPanel from '../GrahasPanel';
 import DashaPanel from '../DashaPanel';
@@ -137,6 +138,7 @@ export interface WorkspaceViewProps {
   nakshatraAdjust: number;
   dashaSettings: DashaSettings;
   effectiveBnnHouses: { major: number; minor: number };
+  effectiveNadiParayaHouses: NadiParayaHouseActivation[];
   bnnOverrideStr: string;
   onBnnOverrideStrChange: (v: string) => void;
   bcpEnabled: boolean;
@@ -157,6 +159,7 @@ export default function WorkspaceView({
   karakaByPlanet,
   nakshatraAdjust,
   effectiveBnnHouses,
+  effectiveNadiParayaHouses,
   bnnOverrideStr,
   onBnnOverrideStrChange,
   bcpEnabled,
@@ -232,6 +235,7 @@ export default function WorkspaceView({
       activeMonthHouse: monthHouse,
       bnnMajorHouse: bnnMaj,
       bnnMinorHouse: bnnMin,
+      nadiParayaHouses: effectiveNadiParayaHouses,
       transitPlanets: showTransit ? transitPlanets : [],
       showTransitPlanets: showTransit,
       legendLayers,

--- a/src/lib/bnn/nadiParaya.ts
+++ b/src/lib/bnn/nadiParaya.ts
@@ -2,6 +2,11 @@ import { SIGN_NAMES } from '@/lib/varga/index';
 
 export type ParayaBody = 'Jupiter' | 'Saturn' | 'Rahu' | 'Ketu';
 
+export type NadiParayaHouseActivation = {
+  body: ParayaBody;
+  house: number;
+};
+
 export type ParayaPeriod = {
   body: ParayaBody;
   signIndex: number;

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.73',
+    date: '2026-08-10',
+    title: 'Nadi paraya chart highlights',
+    changes: [
+      'Added Jupiter, Saturn, Rahu and Ketu paraya activations directly to North and South Indian charts.',
+      'Active houses use the same gold, blue, violet and orange colors as the paraya cards.',
+      'Multiple paraya activations in one house remain visible side by side instead of covering each other.',
+    ],
+  },
+  {
     version: 'v1.72',
     date: '2026-08-10',
     title: 'Nadi paraya colors',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.72';
+export const APP_VERSION = 'v1.73';


### PR DESCRIPTION
## Summary
- map each active Nadi paraya sign to its whole-sign natal house
- show Jupiter, Saturn, Rahu, and Ketu activations directly on North and South Indian charts
- preserve multiple simultaneous activations in the same house with separate colored markers
- carry the same highlights into workspace charts

## Verification
- `npm run build` passes, including TypeScript validation