### PR TITLE
Show exact Nadi paraya degrees

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -303,6 +303,7 @@ export default function Home() {
     return [paraya.jupiter, paraya.saturn, paraya.rahu, paraya.ketu].map(period => ({
       body: period.body,
       house: ((period.signIndex + 1 - asc + 12) % 12) + 1,
+      degree: period.degree,
     }));
   }, [chartData, effectiveBnnAge]);
 

--- a/src/components/BNNEventDetectionPanel.tsx
+++ b/src/components/BNNEventDetectionPanel.tsx
@@ -183,7 +183,7 @@ function ParayaCard({ symbol, period, retrograde }: { symbol: string; period: Pa
         <span className={`text-[10px] font-mono font-medium ${color.label}`}>
           {symbol} {period.body}{retrograde ? ' ℞' : ''}
         </span>
-        <span className={`text-xs font-mono font-semibold ${color.sign}`}>{period.signName}</span>
+        <span className={`text-xs font-mono font-semibold ${color.sign}`}>{period.signName} {period.degree.toFixed(2)}°</span>
       </div>
       <div className="mt-1 text-[9px] font-mono text-zinc-400 dark:text-zinc-600">
         age {period.startAge}–{period.endAge} · {period.durationYears}y · cycle {period.cycleNumber}

--- a/src/components/NorthIndianChart.tsx
+++ b/src/components/NorthIndianChart.tsx
@@ -293,7 +293,7 @@ export default function NorthIndianChart({
                 >
                   {parayaHere.map((activation, index) => (
                     <tspan key={activation.body} fill={PARAYA_COLORS[activation.body]} dx={index === 0 ? 0 : 4}>
-                      {PARAYA_CODES[activation.body]}
+                      {PARAYA_CODES[activation.body]} {activation.degree.toFixed(1)}°
                     </tspan>
                   ))}
                 </text>

--- a/src/components/SouthIndianChart.tsx
+++ b/src/components/SouthIndianChart.tsx
@@ -232,7 +232,7 @@ export default function SouthIndianChart({
                       className="flex-1 rounded-sm text-center text-[8px] leading-3 font-bold text-white"
                       style={{ backgroundColor: PARAYA_COLORS[activation.body] }}
                     >
-                      {PARAYA_CODES[activation.body]}
+                      {PARAYA_CODES[activation.body]} {activation.degree.toFixed(1)}°
                     </span>
                   ))}
                 </div>

--- a/src/lib/bnn/nadiParaya.test.ts
+++ b/src/lib/bnn/nadiParaya.test.ts
@@ -8,10 +8,12 @@ const atBirth = calculateNadiParaya({
   natalRahuSignIndex: 11,
 });
 assert.equal(atBirth.jupiter.signIndex, 0);
+assert.equal(atBirth.jupiter.degree, 0);
 assert.equal(atBirth.saturn.signIndex, 7);
 assert.equal(atBirth.saturn.endAge, 3);
 assert.equal(atBirth.rahu.signIndex, 11);
 assert.equal(atBirth.rahu.endAge, 2);
+assert.ok(atBirth.rahu.degree > 29.99 && atBirth.rahu.degree < 30);
 assert.equal(atBirth.ketu.signIndex, 5);
 
 const boundaries = calculateNadiParaya({
@@ -38,6 +40,23 @@ const retrograde = calculateNadiParaya({
 assert.equal(retrograde.jupiter.signIndex, 11);
 assert.equal(retrograde.saturn.signIndex, 6);
 assert.equal(retrograde.rahu.signIndex, 11);
+
+const midPeriods = calculateNadiParaya({
+  ageYears: 1,
+  natalJupiterSignIndex: 0,
+  natalSaturnSignIndex: 7,
+  natalRahuSignIndex: 11,
+});
+assert.equal(midPeriods.saturn.degree, 10);
+assert.equal(midPeriods.rahu.degree, 15);
+
+const midJupiter = calculateNadiParaya({
+  ageYears: 0.5,
+  natalJupiterSignIndex: 0,
+  natalSaturnSignIndex: 7,
+  natalRahuSignIndex: 11,
+});
+assert.equal(midJupiter.jupiter.degree, 15);
 
 const saturnCycle = buildParayaTimeline({ body: 'Saturn', natalSignIndex: 0, maxAge: 30 });
 const rahuCycle = buildParayaTimeline({ body: 'Rahu', natalSignIndex: 0, maxAge: 18 });

--- a/src/lib/bnn/nadiParaya.ts
+++ b/src/lib/bnn/nadiParaya.ts
@@ -5,6 +5,7 @@ export type ParayaBody = 'Jupiter' | 'Saturn' | 'Rahu' | 'Ketu';
 export type NadiParayaHouseActivation = {
   body: ParayaBody;
   house: number;
+  degree: number;
 };
 
 export type ParayaPeriod = {
@@ -15,6 +16,7 @@ export type ParayaPeriod = {
   endAge: number;
   durationYears: number;
   cycleNumber: number;
+  degree: number;
 };
 
 export type NadiParayaResult = {
@@ -49,6 +51,11 @@ function periodAtAge(params: {
     const endAgeInCycle = startAgeInCycle + durationYears;
     if (ageInCycle < endAgeInCycle || step === 11) {
       const signIndex = normalizeSign(startSign + params.direction * step);
+      const elapsedInPeriod = Math.max(0, ageInCycle - startAgeInCycle);
+      const progress = Math.max(0, Math.min(1, elapsedInPeriod / durationYears));
+      const degree = params.direction === 1
+        ? progress * 30
+        : Math.min(29.999999, (1 - progress) * 30);
       return {
         body: params.body,
         signIndex,
@@ -57,6 +64,7 @@ function periodAtAge(params: {
         endAge: completedCycles * cycleLength + endAgeInCycle,
         durationYears,
         cycleNumber: completedCycles + 1,
+        degree,
       };
     }
     startAgeInCycle = endAgeInCycle;

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.74',
+    date: '2026-08-10',
+    title: 'Nadi paraya degrees',
+    changes: [
+      'Added the exact in-sign progression degree for Jupiter, Saturn, Rahu and Ketu.',
+      'Forward progressions advance from 0° to 30°; Rahu and Ketu move from 30° toward 0°.',
+      'Current paraya degrees are shown both in the BNN cards and directly on North and South Indian charts.',
+    ],
+  },
+  {
     version: 'v1.73',
     date: '2026-08-10',
     title: 'Nadi paraya chart highlights',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.73';
+export const APP_VERSION = 'v1.74';


### PR DESCRIPTION
## Summary
- calculate the exact in-sign degree reached within each active paraya period
- move Jupiter and Saturn from 0° toward 30°
- move Rahu and Ketu backward from 30° toward 0°
- show degrees in the Nadi Paraya cards and on both chart styles

## Verification
- Nadi paraya boundary and midpoint tests pass
- `npm run build` passes, including TypeScript validation