### PR TITLE
Add interactive Nadi paraya date calculator

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -942,6 +942,7 @@ export default function Home() {
                     targetDate={targetDate}
                     bnnOverrideStr={bnnOverrideStr}
                     onBnnOverrideStrChange={setBnnOverrideStr}
+                    onTargetDateChange={setTargetDate}
                   />
                 : <EmptyState message="Calculate a chart to see BNN analysis" />
             )}
@@ -958,6 +959,7 @@ export default function Home() {
                     transitLoading={transitLoading}
                     birthDatetime={birthDatetime}
                     targetDate={targetDate}
+                    onTargetDateChange={setTargetDate}
                     chartDisplaySettings={chartDisplaySettings}
                     karakaByPlanet={karakaByPlanet}
                     nakshatraAdjust={nakshatraAdjust}
@@ -1069,6 +1071,7 @@ export default function Home() {
                   targetDate={targetDate}
                   bnnOverrideStr={bnnOverrideStr}
                   onBnnOverrideStrChange={setBnnOverrideStr}
+                  onTargetDateChange={setTargetDate}
                 />
               : <EmptyState message="Calculate a chart in Data to see BNN analysis" />
             }
@@ -1092,6 +1095,7 @@ export default function Home() {
                   transitLoading={transitLoading}
                   birthDatetime={birthDatetime}
                   targetDate={targetDate}
+                  onTargetDateChange={setTargetDate}
                   chartDisplaySettings={chartDisplaySettings}
                   karakaByPlanet={karakaByPlanet}
                   nakshatraAdjust={nakshatraAdjust}

--- a/src/components/BNNEventDetectionPanel.tsx
+++ b/src/components/BNNEventDetectionPanel.tsx
@@ -6,7 +6,7 @@ import { SIGN_NAMES } from '@/lib/varga/index';
 import { calculateJupiterianRounds } from '@/lib/bnn/jupiterianRounds';
 import { calculateMinorProgression } from '@/lib/bnn/jupiterMinorProgression';
 import { detectBNNEventWindows, type BNNEventWindow } from '@/lib/bnn/eventDetection';
-import { calculateNadiParaya, type ParayaPeriod } from '@/lib/bnn/nadiParaya';
+import { calculateNadiParaya, findParayaAgesForPosition, type ParayaBody, type ParayaPeriod } from '@/lib/bnn/nadiParaya';
 
 const SIGN_ABBR: Record<number, string> = {
   1: 'Ar', 2: 'Ta', 3: 'Ge', 4: 'Cn', 5: 'Le', 6: 'Vi',
@@ -201,12 +201,13 @@ interface Props {
   /** Controlled override string — when provided, the local state is ignored */
   bnnOverrideStr?: string;
   onBnnOverrideStrChange?: (v: string) => void;
+  onTargetDateChange?: (v: string) => void;
 }
 
 const INPUT =
   'px-2 py-1.5 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 rounded text-xs font-mono text-zinc-700 dark:text-zinc-300 w-24';
 
-export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDate, bnnOverrideStr, onBnnOverrideStrChange }: Props) {
+export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDate, bnnOverrideStr, onBnnOverrideStrChange, onTargetDateChange }: Props) {
   const natalJupiter = chart.planets.find(p => p.name === 'Jupiter');
   const natalSaturn = chart.planets.find(p => p.name === 'Saturn');
   const natalRahu = chart.planets.find(p => p.name === 'Rahu');
@@ -214,6 +215,9 @@ export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDat
   const natalJupiterDegree = natalJupiter ? natalJupiter.degree : 0;
 
   const [collapsed, setCollapsed] = useState(false);
+  const [positionBody, setPositionBody] = useState<ParayaBody>('Jupiter');
+  const [positionHouse, setPositionHouse] = useState('1');
+  const [positionDegree, setPositionDegree] = useState('0');
 
   const autoAge = useMemo(() => {
     if (!birthDatetime || !targetDate) return null;
@@ -271,6 +275,31 @@ export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDat
     jupiterRetrograde: Boolean(natalJupiter?.isRetrograde),
     saturnRetrograde: Boolean(natalSaturn?.isRetrograde),
   }), [effectiveAge, natalJupiterSignIndex, natalJupiter?.isRetrograde, natalSaturn?.sign, natalSaturn?.isRetrograde, natalRahu?.sign]);
