### PR TITLE
Remove BNN controls and North Indian paraya borders

### DIFF
--- a/src/components/NorthIndianChart.tsx
+++ b/src/components/NorthIndianChart.tsx
@@ -256,17 +256,6 @@ export default function NorthIndianChart({
                   strokeDasharray="8,5"
                 />
               )}
-              {parayaHere.map((activation, index) => (
-                <polygon
-                  key={`paraya-border-${activation.body}`}
-                  points={item.points}
-                  fill="none"
-                  stroke={parayaColors[activation.body]}
-                  strokeWidth="4"
-                  strokeDasharray="12,36"
-                  strokeDashoffset={String(index * -12)}
-                />
-              ))}
               {showSigns && (
                 <text x={item.sign.x} y={item.sign.y} textAnchor="middle" dominantBaseline="middle" fontSize="13" fontWeight="600" fill={signFill}>
                   {SIGN_ABBR[sign]}

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -42,7 +42,6 @@ const ADVANCED_TOGGLES: { key: keyof ChartDisplaySettings; label: string }[] = [
   { key: 'showPanchang', label: 'panchang' },
   { key: 'showGrahaDrishti', label: 'graha dṛṣṭi' },
   { key: 'showRashiDrishti', label: 'rāśi dṛṣṭi' },
-  { key: 'showBnnAlpha', label: 'BNN alpha (research)' },
 ];
 
 const CORE_DASHAS = DASHA_REGISTRY.filter(d => d.group === 'Core');
@@ -226,16 +225,6 @@ export default function SettingsPanel(props: Props) {
                   <MiniToggle value={Boolean(chartDisplaySettings[key])} onToggle={() => onToggleChartDisplay(key)} />
                 </div>
               ))}
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-xs font-mono text-zinc-600 dark:text-zinc-300 truncate">BNN highlight</span>
-                <MiniToggle
-                  value={Boolean(chartDisplaySettings.showBnnMajorHighlight || chartDisplaySettings.showBnnMinorHighlight)}
-                  onToggle={() => {
-                    const next = !(chartDisplaySettings.showBnnMajorHighlight || chartDisplaySettings.showBnnMinorHighlight);
-                    onUpdateChartDisplay?.({ showBnnMajorHighlight: next, showBnnMinorHighlight: next });
-                  }}
-                />
-              </div>
             </div>
             <div className="mt-2 flex items-center justify-between gap-2">
               <span className="text-xs font-mono text-zinc-600 dark:text-zinc-300 shrink-0">degrees</span>


### PR DESCRIPTION
## What changed

- Removed the **BNN highlight** toggle from chart overlay settings.
- Removed the **BNN alpha (research)** toggle from advanced settings.
- Removed colored Nadi Paraya border overlays from the North Indian chart.
- Preserved the colored Ju/Sa/Ra/Ke Paraya labels and legend.

## Validation

- `git diff --check` passes.
- Full local lint/build could not run because the execution environment's npm attempted to write to the blocked `/root/.npm` path.