### PR TITLE
Fix Nadi paraya house alignment

### DIFF
--- a/src/components/NorthIndianChart.tsx
+++ b/src/components/NorthIndianChart.tsx
@@ -77,21 +77,22 @@ type HouseShape = {
   points: string;
   planet: { x: number; y: number };
   sign: { x: number; y: number };
+  paraya: { x: number; y: number; step: number };
 };
 
 const HOUSES: HouseShape[] = [
-  { house: 1,  points: '250,0 375,125 250,250 125,125',     planet: { x: 250, y: 115 }, sign: { x: 250, y: 220 } },
-  { house: 2,  points: '0,0 250,0 125,125',                  planet: { x: 125, y: 70  }, sign: { x: 125, y: 95  } },
-  { house: 3,  points: '0,0 125,125 0,250',                  planet: { x: 55,  y: 130 }, sign: { x: 95,  y: 130 } },
-  { house: 4,  points: '0,250 125,125 250,250 125,375',      planet: { x: 135, y: 250 }, sign: { x: 220, y: 250 } },
-  { house: 5,  points: '0,250 125,375 0,500',                planet: { x: 55,  y: 370 }, sign: { x: 95,  y: 380 } },
-  { house: 6,  points: '0,500 125,375 250,500',              planet: { x: 125, y: 430 }, sign: { x: 125, y: 400 } },
-  { house: 7,  points: '250,500 125,375 250,250 375,375',    planet: { x: 250, y: 390 }, sign: { x: 250, y: 280 } },
-  { house: 8,  points: '250,500 375,375 500,500',            planet: { x: 375, y: 430 }, sign: { x: 375, y: 400 } },
-  { house: 9,  points: '500,500 375,375 500,250',            planet: { x: 445, y: 370 }, sign: { x: 400, y: 380 } },
-  { house: 10, points: '500,250 375,375 250,250 375,125',    planet: { x: 365, y: 250 }, sign: { x: 280, y: 250 } },
-  { house: 11, points: '500,250 375,125 500,0',              planet: { x: 445, y: 130 }, sign: { x: 400, y: 130 } },
-  { house: 12, points: '500,0 375,125 250,0',                planet: { x: 375, y: 70  }, sign: { x: 375, y: 95  } },
+  { house: 1,  points: '250,0 375,125 250,250 125,125',     planet: { x: 250, y: 115 }, sign: { x: 250, y: 220 }, paraya: { x: 250, y: 205, step: -12 } },
+  { house: 2,  points: '0,0 250,0 125,125',                  planet: { x: 125, y: 70  }, sign: { x: 125, y: 95  }, paraya: { x: 125, y: 105, step: -12 } },
+  { house: 3,  points: '0,0 125,125 0,250',                  planet: { x: 55,  y: 130 }, sign: { x: 95,  y: 130 }, paraya: { x: 103, y: 125, step: 12 } },
+  { house: 4,  points: '0,250 125,125 250,250 125,375',      planet: { x: 135, y: 250 }, sign: { x: 220, y: 250 }, paraya: { x: 200, y: 250, step: 12 } },
+  { house: 5,  points: '0,250 125,375 0,500',                planet: { x: 55,  y: 370 }, sign: { x: 95,  y: 380 }, paraya: { x: 103, y: 375, step: -12 } },
+  { house: 6,  points: '0,500 125,375 250,500',              planet: { x: 125, y: 430 }, sign: { x: 125, y: 400 }, paraya: { x: 125, y: 395, step: 12 } },
+  { house: 7,  points: '250,500 125,375 250,250 375,375',    planet: { x: 250, y: 390 }, sign: { x: 250, y: 280 }, paraya: { x: 250, y: 295, step: 12 } },
+  { house: 8,  points: '250,500 375,375 500,500',            planet: { x: 375, y: 430 }, sign: { x: 375, y: 400 }, paraya: { x: 375, y: 395, step: 12 } },
+  { house: 9,  points: '500,500 375,375 500,250',            planet: { x: 445, y: 370 }, sign: { x: 400, y: 380 }, paraya: { x: 397, y: 375, step: -12 } },
+  { house: 10, points: '500,250 375,375 250,250 375,125',    planet: { x: 365, y: 250 }, sign: { x: 280, y: 250 }, paraya: { x: 300, y: 250, step: 12 } },
+  { house: 11, points: '500,250 375,125 500,0',              planet: { x: 445, y: 130 }, sign: { x: 400, y: 130 }, paraya: { x: 420, y: 130, step: 12 } },
+  { house: 12, points: '500,0 375,125 250,0',                planet: { x: 375, y: 70  }, sign: { x: 375, y: 95  }, paraya: { x: 375, y: 105, step: -12 } },
 ];
 
 function getHouseFill(
@@ -289,8 +290,8 @@ export default function NorthIndianChart({
               {parayaHere.map((activation, index) => (
                 <text
                   key={`paraya-label-${activation.body}`}
-                  x={item.sign.x}
-                  y={item.sign.y + (showSigns ? 24 : 10) + index * 12}
+                  x={item.paraya.x}
+                  y={item.paraya.y + index * item.paraya.step}
                   textAnchor="middle"
                   dominantBaseline="middle"
                   fontSize="10"

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.76',
+    date: '2026-08-10',
+    title: 'Paraya house alignment',
+    changes: [
+      'Added a dedicated safe label anchor and stacking direction for every North Indian chart house.',
+      'Corrected Jupiter positioning in house 11 and Ketu positioning in house 2.',
+      'Paraya labels now remain inside triangular and diamond-shaped house boundaries.',
+    ],
+  },
+  {
     version: 'v1.75',
     date: '2026-08-10',
     title: 'Clearer paraya chart labels',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.75';
+export const APP_VERSION = 'v1.76';


### PR DESCRIPTION
## Summary
- replace the shared Paraya label offset with house-specific safe anchors
- correct Jupiter positioning in North Indian house 11
- correct Ketu positioning in North Indian house 2
- stack multiple labels inward according to each house's geometry

## Verification
- `npm run build` passes, including TypeScript validation