+
+  const positionMatches = useMemo(() => {
+    const house = Math.max(1, Math.min(12, parseInt(positionHouse) || 1));
+    const degree = Math.max(0, Math.min(29.999999, parseFloat(positionDegree) || 0));
+    const targetSignIndex = (chart.ascendant.sign - 1 + house - 1) % 12;
+    return findParayaAgesForPosition({
+      body: positionBody,
+      targetSignIndex,
+      degree,
+      natalJupiterSignIndex,
+      natalSaturnSignIndex: (natalSaturn?.sign ?? 1) - 1,
+      natalRahuSignIndex: (natalRahu?.sign ?? 1) - 1,
+      jupiterRetrograde: Boolean(natalJupiter?.isRetrograde),
+      saturnRetrograde: Boolean(natalSaturn?.isRetrograde),
+      maxAge: 120,
+    }).sort((a, b) => Math.abs(a.ageYears - effectiveAge) - Math.abs(b.ageYears - effectiveAge));
+  }, [positionBody, positionHouse, positionDegree, chart.ascendant.sign, natalJupiterSignIndex, natalJupiter?.isRetrograde, natalSaturn?.sign, natalSaturn?.isRetrograde, natalRahu?.sign, effectiveAge]);
+
+  const birthForPosition = birthDatetime ? parseBirthDatetime(birthDatetime) : null;
+  const matchDate = (ageYears: number): string | null => {
+    if (!birthForPosition) return null;
+    const date = new Date(birthForPosition.getTime() + ageYears * 365.25 * 24 * 60 * 60 * 1000);
+    const pad = (value: number) => String(value).padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+  };
 
   // All hooks above — early return after
   if (!natalJupiter) {
@@ -405,6 +434,53 @@ export default function BNNEventDetectionPanel({ chart, birthDatetime, targetDat
             <p className="text-[9px] font-mono text-zinc-400 dark:text-zinc-600 leading-relaxed">
               Jupiter: 1y/sign forward · Saturn: 3–2 forward · Rahu/Ketu: 2–1 backward. Retrograde Jupiter or Saturn starts one sign earlier.
             </p>
+
+            <div className="rounded-md border border-zinc-200 dark:border-zinc-700 p-2.5 space-y-3">
+              <div>
+                <label className="block text-[9px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600 mb-1">date → positions</label>
+                <input
+                  type="date"
+                  value={targetDate ?? ''}
+                  onChange={event => {
+                    setOverrideStr('');
+                    onTargetDateChange?.(event.target.value);
+                  }}
+                  className="w-full px-2 py-1.5 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 rounded text-xs font-mono text-zinc-700 dark:text-zinc-300"
+                />
+              </div>
+
+              <div className="border-t border-zinc-100 dark:border-zinc-800 pt-2 space-y-2">
+                <div className="text-[9px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600">position → dates</div>
+                <div className="grid grid-cols-3 gap-1.5">
+                  <select value={positionBody} onChange={event => setPositionBody(event.target.value as ParayaBody)} className="min-w-0 px-1.5 py-1.5 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 rounded text-[10px] font-mono">
+                    <option value="Jupiter">Jupiter</option>
+                    <option value="Saturn">Saturn</option>
+                    <option value="Rahu">Rahu</option>
+                    <option value="Ketu">Ketu</option>
+                  </select>
+                  <select value={positionHouse} onChange={event => setPositionHouse(event.target.value)} className="min-w-0 px-1.5 py-1.5 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 rounded text-[10px] font-mono">
+                    {Array.from({ length: 12 }, (_, index) => <option key={index + 1} value={index + 1}>H{index + 1}</option>)}
+                  </select>
+                  <div className="relative">
+                    <input type="number" min="0" max="29.999999" step="0.1" value={positionDegree} onChange={event => setPositionDegree(event.target.value)} className="w-full px-1.5 py-1.5 pr-4 bg-white dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-600 rounded text-[10px] font-mono" />
+                    <span className="absolute right-1.5 top-1.5 text-[10px] text-zinc-400">°</span>
+                  </div>
+                </div>
+                <input type="range" min="0" max="29.9" step="0.1" value={Math.max(0, Math.min(29.9, parseFloat(positionDegree) || 0))} onChange={event => setPositionDegree(event.target.value)} className="w-full accent-emerald-600" />
+                <div className="space-y-1">
+                  {positionMatches.slice(0, 5).map(match => {
+                    const date = matchDate(match.ageYears);
+                    if (!date) return null;
+                    return (
+                      <button key={`${match.cycleNumber}-${match.ageYears}`} type="button" onClick={() => { setOverrideStr(''); onTargetDateChange?.(date); }} className="w-full flex items-center justify-between rounded border border-zinc-200 dark:border-zinc-700 px-2 py-1 text-[10px] font-mono hover:border-emerald-400 dark:hover:border-green-700">
+                        <span>{date}</span>
+                        <span className="text-zinc-400">age {match.ageYears.toFixed(2)} · cycle {match.cycleNumber}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
           </div>
 
           {/* Strong event windows */}

--- a/src/components/NorthIndianChart.tsx
+++ b/src/components/NorthIndianChart.tsx
@@ -82,7 +82,7 @@ type HouseShape = {
 
 const HOUSES: HouseShape[] = [
   { house: 1,  points: '250,0 375,125 250,250 125,125',     planet: { x: 250, y: 115 }, sign: { x: 250, y: 220 }, paraya: { x: 250, y: 205, step: -12 } },
-  { house: 2,  points: '0,0 250,0 125,125',                  planet: { x: 125, y: 70  }, sign: { x: 125, y: 95  }, paraya: { x: 125, y: 105, step: -12 } },
+  { house: 2,  points: '0,0 250,0 125,125',                  planet: { x: 125, y: 70  }, sign: { x: 125, y: 95  }, paraya: { x: 125, y: 25, step: 12 } },
   { house: 3,  points: '0,0 125,125 0,250',                  planet: { x: 55,  y: 130 }, sign: { x: 95,  y: 130 }, paraya: { x: 103, y: 125, step: 12 } },
   { house: 4,  points: '0,250 125,125 250,250 125,375',      planet: { x: 135, y: 250 }, sign: { x: 220, y: 250 }, paraya: { x: 200, y: 250, step: 12 } },
   { house: 5,  points: '0,250 125,375 0,500',                planet: { x: 55,  y: 370 }, sign: { x: 95,  y: 380 }, paraya: { x: 103, y: 375, step: -12 } },
@@ -91,7 +91,7 @@ const HOUSES: HouseShape[] = [
   { house: 8,  points: '250,500 375,375 500,500',            planet: { x: 375, y: 430 }, sign: { x: 375, y: 400 }, paraya: { x: 375, y: 395, step: 12 } },
   { house: 9,  points: '500,500 375,375 500,250',            planet: { x: 445, y: 370 }, sign: { x: 400, y: 380 }, paraya: { x: 397, y: 375, step: -12 } },
   { house: 10, points: '500,250 375,375 250,250 375,125',    planet: { x: 365, y: 250 }, sign: { x: 280, y: 250 }, paraya: { x: 300, y: 250, step: 12 } },
-  { house: 11, points: '500,250 375,125 500,0',              planet: { x: 445, y: 130 }, sign: { x: 400, y: 130 }, paraya: { x: 420, y: 130, step: 12 } },
+  { house: 11, points: '500,250 375,125 500,0',              planet: { x: 445, y: 130 }, sign: { x: 400, y: 130 }, paraya: { x: 465, y: 65, step: 12 } },
   { house: 12, points: '500,0 375,125 250,0',                planet: { x: 375, y: 70  }, sign: { x: 375, y: 95  }, paraya: { x: 375, y: 105, step: -12 } },
 ];
 

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -133,6 +133,7 @@ export interface WorkspaceViewProps {
   transitLoading?: boolean;
   birthDatetime: string;
   targetDate: string;
+  onTargetDateChange: (v: string) => void;
   chartDisplaySettings: ChartDisplaySettings;
   karakaByPlanet: Record<string, string>;
   nakshatraAdjust: number;
@@ -155,6 +156,7 @@ export default function WorkspaceView({
   transitLoading = false,
   birthDatetime,
   targetDate,
+  onTargetDateChange,
   chartDisplaySettings,
   karakaByPlanet,
   nakshatraAdjust,
@@ -309,6 +311,7 @@ export default function WorkspaceView({
                 targetDate={targetDate}
                 bnnOverrideStr={bnnOverrideStr}
                 onBnnOverrideStrChange={onBnnOverrideStrChange}
+                onTargetDateChange={onTargetDateChange}
               />
             </div>
           </div>

--- a/src/lib/bnn/nadiParaya.test.ts
+++ b/src/lib/bnn/nadiParaya.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { buildParayaTimeline, calculateNadiParaya } from './nadiParaya';
+import { buildParayaTimeline, calculateNadiParaya, findParayaAgesForPosition } from './nadiParaya';
 
 const atBirth = calculateNadiParaya({
   ageYears: 0,
@@ -64,5 +64,26 @@ assert.equal(saturnCycle.length, 12);
 assert.equal(saturnCycle.at(-1)?.endAge, 30);
 assert.equal(rahuCycle.length, 12);
 assert.equal(rahuCycle.at(-1)?.endAge, 18);
+
+const jupiterMatches = findParayaAgesForPosition({
+  body: 'Jupiter', targetSignIndex: 0, degree: 15,
+  natalJupiterSignIndex: 0, natalSaturnSignIndex: 7, natalRahuSignIndex: 11,
+  maxAge: 30,
+});
+assert.deepEqual(jupiterMatches.map(match => match.ageYears), [0.5, 12.5, 24.5]);
+
+const rahuMatches = findParayaAgesForPosition({
+  body: 'Rahu', targetSignIndex: 11, degree: 15,
+  natalJupiterSignIndex: 0, natalSaturnSignIndex: 7, natalRahuSignIndex: 11,
+  maxAge: 20,
+});
+assert.deepEqual(rahuMatches.map(match => match.ageYears), [1, 19]);
+
+const ketuMatches = findParayaAgesForPosition({
+  body: 'Ketu', targetSignIndex: 5, degree: 15,
+  natalJupiterSignIndex: 0, natalSaturnSignIndex: 7, natalRahuSignIndex: 11,
+  maxAge: 20,
+});
+assert.deepEqual(ketuMatches.map(match => match.ageYears), [1, 19]);
 
 console.log('Nadi paraya tests passed');

--- a/src/lib/bnn/nadiParaya.ts
+++ b/src/lib/bnn/nadiParaya.ts
@@ -27,6 +27,14 @@ export type NadiParayaResult = {
   ketu: ParayaPeriod;
 };
 
+export type ParayaPositionMatch = {
+  body: ParayaBody;
+  ageYears: number;
+  signIndex: number;
+  degree: number;
+  cycleNumber: number;
+};
+
 function normalizeSign(signIndex: number): number {
   return ((Math.floor(signIndex) % 12) + 12) % 12;
 }
@@ -142,4 +150,53 @@ export function buildParayaTimeline(params: {
     age = period.endAge;
   }
   return periods;
+}
+
+export function findParayaAgesForPosition(params: {
+  body: ParayaBody;
+  targetSignIndex: number;
+  degree: number;
+  natalJupiterSignIndex: number;
+  natalSaturnSignIndex: number;
+  natalRahuSignIndex: number;
+  jupiterRetrograde?: boolean;
+  saturnRetrograde?: boolean;
+  maxAge?: number;
+}): ParayaPositionMatch[] {
+  const maxAge = params.maxAge ?? 120;
+  const targetSignIndex = normalizeSign(params.targetSignIndex);
+  const degree = Math.max(0, Math.min(29.999999, params.degree));
+  const sourceBody = params.body === 'Ketu' ? 'Rahu' : params.body;
+  const sourceTargetSign = params.body === 'Ketu' ? normalizeSign(targetSignIndex - 6) : targetSignIndex;
+  const natalSignIndex = sourceBody === 'Jupiter'
+    ? params.natalJupiterSignIndex
+    : sourceBody === 'Saturn'
+      ? params.natalSaturnSignIndex
+      : params.natalRahuSignIndex;
+  const retrograde = sourceBody === 'Jupiter'
+    ? params.jupiterRetrograde
+    : sourceBody === 'Saturn'
+      ? params.saturnRetrograde
+      : false;
+  const timeline = buildParayaTimeline({
+    body: sourceBody,
+    natalSignIndex,
+    maxAge,
+    retrograde,
+  });
+  const backward = sourceBody === 'Rahu';
+
+  return timeline
+    .filter(period => period.signIndex === sourceTargetSign)
+    .map(period => {
+      const progress = backward ? (30 - degree) / 30 : degree / 30;
+      return {
+        body: params.body,
+        ageYears: period.startAge + progress * period.durationYears,
+        signIndex: targetSignIndex,
+        degree,
+        cycleNumber: period.cycleNumber,
+      };
+    })
+    .filter(match => match.ageYears <= maxAge);
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,16 @@
 export const CHANGELOG = [
   {
+    version: 'v1.77',
+    date: '2026-08-11',
+    title: 'Interactive Nadi paraya date calculator',
+    changes: [
+      'Added a date control that updates all Jupiter, Saturn, Rahu and Ketu paraya positions and chart highlights.',
+      'Added an inverse calculator: choose a body, house and degree to see matching dates and apply one to the chart.',
+      'Rahu and Ketu are calculated as an opposite axis, with matches shown across cycles up to age 120.',
+      'Moved North Indian house 2 and house 11 labels away from triangle tips into clear interior positions.',
+    ],
+  },
+  {
     version: 'v1.76',
     date: '2026-08-10',
     title: 'Paraya house alignment',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.76';
+export const APP_VERSION = 'v1.77';


### PR DESCRIPTION
## Summary
- add a date control that updates all Nadi paraya positions and chart highlights
- add inverse position-to-date lookup by body, whole-sign house, and degree
- show nearest matching dates across progression cycles through age 120
- allow a result date to be applied directly to the chart
- move North Indian house 2 and 11 labels farther inside their triangles

## Verification
- Jupiter, Rahu, and Ketu inverse-position regression tests pass
- existing Nadi paraya boundary and full-cycle tests pass
- `npm run build` passes, including TypeScript validation