### PR TITLE
Add Dasha Event List and automatic transits

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,9 +21,6 @@ import PanchangPanel from '@/components/PanchangPanel';
 import CalculationDebugPanel from '@/components/CalculationDebugPanel';
 import { buildReportMarkdown } from '@/lib/exportReport';
 import FileActions, { ChartSnapshot } from '@/components/FileActions';
-import BcpSummary from '@/components/BcpSummary';
-import BcpManualOverride from '@/components/BcpManualOverride';
-import BNNEventDetectionPanel from '@/components/BNNEventDetectionPanel';
 import WorkspaceView from '@/components/workspace/WorkspaceView';
 import PublicChartsPanel from '@/components/PublicChartsPanel';
 import { ayanamsaLabel } from '@/lib/ayanamsas';
@@ -64,6 +61,12 @@ function getTodayString(): string {
   );
 }
 
+function getNowDateTimeString(): string {
+  const d = new Date();
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()} ${pad(d.getHours())}.${pad(d.getMinutes())}.${pad(d.getSeconds())}`;
+}
+
 function parseTargetDateString(value: string): Date | null {
   const parts = value.split('-');
   if (parts.length !== 3) return null;
@@ -88,7 +91,7 @@ function computeManualBcp(completedAge: number, month: number): BcpResult {
   };
 }
 
-type DesktopTab = 'data' | 'grahas' | 'dasha' | 'bnn' | 'public' | 'workspace' | 'settings';
+type DesktopTab = 'data' | 'grahas' | 'dasha' | 'public' | 'workspace' | 'settings';
 
 type CalculationOptions = {
   preserveCurrentPanel?: boolean;
@@ -478,6 +481,7 @@ export default function Home() {
         } else {
           setChartData(data);
           setTransitPlanets([]);
+          setTransitDatetime((current) => current || getNowDateTimeString());
           if (!options?.preserveCurrentPanel) {
             setActiveTab('chart');
             setDesktopTab('grahas');
@@ -578,6 +582,12 @@ export default function Home() {
       setTransitLoading(false);
     }
   }, [transitDatetime, chartData, manualLat, manualLng, effectiveTzOffset, calculationSettings.ayanamsa, calculationSettings.ayanamsaOffsetDegrees, calculationSettings.nodeMode]);
+
+  useEffect(() => {
+    if (!chartData || !transitDatetime.trim()) return;
+    const timer = window.setTimeout(() => { void handleCalculateTransit(); }, 350);
+    return () => window.clearTimeout(timer);
+  }, [chartData, transitDatetime, handleCalculateTransit]);
 
   const handleExportReport = useCallback(() => {
     const lat = parseFloat(manualLat);
@@ -861,15 +871,6 @@ export default function Home() {
               />
             )}
           </div>
-          {uiMode === 'simple' && dashaSettings.dashas.bcp && effectiveBcpResult && chartData && (
-            <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg p-4">
-              <BcpSummary
-                bcp={effectiveBcpResult}
-                planets={chartData.planets}
-                ascSign={chartData.ascendant.sign}
-              />
-            </div>
-          )}
           {chartDisplaySettings.showPanchang && chartData && (
             <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-lg p-4">
               <PanchangPanel
@@ -886,7 +887,7 @@ export default function Home() {
         {/* Right: tabbed panels */}
         <div className="space-y-3">
           <div className="flex gap-1 bg-zinc-100 dark:bg-zinc-800/50 rounded-lg p-1 overflow-x-auto">
-            {(['data', 'grahas', 'dasha', 'bnn', 'public', ...(chartDisplaySettings.showWorkspace ? ['workspace'] : []), 'settings'] as DesktopTab[]).map((tab) => (
+            {(['data', 'grahas', 'dasha', 'public', ...(chartDisplaySettings.showWorkspace ? ['workspace'] : []), 'settings'] as DesktopTab[]).map((tab) => (
               <button
                 key={tab}
                 onClick={() => setDesktopTab(tab)}
@@ -923,7 +924,6 @@ export default function Home() {
             {desktopTab === 'dasha' && (
               effectiveBcpResult && chartData
                 ? <div className="space-y-4">
-                    {dashaSettings.dashas.bcp && <BcpManualOverride {...bcpManualProps} />}
                     <DashaEventList key={birthDatetime} planets={chartData.planets} ascendant={chartData.ascendant} birthDatetime={birthDatetime} dashaSettings={dashaSettings} />
                     <DashaPanel
                       bcp={effectiveBcpResult}
@@ -934,19 +934,7 @@ export default function Home() {
                       collapsible={uiMode !== 'simple'}
                     />
                   </div>
-                : <EmptyState message="Calculate a chart to see BCP dasha analysis" />
-            )}
-            {desktopTab === 'bnn' && (
-              chartData
-                ? <BNNEventDetectionPanel
-                    chart={chartData}
-                    birthDatetime={birthDatetime}
-                    targetDate={targetDate}
-                    bnnOverrideStr={bnnOverrideStr}
-                    onBnnOverrideStrChange={setBnnOverrideStr}
-                    onTargetDateChange={setTargetDate}
-                  />
-                : <EmptyState message="Calculate a chart to see BNN analysis" />
+                : <EmptyState message="Calculate a chart to see Dasha analysis" />
             )}
             {desktopTab === 'public' && <PublicChartsPanel />}
             {desktopTab === 'workspace' && (
@@ -1000,15 +988,6 @@ export default function Home() {
                 />
               )}
             </Panel>
-            {uiMode === 'simple' && dashaSettings.dashas.bcp && effectiveBcpResult && chartData && (
-              <Panel>
-                <BcpSummary
-                  bcp={effectiveBcpResult}
-                  planets={chartData.planets}
-                  ascSign={chartData.ascendant.sign}
-                />
-              </Panel>
-            )}
             {chartDisplaySettings.showPanchang && chartData && (
               <Panel>
                 <PanchangPanel
@@ -1049,7 +1028,6 @@ export default function Home() {
           <Panel>
             {effectiveBcpResult && chartData
               ? <div className="space-y-4">
-                  {dashaSettings.dashas.bcp && <BcpManualOverride {...bcpManualProps} />}
                   <DashaEventList key={birthDatetime} planets={chartData.planets} ascendant={chartData.ascendant} birthDatetime={birthDatetime} dashaSettings={dashaSettings} />
                   <DashaPanel
                     bcp={effectiveBcpResult}
@@ -1060,23 +1038,7 @@ export default function Home() {
                     collapsible={uiMode !== 'simple'}
                   />
                 </div>
-              : <EmptyState message="Calculate a chart in Data to see BCP dasha analysis" />
-            }
-          </Panel>
-        )}
-
-        {activeTab === 'bnn' && (
-          <Panel>
-            {chartData
-              ? <BNNEventDetectionPanel
-                  chart={chartData}
-                  birthDatetime={birthDatetime}
-                  targetDate={targetDate}
-                  bnnOverrideStr={bnnOverrideStr}
-                  onBnnOverrideStrChange={setBnnOverrideStr}
-                  onTargetDateChange={setTargetDate}
-                />
-              : <EmptyState message="Calculate a chart in Data to see BNN analysis" />
+              : <EmptyState message="Calculate a chart in Data to see Dasha analysis" />
             }
           </Panel>
         )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import DataPanel from '@/components/DataPanel';
 import SettingsPanel from '@/components/SettingsPanel';
 import GrahasPanel from '@/components/GrahasPanel';
 import DashaPanel from '@/components/DashaPanel';
+import DashaEventList from '@/components/DashaEventList';
 import ChartSection from '@/components/ChartSection';
 import PanchangPanel from '@/components/PanchangPanel';
 import CalculationDebugPanel from '@/components/CalculationDebugPanel';
@@ -923,6 +924,7 @@ export default function Home() {
               effectiveBcpResult && chartData
                 ? <div className="space-y-4">
                     {dashaSettings.dashas.bcp && <BcpManualOverride {...bcpManualProps} />}
+                    <DashaEventList key={birthDatetime} planets={chartData.planets} ascendant={chartData.ascendant} birthDatetime={birthDatetime} dashaSettings={dashaSettings} />
                     <DashaPanel
                       bcp={effectiveBcpResult}
                       planets={chartData.planets}
@@ -1048,6 +1050,7 @@ export default function Home() {
             {effectiveBcpResult && chartData
               ? <div className="space-y-4">
                   {dashaSettings.dashas.bcp && <BcpManualOverride {...bcpManualProps} />}
+                  <DashaEventList key={birthDatetime} planets={chartData.planets} ascendant={chartData.ascendant} birthDatetime={birthDatetime} dashaSettings={dashaSettings} />
                   <DashaPanel
                     bcp={effectiveBcpResult}
                     planets={chartData.planets}

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-export type TabId = 'chart' | 'data' | 'grahas' | 'dasha' | 'bnn' | 'public' | 'settings' | 'workspace';
+export type TabId = 'chart' | 'data' | 'grahas' | 'dasha' | 'public' | 'settings' | 'workspace';
 
 interface Tab {
   id: TabId;
@@ -12,7 +12,6 @@ const BASE_TABS: Tab[] = [
   { id: 'data',     label: 'Data' },
   { id: 'grahas',   label: 'Grahas' },
   { id: 'dasha',    label: 'Dasha' },
-  { id: 'bnn',      label: 'BNN' },
   { id: 'public',   label: 'Public' },
   { id: 'settings', label: 'Settings' },
 ];

--- a/src/components/ChartSection.tsx
+++ b/src/components/ChartSection.tsx
@@ -10,7 +10,6 @@ import AshtakavargaPanel from '@/components/AshtakavargaPanel';
 import { calculateJupiterianRounds } from '@/lib/bnn/jupiterianRounds';
 import { calculateMinorProgression } from '@/lib/bnn/jupiterMinorProgression';
 import TransitDateControls from './TransitDateControls';
-import BCPAgeControls from './BCPAgeControls';
 import NadiAmsaPanel from './NadiAmsaPanel';
 import type { NadiParayaHouseActivation } from '@/lib/bnn/nadiParaya';
 
@@ -53,17 +52,6 @@ export interface ChartSectionProps {
   onManualBcpMonthChange?: (v: string) => void;
 }
 
-function isBcpEnabled(): boolean {
-  try {
-    const raw = localStorage.getItem('dashaSettings');
-    if (!raw) return true;
-    const parsed = JSON.parse(raw);
-    return parsed?.dashas?.bcp !== false;
-  } catch {
-    return true;
-  }
-}
-
 export default function ChartSection({
   bcp,
   chart,
@@ -89,7 +77,6 @@ export default function ChartSection({
   onManualBcpMonthChange,
 }: ChartSectionProps) {
   const [chartStyle, setChartStyle] = useState<ChartStyle>(chartDisplaySettings.chartStyle ?? 'north');
-  const [showBcpHighlights, setShowBcpHighlights] = useState<boolean>(isBcpEnabled());
   const [view, setView] = useState<'chart' | 'varga' | 'nadi' | 'ashtakavarga' | 'drishti'>('chart');
 
   const bnnHouses = useMemo(() => {
@@ -129,24 +116,13 @@ export default function ChartSection({
       }
     };
 
-    const handleBcpToggle = (event: Event) => {
-      const customEvent = event as CustomEvent<boolean>;
-      if (typeof customEvent.detail === 'boolean') {
-        setShowBcpHighlights(customEvent.detail);
-        return;
-      }
-      setShowBcpHighlights(isBcpEnabled());
-    };
-
     const handleShowVarga = () => setView('varga');
 
     window.addEventListener('bcp:chart-style-change', handleChartStyleChange);
-    window.addEventListener('bcp:dasha-bcp-toggle', handleBcpToggle);
     window.addEventListener('bcp:show-varga-matrix', handleShowVarga);
 
     return () => {
       window.removeEventListener('bcp:chart-style-change', handleChartStyleChange);
-      window.removeEventListener('bcp:dasha-bcp-toggle', handleBcpToggle);
       window.removeEventListener('bcp:show-varga-matrix', handleShowVarga);
     };
   }, []);
@@ -159,8 +135,8 @@ export default function ChartSection({
     );
   }
 
-  const yearHouse = showBcpHighlights ? bcp.activeYearHouse : 0;
-  const monthHouse = showBcpHighlights ? bcp.activeMonthHouse : 0;
+  const yearHouse = 0;
+  const monthHouse = 0;
   const bnnMajorHouse = chartDisplaySettings.showBnnMajorHighlight ? bnnHouses.major : 0;
   const bnnMinorHouse = chartDisplaySettings.showBnnMinorHighlight ? bnnHouses.minor : 0;
 
@@ -170,12 +146,7 @@ export default function ChartSection({
   return (
     <div className="space-y-3 min-w-0 overflow-x-hidden">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 min-w-0">
-        {showBcpHighlights && view === 'chart' ? (
-          <div className="flex gap-3 text-[11px] sm:text-xs font-mono px-1 min-w-0 whitespace-nowrap overflow-x-auto">
-            <span className="text-cyan-600 dark:text-cyan-400">Y: H{bcp.activeYearHouse}</span>
-            <span className="text-emerald-700 dark:text-green-400">M: H{bcp.activeMonthHouse}</span>
-          </div>
-        ) : <div />}
+        <div />
 
         <div className="w-full sm:w-auto overflow-x-auto">
           <div className="inline-flex min-w-max gap-1 bg-zinc-100 dark:bg-zinc-800/50 rounded-lg p-1">
@@ -206,7 +177,7 @@ export default function ChartSection({
           transitPlanets={transitPlanets}
           showSigns={chartDisplaySettings.showSigns}
           showNatalPlanets={chartDisplaySettings.showNatalPlanets}
-          showTransitPlanets={chartDisplaySettings.showTransitPlanets}
+          showTransitPlanets={transitPlanets.length > 0}
           degreePrecision={chartDisplaySettings.degreePrecision ?? 'off'}
           showCharaKaraka={chartDisplaySettings.showCharaKaraka}
           showNakshatra={chartDisplaySettings.showNakshatra}
@@ -228,13 +199,13 @@ export default function ChartSection({
           transitPlanets={transitPlanets}
           showSigns={chartDisplaySettings.showSigns}
           showNatalPlanets={chartDisplaySettings.showNatalPlanets}
-          showTransitPlanets={chartDisplaySettings.showTransitPlanets}
+          showTransitPlanets={transitPlanets.length > 0}
           degreePrecision={chartDisplaySettings.degreePrecision ?? 'off'}
           showCharaKaraka={chartDisplaySettings.showCharaKaraka}
           showNakshatra={chartDisplaySettings.showNakshatra}
           showOuterPlanets={chartDisplaySettings.showOuterPlanets}
           showSpecialLagnas={chartDisplaySettings.showSpecialLagnas}
-          showBcpHighlights={showBcpHighlights}
+          showBcpHighlights={false}
           karakaByPlanet={karakaByPlanet}
           nakshatraAdjust={nakshatraAdjust}
           bnnMajorHouse={bnnMajorHouse}
@@ -251,18 +222,6 @@ export default function ChartSection({
             onCalculateTransit={onCalculateTransit}
             transitLoading={transitLoading}
           />
-          {bcpEnabled && manualBcpAge !== undefined && onManualBcpAgeChange && manualBcpMonth !== undefined && onManualBcpMonthChange && (
-            <BCPAgeControls
-              useManualBcpMode={useManualBcpMode ?? false}
-              onUseManualBcpModeChange={onUseManualBcpModeChange ?? (() => {})}
-              manualBcpAge={manualBcpAge}
-              onManualBcpAgeChange={onManualBcpAgeChange}
-              manualBcpMonth={manualBcpMonth}
-              onManualBcpMonthChange={onManualBcpMonthChange}
-              activeYearHouse={bcp?.activeYearHouse}
-              activeMonthHouse={bcp?.activeMonthHouse}
-            />
-          )}
         </div>
       )}
     </div>

--- a/src/components/DashaEventList.tsx
+++ b/src/components/DashaEventList.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { type FormEvent, useEffect, useMemo, useState } from 'react';
+import type { DashaSettings, PlanetData } from '@/types';
+import { DEFAULT_DASHA_SETTINGS } from '@/types';
+import { parseDateTime } from '@/lib/bcp';
+import { calculateDashaEventSnapshots } from '@/lib/dashaEvents';
+
+interface Props { planets: PlanetData[]; ascendant: { longitude: number; sign: number; degree: number }; birthDatetime: string; dashaSettings: DashaSettings; }
+interface StoredEvent { id: string; name: string; date: string; }
+function today(): string { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`; }
+function parseEventDate(value: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]), 12);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+function formatDate(value: string): string { const [year, month, day] = value.split('-'); return `${day}.${month}.${year}`; }
+
+export default function DashaEventList({ planets, ascendant, birthDatetime, dashaSettings }: Props) {
+  const storageKey = useMemo(() => `bhrigu:dasha-events:${birthDatetime.trim()}`, [birthDatetime]);
+  const [events, setEvents] = useState<StoredEvent[]>([]);
+  const [storageLoaded, setStorageLoaded] = useState(false);
+  const [name, setName] = useState('');
+  const [date, setDate] = useState(today);
+  const birthDate = parseDateTime(birthDatetime);
+  const charaOptions = dashaSettings.charaOptions ?? DEFAULT_DASHA_SETTINGS.charaOptions;
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      try {
+        const stored = localStorage.getItem(storageKey);
+        const parsed: unknown = stored ? JSON.parse(stored) : [];
+        setEvents(Array.isArray(parsed) ? parsed.filter((item): item is StoredEvent => Boolean(item && typeof item.id === 'string' && typeof item.name === 'string' && typeof item.date === 'string')) : []);
+      } catch { setEvents([]); }
+      setStorageLoaded(true);
+    });
+  }, [storageKey]);
+  useEffect(() => { if (storageLoaded) localStorage.setItem(storageKey, JSON.stringify(events)); }, [events, storageKey, storageLoaded]);
+
+  function addEvent(event: FormEvent) {
+    event.preventDefault();
+    if (!name.trim() || !parseEventDate(date)) return;
+    setEvents((current) => [...current, { id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`, name: name.trim(), date }].sort((a, b) => a.date.localeCompare(b.date)));
+    setName('');
+  }
+
+  return (
+    <section className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50/70 dark:bg-zinc-950/40 p-3 space-y-3">
+      <div><h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Event List</h3><p className="text-[11px] text-zinc-500 dark:text-zinc-400">Save dated life events and compare the active periods in every calculated Dasha system.</p></div>
+      <form onSubmit={addEvent} className="grid grid-cols-1 sm:grid-cols-[1fr_150px_auto] gap-2">
+        <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Event name" aria-label="Event name" className="min-w-0 rounded-md border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2.5 py-2 text-xs" />
+        <input type="date" value={date} onChange={(e) => setDate(e.target.value)} aria-label="Event date" className="rounded-md border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2.5 py-2 text-xs" />
+        <button type="submit" disabled={!name.trim() || !date} className="rounded-md bg-emerald-700 px-3 py-2 text-xs font-semibold text-white disabled:opacity-40">Add event</button>
+      </form>
+      {events.length === 0 ? <p className="py-3 text-center text-xs italic text-zinc-400">No saved events yet.</p> : <div className="space-y-2">
+        {events.map((item, index) => {
+          const eventDate = parseEventDate(item.date);
+          const snapshots = birthDate && eventDate ? calculateDashaEventSnapshots({ eventDate, birthDate, planets, ascendant, charaOptions }) : [];
+          return <details key={item.id} open={index === 0} className="group rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
+            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2">
+              <span className="text-zinc-400 transition-transform group-open:rotate-90">›</span><span className="min-w-0 flex-1 truncate text-xs font-semibold text-zinc-800 dark:text-zinc-100">{item.name}</span><span className="font-mono text-[11px] text-zinc-500">{formatDate(item.date)}</span>
+              <button type="button" onClick={(e) => { e.preventDefault(); setEvents((current) => current.filter((stored) => stored.id !== item.id)); }} className="rounded px-1.5 py-0.5 text-[11px] text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40" aria-label={`Delete ${item.name}`}>Delete</button>
+            </summary>
+            <div className="border-t border-zinc-100 dark:border-zinc-800 px-3 py-2">
+              {snapshots.length ? <div className="divide-y divide-zinc-100 dark:divide-zinc-800">{snapshots.map((snapshot) => <div key={snapshot.key} className="grid grid-cols-[minmax(105px,0.8fr)_minmax(0,1.4fr)] gap-2 py-1.5 text-[11px]">
+                <span className="font-medium text-zinc-600 dark:text-zinc-300">{snapshot.label}</span>
+                {snapshot.levels.length ? <span className="flex flex-wrap gap-x-2 gap-y-1 font-mono">{snapshot.levels.map((level) => <span key={level.level}><span className="text-zinc-400">{level.level}</span> <span className="font-semibold text-emerald-700 dark:text-green-400">{level.value}</span></span>)}</span> : <span className="italic text-zinc-400">{snapshot.note ?? 'Unavailable'}</span>}
+              </div>)}</div> : <p className="text-xs italic text-zinc-400">Invalid birth or event date.</p>}
+            </div>
+          </details>;
+        })}
+      </div>}
+    </section>
+  );
+}

--- a/src/components/TransitDateControls.tsx
+++ b/src/components/TransitDateControls.tsx
@@ -25,7 +25,7 @@ export default function TransitDateControls({
   return (
     <div className="space-y-1.5">
       <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-600">
-        transit datetime
+        transit datetime · updates automatically
       </div>
       <div className="flex gap-1.5 items-center min-w-0">
         <input

--- a/src/components/workspace/WorkspaceView.tsx
+++ b/src/components/workspace/WorkspaceView.tsx
@@ -8,12 +8,9 @@ import type {
 import NorthIndianChart from '../NorthIndianChart';
 import SouthIndianChart from '../SouthIndianChart';
 import TransitDateControls from '../TransitDateControls';
-import BNNEventDetectionPanel from '../BNNEventDetectionPanel';
 import type { NadiParayaHouseActivation } from '@/lib/bnn/nadiParaya';
-import BCPAgeControls from '../BCPAgeControls';
 import GrahasPanel from '../GrahasPanel';
 import DashaPanel from '../DashaPanel';
-import BcpSummary from '../BcpSummary';
 import YogaTable from '../YogaTable';
 import { VargaMatrixCard, VargaStrengthCard, ShadbalaCard, BhavaBalaCard } from '@/pages/VargaMatrix';
 
@@ -22,8 +19,6 @@ import { VargaMatrixCard, VargaStrengthCard, ShadbalaCard, BhavaBalaCard } from 
 const PANEL_OPTIONS: { value: WorkspacePanelType; label: string }[] = [
   { value: 'natal',          label: 'Natal Chart' },
   { value: 'natal-transit',  label: 'Natal + Transit' },
-  { value: 'bcp',            label: 'BCP' },
-  { value: 'bnn',            label: 'BNN' },
   { value: 'vimshottari',    label: 'Vimshottari' },
   { value: 'graha-table',    label: 'Graha Table' },
   { value: 'yoga-table',     label: 'Yoga Table' },
@@ -48,9 +43,9 @@ const PANEL_TITLES: Record<WorkspacePanelType, string> = {
 };
 
 const DEFAULT_PANELS: WorkspacePanel[] = [
-  { id: 'ws-1', title: 'BNN',            type: 'bnn' },
-  { id: 'ws-2', title: 'BCP',            type: 'bcp' },
-  { id: 'ws-3', title: 'Natal + Transit', type: 'natal-transit' },
+  { id: 'ws-1', title: 'Natal + Transit', type: 'natal-transit' },
+  { id: 'ws-2', title: 'Vimshottari',     type: 'vimshottari' },
+  { id: 'ws-3', title: 'Graha Table',     type: 'graha-table' },
 ];
 
 const VIMSHOTTARI_SETTINGS: DashaSettings = {
@@ -173,7 +168,11 @@ export default function WorkspaceView({
       const raw = localStorage.getItem('workspace_panels');
       if (raw) {
         const parsed = JSON.parse(raw) as WorkspacePanel[];
-        if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+        if (Array.isArray(parsed) && parsed.length > 0) return parsed.map((panel) =>
+          panel.type === 'bcp' || panel.type === 'bnn'
+            ? { ...panel, title: 'Natal + Transit', type: 'natal-transit' as const }
+            : panel
+        );
       }
     } catch {}
     return DEFAULT_PANELS;
@@ -182,9 +181,6 @@ export default function WorkspaceView({
   useEffect(() => {
     try { localStorage.setItem('workspace_panels', JSON.stringify(panels)); } catch {}
   }, [panels]);
-
-  // bnnHouses come from parent (already includes age override via effectiveBnnHouses)
-  const bnnHouses = effectiveBnnHouses;
 
   // ── Panel management ──
   const addPanel = useCallback(() => {
@@ -264,56 +260,6 @@ export default function WorkspaceView({
               onCalculateTransit={onCalculateTransit}
               transitLoading={transitLoading}
             />
-          </div>
-        );
-
-      case 'bcp': {
-        const effectiveWorkspaceBcp =
-          bcpManualProps.useManualBcpMode && bcpManualProps.manualBcpResult
-            ? bcpManualProps.manualBcpResult
-            : bcp;
-        return (
-          <div className="space-y-4">
-            {renderChart({
-              yearHouse: effectiveWorkspaceBcp?.activeYearHouse ?? 0,
-              monthHouse: effectiveWorkspaceBcp?.activeMonthHouse ?? 0,
-              legendLayers: { bcp: true, bnn: false, transit: false },
-            })}
-            {bcp && (
-              <div className="border-t border-zinc-100 dark:border-zinc-800 pt-3 space-y-3">
-                <BcpSummary bcp={effectiveWorkspaceBcp ?? bcp} planets={chart.planets} ascSign={chart.ascendant.sign} />
-                {bcpEnabled && (
-                  <BCPAgeControls
-                    useManualBcpMode={bcpManualProps.useManualBcpMode}
-                    onUseManualBcpModeChange={bcpManualProps.onUseManualBcpModeChange}
-                    manualBcpAge={bcpManualProps.manualBcpAge}
-                    onManualBcpAgeChange={bcpManualProps.onManualBcpAgeChange}
-                    manualBcpMonth={bcpManualProps.manualBcpMonth}
-                    onManualBcpMonthChange={bcpManualProps.onManualBcpMonthChange}
-                    activeYearHouse={effectiveWorkspaceBcp?.activeYearHouse ?? bcp?.activeYearHouse}
-                    activeMonthHouse={effectiveWorkspaceBcp?.activeMonthHouse ?? bcp?.activeMonthHouse}
-                  />
-                )}
-              </div>
-            )}
-          </div>
-        );
-      }
-
-      case 'bnn':
-        return (
-          <div className="space-y-4">
-            {renderChart({ bnnMaj: bnnHouses.major, bnnMin: bnnHouses.minor, legendLayers: { bcp: false, bnn: true, transit: false } })}
-            <div className="border-t border-zinc-100 dark:border-zinc-800 pt-3">
-              <BNNEventDetectionPanel
-                chart={chart}
-                birthDatetime={birthDatetime}
-                targetDate={targetDate}
-                bnnOverrideStr={bnnOverrideStr}
-                onBnnOverrideStrChange={onBnnOverrideStrChange}
-                onTargetDateChange={onTargetDateChange}
-              />
-            </div>
           </div>
         );
 

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,15 @@
 export const CHANGELOG = [
   {
+    version: 'v1.79',
+    date: '2026-08-11',
+    title: 'Dasha Event List',
+    changes: [
+      'Added a chart-specific Event List to the Dasha tab with persistent browser storage.',
+      'Each event compares active BCP, Vimsottari, Vimsottari Original, Chara and Kalachakra periods for its date.',
+      'Shows MD–AD–PD for Vimsottari and Chara, MD–AD for Kalachakra, and BCP year/month houses.',
+    ],
+  },
+  {
     version: 'v1.78',
     date: '2026-08-11',
     title: 'Dynamic paraya label layout',

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,12 +1,22 @@
 export const CHANGELOG = [
   {
+    version: 'v1.80',
+    date: '2026-08-11',
+    title: 'Automatic transits and streamlined analysis',
+    changes: [
+      'Removed Bhrigu Chakra Paddhati from Dasha panels, chart highlights, summaries and Workspace choices.',
+      'Removed BNN Event Detection from desktop, mobile and Workspace navigation.',
+      'Transit positions now initialize to the current time, recalculate automatically after date changes and remain visible on the natal chart.',
+    ],
+  },
+  {
     version: 'v1.79',
     date: '2026-08-11',
     title: 'Dasha Event List',
     changes: [
       'Added a chart-specific Event List to the Dasha tab with persistent browser storage.',
-      'Each event compares active BCP, Vimsottari, Vimsottari Original, Chara and Kalachakra periods for its date.',
-      'Shows MD–AD–PD for Vimsottari and Chara, MD–AD for Kalachakra, and BCP year/month houses.',
+      'Each event compares active Vimsottari, Vimsottari Original, Chara and Kalachakra periods for its date.',
+      'Shows MD–AD–PD for Vimsottari and Chara, and MD–AD for Kalachakra.',
     ],
   },
   {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.78';
+export const APP_VERSION = 'v1.79';

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.79';
+export const APP_VERSION = 'v1.80';

--- a/src/lib/dashaEvents.test.ts
+++ b/src/lib/dashaEvents.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { DEFAULT_DASHA_SETTINGS, type PlanetData } from '@/types';
+import { calculateDashaEventSnapshots } from './dashaEvents';
+
+const planets: PlanetData[] = [
+  { name: 'Sun', sign: 6, house: 3, degree: 20, longitude: 170 },
+  { name: 'Moon', sign: 3, house: 12, degree: 6, longitude: 66 },
+  { name: 'Mars', sign: 6, house: 3, degree: 10, longitude: 160 },
+  { name: 'Mercury', sign: 7, house: 4, degree: 20, longitude: 200 },
+  { name: 'Jupiter', sign: 1, house: 10, degree: 3, longitude: 3 },
+  { name: 'Venus', sign: 7, house: 4, degree: 10, longitude: 190 },
+  { name: 'Saturn', sign: 8, house: 5, degree: 24, longitude: 234 },
+  { name: 'Rahu', sign: 12, house: 9, degree: 8, longitude: 338 },
+  { name: 'Ketu', sign: 6, house: 3, degree: 8, longitude: 158 },
+];
+
+const snapshots = calculateDashaEventSnapshots({
+  birthDate: new Date(2000, 0, 1, 10),
+  eventDate: new Date(2001, 0, 1, 12),
+  planets,
+  ascendant: { longitude: 90, sign: 4, degree: 0 },
+  charaOptions: DEFAULT_DASHA_SETTINGS.charaOptions,
+});
+
+assert.deepEqual(snapshots.map((snapshot) => snapshot.key), ['bcp', 'vimshottari', 'vds', 'chara', 'kalaChakra']);
+assert.deepEqual(snapshots[0].levels.map((level) => level.level), ['Year', 'Month']);
+assert.equal(snapshots[1].levels.length, 3);
+assert.equal(snapshots[3].levels.length, 3);
+assert.equal(snapshots[4].levels.length, 2);
+
+const beforeBirth = calculateDashaEventSnapshots({
+  birthDate: new Date(2000, 0, 1),
+  eventDate: new Date(1999, 0, 1),
+  planets,
+  ascendant: { longitude: 90, sign: 4, degree: 0 },
+  charaOptions: DEFAULT_DASHA_SETTINGS.charaOptions,
+});
+assert.ok(beforeBirth.every((snapshot) => snapshot.levels.length === 0 && snapshot.note === 'Date is before birth'));
+
+console.log('Dasha Event List tests passed');

--- a/src/lib/dashaEvents.test.ts
+++ b/src/lib/dashaEvents.test.ts
@@ -22,11 +22,10 @@ const snapshots = calculateDashaEventSnapshots({
   charaOptions: DEFAULT_DASHA_SETTINGS.charaOptions,
 });
 
-assert.deepEqual(snapshots.map((snapshot) => snapshot.key), ['bcp', 'vimshottari', 'vds', 'chara', 'kalaChakra']);
-assert.deepEqual(snapshots[0].levels.map((level) => level.level), ['Year', 'Month']);
-assert.equal(snapshots[1].levels.length, 3);
-assert.equal(snapshots[3].levels.length, 3);
-assert.equal(snapshots[4].levels.length, 2);
+assert.deepEqual(snapshots.map((snapshot) => snapshot.key), ['vimshottari', 'vds', 'chara', 'kalaChakra']);
+assert.equal(snapshots[0].levels.length, 3);
+assert.equal(snapshots[2].levels.length, 3);
+assert.equal(snapshots[3].levels.length, 2);
 
 const beforeBirth = calculateDashaEventSnapshots({
   birthDate: new Date(2000, 0, 1),

--- a/src/lib/dashaEvents.ts
+++ b/src/lib/dashaEvents.ts
@@ -1,5 +1,4 @@
 import type { CharaOptions, PlanetData } from '@/types';
-import { calculateBcp } from './bcp';
 import { calculateCleanCharaMD, calculateCleanCharaSubDashas, type CleanCharaEntry } from './charaClean';
 import { calculateKalachakra, calculateKalachakraAntardashas, type KalachakraEntry } from './kalachakra';
 import { calculateVds } from './vds';
@@ -7,7 +6,7 @@ import { calculateSubDashas, calculateVimshottari, type MahadashaEntry } from '.
 
 export interface DashaEventLevel { level: string; value: string; }
 export interface DashaEventSnapshot {
-  key: 'bcp' | 'vimshottari' | 'vds' | 'chara' | 'kalaChakra';
+  key: 'vimshottari' | 'vds' | 'chara' | 'kalaChakra';
   label: string;
   levels: DashaEventLevel[];
   note?: string;
@@ -47,7 +46,6 @@ function kalachakraLevels(entries: KalachakraEntry[], cycle: number[], date: Dat
 export function calculateDashaEventSnapshots(input: SnapshotInput): DashaEventSnapshot[] {
   const { eventDate, birthDate, planets, ascendant, charaOptions } = input;
   if (eventDate < birthDate) return [
-    { key: 'bcp', label: 'BCP', levels: [], note: 'Date is before birth' },
     { key: 'vimshottari', label: 'Vimsottari', levels: [], note: 'Date is before birth' },
     { key: 'vds', label: 'Vimsottari Original', levels: [], note: 'Date is before birth' },
     { key: 'chara', label: 'Chara Dasha', levels: [], note: 'Date is before birth' },
@@ -56,13 +54,7 @@ export function calculateDashaEventSnapshots(input: SnapshotInput): DashaEventSn
 
   const moon = planets.find((planet) => planet.name === 'Moon');
   const sun = planets.find((planet) => planet.name === 'Sun');
-  const bcp = calculateBcp(birthDate, eventDate);
-  const snapshots: DashaEventSnapshot[] = [{
-    key: 'bcp', label: 'BCP', levels: [
-      { level: 'Year', value: `H${bcp.activeYearHouse}` },
-      { level: 'Month', value: `H${bcp.activeMonthHouse}` },
-    ],
-  }];
+  const snapshots: DashaEventSnapshot[] = [];
 
   snapshots.push(moon ? {
     key: 'vimshottari', label: 'Vimsottari',

--- a/src/lib/dashaEvents.ts
+++ b/src/lib/dashaEvents.ts
@@ -1,0 +1,85 @@
+import type { CharaOptions, PlanetData } from '@/types';
+import { calculateBcp } from './bcp';
+import { calculateCleanCharaMD, calculateCleanCharaSubDashas, type CleanCharaEntry } from './charaClean';
+import { calculateKalachakra, calculateKalachakraAntardashas, type KalachakraEntry } from './kalachakra';
+import { calculateVds } from './vds';
+import { calculateSubDashas, calculateVimshottari, type MahadashaEntry } from './vimshottari';
+
+export interface DashaEventLevel { level: string; value: string; }
+export interface DashaEventSnapshot {
+  key: 'bcp' | 'vimshottari' | 'vds' | 'chara' | 'kalaChakra';
+  label: string;
+  levels: DashaEventLevel[];
+  note?: string;
+}
+interface SnapshotInput {
+  eventDate: Date;
+  birthDate: Date;
+  planets: PlanetData[];
+  ascendant: { longitude: number; sign: number; degree: number };
+  charaOptions: CharaOptions;
+}
+
+function activeEntry<T extends { startDate: Date; endDate: Date }>(entries: T[], date: Date): T | null {
+  return entries.find((entry) => date >= entry.startDate && date < entry.endDate) ?? null;
+}
+function vimshottariLevels(entries: MahadashaEntry[], date: Date): DashaEventLevel[] {
+  const md = activeEntry(entries, date);
+  if (!md) return [];
+  const ad = activeEntry(calculateSubDashas(md), date);
+  const pd = ad ? activeEntry(calculateSubDashas(ad), date) : null;
+  return [{ level: 'MD', value: md.lord }, ...(ad ? [{ level: 'AD', value: ad.lord }] : []), ...(pd ? [{ level: 'PD', value: pd.lord }] : [])];
+}
+function charaLevels(entries: CleanCharaEntry[], date: Date, options: CharaOptions): DashaEventLevel[] {
+  const md = activeEntry(entries, date);
+  if (!md) return [];
+  const ad = activeEntry(calculateCleanCharaSubDashas(md, options), date);
+  const pd = ad ? activeEntry(calculateCleanCharaSubDashas(ad, options), date) : null;
+  return [{ level: 'MD', value: md.abbr }, ...(ad ? [{ level: 'AD', value: ad.abbr }] : []), ...(pd ? [{ level: 'PD', value: pd.abbr }] : [])];
+}
+function kalachakraLevels(entries: KalachakraEntry[], cycle: number[], date: Date): DashaEventLevel[] {
+  const md = activeEntry(entries, date);
+  if (!md) return [];
+  const ad = activeEntry(calculateKalachakraAntardashas(md, cycle), date);
+  return [{ level: 'MD', value: md.signName }, ...(ad ? [{ level: 'AD', value: ad.signName }] : [])];
+}
+
+export function calculateDashaEventSnapshots(input: SnapshotInput): DashaEventSnapshot[] {
+  const { eventDate, birthDate, planets, ascendant, charaOptions } = input;
+  if (eventDate < birthDate) return [
+    { key: 'bcp', label: 'BCP', levels: [], note: 'Date is before birth' },
+    { key: 'vimshottari', label: 'Vimsottari', levels: [], note: 'Date is before birth' },
+    { key: 'vds', label: 'Vimsottari Original', levels: [], note: 'Date is before birth' },
+    { key: 'chara', label: 'Chara Dasha', levels: [], note: 'Date is before birth' },
+    { key: 'kalaChakra', label: 'Kalachakra Dasha', levels: [], note: 'Date is before birth' },
+  ];
+
+  const moon = planets.find((planet) => planet.name === 'Moon');
+  const sun = planets.find((planet) => planet.name === 'Sun');
+  const bcp = calculateBcp(birthDate, eventDate);
+  const snapshots: DashaEventSnapshot[] = [{
+    key: 'bcp', label: 'BCP', levels: [
+      { level: 'Year', value: `H${bcp.activeYearHouse}` },
+      { level: 'Month', value: `H${bcp.activeMonthHouse}` },
+    ],
+  }];
+
+  snapshots.push(moon ? {
+    key: 'vimshottari', label: 'Vimsottari',
+    levels: vimshottariLevels(calculateVimshottari(moon.longitude, birthDate).entries, eventDate),
+  } : { key: 'vimshottari', label: 'Vimsottari', levels: [], note: 'Moon unavailable' });
+
+  const planetLongitudes = Object.fromEntries(planets.map((planet) => [planet.name, planet.longitude]));
+  const vds = moon && sun ? calculateVds({ moonLongitude: moon.longitude, sunLongitude: sun.longitude, lagnaLongitude: ascendant.longitude, lagnaSign: ascendant.sign, lagnaDegree: ascendant.degree, birthDate, planetLongitudes }) : null;
+  snapshots.push({ key: 'vds', label: 'Vimsottari Original', levels: vds ? vimshottariLevels(vds.entries, eventDate) : [], note: vds ? undefined : 'Calculation unavailable' });
+
+  const chara = calculateCleanCharaMD(planets, ascendant.sign, birthDate, charaOptions);
+  snapshots.push({ key: 'chara', label: 'Chara Dasha', levels: chara ? charaLevels(chara.entries, eventDate, charaOptions) : [], note: chara ? undefined : 'Calculation unavailable' });
+
+  if (moon) {
+    const kalachakra = calculateKalachakra(moon.longitude, birthDate);
+    snapshots.push({ key: 'kalaChakra', label: 'Kalachakra Dasha', levels: kalachakraLevels(kalachakra.entries, kalachakra.cycle, eventDate) });
+  } else snapshots.push({ key: 'kalaChakra', label: 'Kalachakra Dasha', levels: [], note: 'Moon unavailable' });
+
+  return snapshots.map((snapshot) => snapshot.levels.length || snapshot.note ? snapshot : { ...snapshot, note: 'Date is outside the calculated cycle' });
+}

--- a/src/lib/dashaRegistry.ts
+++ b/src/lib/dashaRegistry.ts
@@ -2,7 +2,7 @@ import { DashaSettings } from '@/types';
 
 export type DashaKey = keyof DashaSettings['dashas'];
 export type DashaStatus = 'implemented' | 'beta' | 'placeholder';
-export type DashaRendererKey = 'bcp' | 'vimshottari' | 'vds' | 'chara' | 'kalachakra';
+export type DashaRendererKey = 'vimshottari' | 'vds' | 'chara' | 'kalachakra';
 
 export type DashaRegistryItem = {
   key: DashaKey;
@@ -13,7 +13,6 @@ export type DashaRegistryItem = {
 };
 
 export const DASHA_REGISTRY: DashaRegistryItem[] = [
-  { key: 'bcp', label: 'Bhrigu Chakra Paddhati', group: 'Core', status: 'implemented', renderer: 'bcp' },
   { key: 'vimshottari', label: 'Vimsottari', group: 'Core', status: 'implemented', renderer: 'vimshottari' },
   { key: 'vds', label: 'Vimsottari Original', group: 'Core', status: 'implemented', renderer: 'vds' },
 

--- a/src/lib/dashaRenderers.tsx
+++ b/src/lib/dashaRenderers.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react';
 import { BcpResult, PlanetData, CharaOptions } from '@/types';
 import { DashaRendererKey } from './dashaRegistry';
-import BcpSummary from '@/components/BcpSummary';
 import VimshottariPanel from '@/components/VimshottariPanel';
 import VdsPanel from '@/components/VdsPanel';
 import CharaCleanPanel from '@/components/CharaCleanPanel';
@@ -16,9 +15,6 @@ export type DashaRendererContext = {
 };
 
 const RENDERERS: Record<DashaRendererKey, (ctx: DashaRendererContext) => ReactNode> = {
-  bcp: ({ bcp, planets, ascendant }) => (
-    <BcpSummary bcp={bcp} planets={planets} ascSign={ascendant.sign} />
-  ),
   vimshottari: ({ planets, birthDatetime }) => (
     <VimshottariPanel planets={planets} birthDatetime={birthDatetime} />
   ),


### PR DESCRIPTION
## Summary
- add a persistent chart-specific Event List with active Vimsottari, VDS, Chara and Kalachakra periods
- remove Bhrigu Chakra Paddhati from Dasha/chart/Workspace UI
- remove BNN Event Detection navigation and Workspace panel
- initialize transits to now, recalculate automatically after date edits, and keep transit planets visible

## Verification
- `node --import tsx src/lib/dashaEvents.test.ts`
- `npm run build`
- `git diff --check`
