### PR TITLE
Add complete sub-dasha navigation in v1.81

### DIFF
--- a/src/components/CharaCleanPanel.tsx
+++ b/src/components/CharaCleanPanel.tsx
@@ -12,8 +12,22 @@ interface Props {
   settings: CharaOptions;
 }
 
+const LEVELS = ['md', 'ad', 'pd', 'sd', 'prana', 'deha'] as const;
+type Level = (typeof LEVELS)[number];
+const LEVEL_LABEL: Record<Level, string> = { md: 'MD', ad: 'AD', pd: 'PD', sd: 'SD', prana: 'PR', deha: 'DE' };
+
+function fmt(date: Date, withTime = false) {
+  const day = `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${date.getFullYear()}`;
+  return withTime ? `${day} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}` : day;
+}
+
+function entryKey(entry: CleanCharaEntry) {
+  return `${entry.sign}-${entry.startDate.getTime()}`;
+}
+
 export default function CharaCleanPanel({ planets, ascendant, birthDatetime, settings }: Props) {
-  const [selected, setSelected] = useState<CleanCharaEntry | null>(null);
+  const [levelIndex, setLevelIndex] = useState(0);
+  const [path, setPath] = useState<CleanCharaEntry[]>([]);
   const now = useMemo(() => new Date(), []);
   const bd = parseDateTime(birthDatetime);
   const result = bd ? calculateCleanCharaMD(planets, ascendant.sign, bd, settings) : null;
@@ -22,29 +36,61 @@ export default function CharaCleanPanel({ planets, ascendant, birthDatetime, set
     return <div className="text-xs font-mono text-zinc-400">No data</div>;
   }
 
-  const rows = selected ? calculateCleanCharaSubDashas(selected, settings) : result.entries;
-  const fmt = (date: Date) => `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${date.getFullYear()}`;
+  const parent = levelIndex > 0 ? path[levelIndex - 1] : null;
+  const rows = parent ? calculateCleanCharaSubDashas(parent, settings) : result.entries;
   const isActive = (entry: CleanCharaEntry) => entry.startDate <= now && now < entry.endDate;
-  const current = result.entries.find(isActive);
+  const activePath: CleanCharaEntry[] = [];
+  let activeRows = result.entries;
+  for (let index = 0; index < LEVELS.length; index++) {
+    const current = activeRows.find(isActive);
+    if (!current) break;
+    activePath.push(current);
+    activeRows = calculateCleanCharaSubDashas(current, settings);
+  }
+  const currentLevel = LEVELS[levelIndex];
+  const deep = levelIndex >= 2;
+
+  const openEntry = (entry: CleanCharaEntry) => {
+    if (levelIndex >= LEVELS.length - 1) return;
+    setPath(previous => [...previous.slice(0, levelIndex), entry]);
+    setLevelIndex(levelIndex + 1);
+  };
+
+  const goBack = () => {
+    if (levelIndex === 0) return;
+    setLevelIndex(levelIndex - 1);
+    setPath(previous => previous.slice(0, levelIndex - 1));
+  };
+
+  const openNow = () => {
+    if (activePath.length === 0) return;
+    const target = Math.min(activePath.length - 1, LEVELS.length - 1);
+    setPath(activePath.slice(0, target));
+    setLevelIndex(target);
+  };
 
   return (
     <div className="space-y-3 min-w-0">
       <div className="flex items-center justify-between gap-2">
         <div className="font-mono text-xs text-zinc-500 uppercase tracking-widest">&gt; chara daśā</div>
-        {selected && <button type="button" onClick={() => setSelected(null)} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono dark:border-zinc-700">← MD</button>}
+        <button type="button" onClick={openNow} className="rounded border border-cyan-300 px-2 py-1 text-[10px] font-mono text-cyan-700 dark:border-cyan-700 dark:text-cyan-300">NOW</button>
       </div>
       <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-[10px] font-mono text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
         <div>Start: {result.startBasis}</div>
-        {current && <div className="mt-1 text-cyan-700 dark:text-cyan-300">Now: {current.abbr} MD · {fmt(current.startDate)}–{fmt(current.endDate)}</div>}
+        {activePath.length > 0 && <div className="mt-1 text-cyan-700 dark:text-cyan-300">Now: {activePath.map((entry, index) => `${entry.abbr} ${LEVEL_LABEL[LEVELS[index]]}`).join(' › ')}</div>}
       </div>
-      <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400">{selected ? `${selected.abbr} antardaśā` : 'mahādaśā'}</div>
+      <div className="flex items-center justify-between gap-2">
+        <button type="button" onClick={goBack} disabled={levelIndex === 0} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono disabled:opacity-30 dark:border-zinc-700">← back</button>
+        <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400">{LEVEL_LABEL[currentLevel]} · {rows.length} periods</div>
+      </div>
+      {path.length > 0 && <div className="text-[10px] font-mono text-emerald-700 dark:text-emerald-300">{path.map((entry, index) => `${entry.abbr} ${LEVEL_LABEL[LEVELS[index]]}`).join(' › ')} › {LEVEL_LABEL[currentLevel]}</div>}
       <div className="space-y-1">
         {rows.map((entry) => {
           const active = isActive(entry);
           return (
-            <button key={`${entry.sign}-${entry.startDate.getTime()}`} type="button" onClick={() => !selected && setSelected(entry)} className={`w-full rounded-md border px-3 py-2 text-left font-mono text-xs ${active ? 'border-cyan-400 bg-cyan-50 text-cyan-800 dark:border-cyan-600 dark:bg-cyan-950/30 dark:text-cyan-300' : 'border-zinc-200 text-zinc-700 dark:border-zinc-700 dark:text-zinc-200'}`}>
+            <button key={entryKey(entry)} type="button" onClick={() => openEntry(entry)} className={`w-full rounded-md border px-3 py-2 text-left font-mono text-xs ${active ? 'border-cyan-400 bg-cyan-50 text-cyan-800 dark:border-cyan-600 dark:bg-cyan-950/30 dark:text-cyan-300' : 'border-zinc-200 text-zinc-700 dark:border-zinc-700 dark:text-zinc-200'}`}>
               <span className="inline-block w-8 font-bold">{entry.abbr}</span>
-              <span>{fmt(entry.startDate)}–{fmt(entry.endDate)}</span>
+              <span>{fmt(entry.startDate, deep)}–{fmt(entry.endDate, deep)}</span>
               <span className="float-right text-zinc-400">{entry.durationYears.toFixed(2)} y</span>
             </button>
           );

--- a/src/components/KalachakraPanel.tsx
+++ b/src/components/KalachakraPanel.tsx
@@ -3,12 +3,17 @@
 import { useMemo, useState } from 'react';
 import type { PlanetData } from '@/types';
 import { parseDateTime } from '@/lib/bcp';
-import { calculateKalachakra, calculateKalachakraAntardashas, type KalachakraEntry } from '@/lib/kalachakra';
+import { calculateKalachakra, calculateKalachakraSubDashas, type KalachakraEntry } from '@/lib/kalachakra';
 
 const ABBR: Record<string, string> = { Aries:'Ar', Taurus:'Ta', Gemini:'Ge', Cancer:'Cn', Leo:'Le', Virgo:'Vi', Libra:'Li', Scorpio:'Sc', Sagittarius:'Sg', Capricorn:'Cp', Aquarius:'Aq', Pisces:'Pi' };
 
-function fmt(date: Date) {
-  return `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${date.getFullYear()}`;
+const LEVELS = ['md', 'ad', 'pd', 'sd', 'prana', 'deha'] as const;
+type Level = (typeof LEVELS)[number];
+const LEVEL_LABEL: Record<Level, string> = { md: 'MD', ad: 'AD', pd: 'PD', sd: 'SD', prana: 'PR', deha: 'DE' };
+
+function fmt(date: Date, withTime = false) {
+  const day = `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${date.getFullYear()}`;
+  return withTime ? `${day} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}` : day;
 }
 
 function active(entry: KalachakraEntry, now: Date) {
@@ -16,7 +21,8 @@ function active(entry: KalachakraEntry, now: Date) {
 }
 
 export default function KalachakraPanel({ planets, birthDatetime }: { planets: PlanetData[]; birthDatetime: string }) {
-  const [selected, setSelected] = useState<KalachakraEntry | null>(null);
+  const [levelIndex, setLevelIndex] = useState(0);
+  const [path, setPath] = useState<KalachakraEntry[]>([]);
   const now = useMemo(() => new Date(), []);
   const result = useMemo(() => {
     const moon = planets.find((planet) => planet.name === 'Moon');
@@ -27,28 +33,61 @@ export default function KalachakraPanel({ planets, birthDatetime }: { planets: P
 
   if (!result) return <div className="text-xs font-mono text-zinc-400 italic">Moon longitude and valid birth datetime required.</div>;
 
-  const current = result.entries.find((item) => active(item, now)) ?? null;
-  const rows = selected ? calculateKalachakraAntardashas(selected, result.cycle) : result.entries;
+  const parent = levelIndex > 0 ? path[levelIndex - 1] : null;
+  const rows = parent ? calculateKalachakraSubDashas(parent, result.cycle) : result.entries;
+  const activePath: KalachakraEntry[] = [];
+  let activeRows = result.entries;
+  for (let index = 0; index < LEVELS.length; index++) {
+    const current = activeRows.find(item => active(item, now));
+    if (!current) break;
+    activePath.push(current);
+    activeRows = calculateKalachakraSubDashas(current, result.cycle);
+  }
+  const currentLevel = LEVELS[levelIndex];
+  const deep = levelIndex >= 2;
+
+  const openEntry = (entry: KalachakraEntry) => {
+    if (levelIndex >= LEVELS.length - 1) return;
+    setPath(previous => [...previous.slice(0, levelIndex), entry]);
+    setLevelIndex(levelIndex + 1);
+  };
+
+  const goBack = () => {
+    if (levelIndex === 0) return;
+    setLevelIndex(levelIndex - 1);
+    setPath(previous => previous.slice(0, levelIndex - 1));
+  };
+
+  const openNow = () => {
+    if (activePath.length === 0) return;
+    const target = Math.min(activePath.length - 1, LEVELS.length - 1);
+    setPath(activePath.slice(0, target));
+    setLevelIndex(target);
+  };
 
   return (
     <div className="space-y-3 min-w-0">
       <div className="flex items-center justify-between gap-2">
         <div className="font-mono text-xs uppercase tracking-widest text-zinc-500 dark:text-zinc-400">&gt; kālachakra daśā</div>
-        {selected && <button type="button" onClick={() => setSelected(null)} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono dark:border-zinc-700">← MD</button>}
+        <button type="button" onClick={openNow} className="rounded border border-cyan-300 px-2 py-1 text-[10px] font-mono text-cyan-700 dark:border-cyan-700 dark:text-cyan-300">NOW</button>
       </div>
       <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-[10px] font-mono text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300">
         <div>{result.nakshatra} · pada {result.pada} · {result.motion}</div>
         <div>Deha: {ABBR[result.dehaSign]} · Jīva: {ABBR[result.jeevaSign]}</div>
-        {current && <div className="mt-1 text-cyan-700 dark:text-cyan-300">Now: {ABBR[current.signName]} MD · {fmt(current.startDate)}–{fmt(current.endDate)}</div>}
+        {activePath.length > 0 && <div className="mt-1 text-cyan-700 dark:text-cyan-300">Now: {activePath.map((entry, index) => `${ABBR[entry.signName]} ${LEVEL_LABEL[LEVELS[index]]}`).join(' › ')}</div>}
       </div>
-      <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400">{selected ? `${ABBR[selected.signName]} antardaśā` : 'mahādaśā'}</div>
+      <div className="flex items-center justify-between gap-2">
+        <button type="button" onClick={goBack} disabled={levelIndex === 0} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono disabled:opacity-30 dark:border-zinc-700">← back</button>
+        <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400">{LEVEL_LABEL[currentLevel]} · {rows.length} periods</div>
+      </div>
+      {path.length > 0 && <div className="text-[10px] font-mono text-emerald-700 dark:text-emerald-300">{path.map((entry, index) => `${ABBR[entry.signName]} ${LEVEL_LABEL[LEVELS[index]]}`).join(' › ')} › {LEVEL_LABEL[currentLevel]}</div>}
       <div className="space-y-1">
         {rows.map((item) => {
           const isNow = active(item, now);
           return (
-            <button key={`${item.sign}-${item.startDate.getTime()}`} type="button" onClick={() => !selected && setSelected(item)} className={`w-full rounded-md border px-3 py-2 text-left font-mono text-xs ${isNow ? 'border-cyan-400 bg-cyan-50 text-cyan-800 dark:border-cyan-600 dark:bg-cyan-950/30 dark:text-cyan-300' : 'border-zinc-200 text-zinc-700 dark:border-zinc-700 dark:text-zinc-200'}`}>
+            <button key={`${item.sign}-${item.startDate.getTime()}`} type="button" onClick={() => openEntry(item)} className={`w-full rounded-md border px-3 py-2 text-left font-mono text-xs ${isNow ? 'border-cyan-400 bg-cyan-50 text-cyan-800 dark:border-cyan-600 dark:bg-cyan-950/30 dark:text-cyan-300' : 'border-zinc-200 text-zinc-700 dark:border-zinc-700 dark:text-zinc-200'}`}>
               <span className="inline-block w-8 font-bold">{ABBR[item.signName]}</span>
-              <span>{fmt(item.startDate)}–{fmt(item.endDate)}</span>
+              <span>{fmt(item.startDate, deep)}–{fmt(item.endDate, deep)}</span>
               <span className="float-right text-zinc-400">{item.durationYears.toFixed(2)} y</span>
             </button>
           );

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,16 @@
 export const CHANGELOG = [
   {
+    version: 'v1.81',
+    date: '2026-08-11',
+    title: 'Complete sub-dasha navigation',
+    changes: [
+      'Added MD–AD–PD–SD–PR–DE drill-down navigation to Chara and Kalachakra Dasha, matching both Vimsottari systems.',
+      'Added complete active-now period paths and direct NOW navigation to every calculated Dasha panel.',
+      'Removed the BNN highlight and BNN alpha settings toggles.',
+      'Removed colored Nadi Paraya house-border overlays from the North Indian chart while keeping the Paraya labels.',
+    ],
+  },
+  {
     version: 'v1.80',
     date: '2026-08-11',
     title: 'Automatic transits and streamlined analysis',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.80';
+export const APP_VERSION = 'v1.81';

--- a/src/lib/kalachakra.test.ts
+++ b/src/lib/kalachakra.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { calculateKalachakra, calculateKalachakraAntardashas } from './kalachakra';
+import { calculateKalachakra, calculateKalachakraAntardashas, calculateKalachakraSubDashas } from './kalachakra';
 
 const birth = new Date(2000, 0, 1);
 const ashwiniStart = calculateKalachakra(0, birth);
@@ -23,6 +23,13 @@ assert.ok(Math.abs(halfway.entries.reduce((sum, item) => sum + item.durationYear
 const children = calculateKalachakraAntardashas(ashwiniStart.entries[0], ashwiniStart.cycle);
 assert.equal(children.length, 9);
 assert.ok(Math.abs(children.reduce((sum, item) => sum + item.durationYears, 0) - 7) < 1e-10);
+
+const grandchildren = calculateKalachakraSubDashas(children[1], ashwiniStart.cycle);
+assert.equal(grandchildren.length, 9);
+assert.equal(grandchildren[0].signName, children[1].signName);
+assert.equal(grandchildren[0].startDate.getTime(), children[1].startDate.getTime());
+assert.equal(grandchildren.at(-1)!.endDate.getTime(), children[1].endDate.getTime());
+assert.ok(Math.abs(grandchildren.reduce((sum, item) => sum + item.durationYears, 0) - children[1].durationYears) < 1e-10);
 
 const halfwayChildren = calculateKalachakraAntardashas(halfway.entries[0], halfway.cycle);
 assert.ok(halfwayChildren[0].startDate.getTime() === birth.getTime());

--- a/src/lib/kalachakra.ts
+++ b/src/lib/kalachakra.ts
@@ -110,14 +110,17 @@ export function calculateKalachakra(moonLongitude: number, birthDate: Date): Kal
   };
 }
 
-export function calculateKalachakraAntardashas(parent: KalachakraEntry, cycle: number[]): KalachakraEntry[] {
+export function calculateKalachakraSubDashas(parent: KalachakraEntry, cycle: number[]): KalachakraEntry[] {
   const parentIndex = parent.cycleIndex >= 0 ? parent.cycleIndex : cycle.indexOf(parent.sign - 1);
-  const ordered = parentIndex < 0 ? cycle : [...cycle.slice(parentIndex), ...cycle.slice(0, parentIndex)];
-  const totalWeight = ordered.reduce((sum, sign) => sum + SIGN_YEARS[sign], 0);
+  const indexedCycle = cycle.map((sign, cycleIndex) => ({ sign, cycleIndex }));
+  const ordered = parentIndex < 0
+    ? indexedCycle
+    : [...indexedCycle.slice(parentIndex), ...indexedCycle.slice(0, parentIndex)];
+  const totalWeight = ordered.reduce((sum, item) => sum + SIGN_YEARS[item.sign], 0);
   let cursor = addYears(parent.startDate, -parent.elapsedYears);
-  const fullEntries = ordered.map((sign, index) => {
+  const fullEntries = ordered.map(({ sign, cycleIndex }) => {
     const duration = parent.fullDurationYears * SIGN_YEARS[sign] / totalWeight;
-    const item = entry(sign, cursor, duration, index);
+    const item = entry(sign, cursor, duration, cycleIndex);
     cursor = item.endDate;
     return item;
   });
@@ -130,3 +133,5 @@ export function calculateKalachakraAntardashas(parent: KalachakraEntry, cycle: n
       return entry(item.sign - 1, parent.startDate, durationYears, item.cycleIndex, item.fullDurationYears, item.fullDurationYears - durationYears);
     });
 }
+
+export const calculateKalachakraAntardashas = calculateKalachakraSubDashas;


### PR DESCRIPTION
## What changed

- Bumped bhrigu.code to **v1.81**.
- Added MD → AD → PD → SD → PR → DE drill-down navigation to Chara Dasha.
- Added the same six-level drill-down navigation to Kalachakra Dasha.
- Added full active-now paths and NOW navigation to both panels.
- Preserved exact cycle occurrence indexes for repeated Kalachakra signs at deep levels.
- Added a recursive Kalachakra sub-period regression test.
- Documented the previous BNN control and North Indian Paraya border removals in the v1.81 changelog.

## Validation

- Production build passes, including TypeScript and static page generation.
- Kalachakra Dasha regression tests pass.
- `git diff --check` passes.
- Full-project ESLint remains blocked by 12 pre-existing errors in unrelated files; none are in the changed files.