### PR TITLE
Add unified Dasha Timeline in v1.86

### DIFF
--- a/src/components/DashaPanel.tsx
+++ b/src/components/DashaPanel.tsx
@@ -2,6 +2,7 @@ import { BcpResult, PlanetData, DashaSettings, DEFAULT_DASHA_SETTINGS } from '@/
 import { RENDERABLE_DASHAS } from '@/lib/dashaRegistry';
 import { renderDasha, DashaRendererContext } from '@/lib/dashaRenderers';
 import CollapsibleCard from './CollapsibleCard';
+import DashaTimeline from './DashaTimeline';
 
 interface Props {
   bcp: BcpResult;
@@ -30,8 +31,9 @@ export default function DashaPanel({ bcp, planets, ascendant, birthDatetime, das
   if (!collapsible) {
     return (
       <div className="space-y-8">
+        <DashaTimeline planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} normalizedDashas={normalizedDashas} charaOptions={charaOptions} />
         {activeDashas.map(d => (
-          <div key={d.key} className="min-w-0">
+          <div key={d.key} id={`dasha-${d.key}`} className="min-w-0 scroll-mt-4">
             {d.renderer ? renderDasha(d.renderer, ctx) : null}
           </div>
         ))}
@@ -41,10 +43,11 @@ export default function DashaPanel({ bcp, planets, ascendant, birthDatetime, das
 
   return (
     <div className="space-y-2">
+      <DashaTimeline planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} normalizedDashas={normalizedDashas} charaOptions={charaOptions} />
       {activeDashas.map((d, i) => (
-        <CollapsibleCard key={d.key} title={d.label} defaultOpen={i === 0}>
+        <div key={d.key} id={`dasha-${d.key}`} className="scroll-mt-4"><CollapsibleCard title={d.label} defaultOpen={i === 0}>
           {d.renderer ? renderDasha(d.renderer, ctx) : null}
-        </CollapsibleCard>
+        </CollapsibleCard></div>
       ))}
     </div>
   );

--- a/src/components/DashaTimeline.tsx
+++ b/src/components/DashaTimeline.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { CharaOptions, DashaSettings, PlanetData } from '@/types';
+import { calculateDashaEventSnapshots } from '@/lib/dashaEvents';
+import { parseDateTime } from '@/lib/bcp';
+
+interface Props {
+  planets: PlanetData[];
+  ascendant: { longitude: number; sign: number; degree: number };
+  birthDatetime: string;
+  normalizedDashas: DashaSettings['dashas'];
+  charaOptions: CharaOptions;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const KEY_TO_SETTING: Record<string, keyof DashaSettings['dashas']> = {
+  vimshottari: 'vimshottari', vds: 'vds', chara: 'chara', yogini: 'yogini', ashtottari: 'ashtottari',
+  kalaChakra: 'kalaChakra', narayana: 'narayana', moola: 'moola', sthira: 'sthira',
+};
+const COLORS = ['bg-emerald-500', 'bg-cyan-500', 'bg-violet-500', 'bg-amber-500', 'bg-rose-500', 'bg-sky-500', 'bg-lime-600', 'bg-fuchsia-500', 'bg-orange-500'];
+
+function dateValue(date: Date) { return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`; }
+function parseDate(value: string) { const [y, m, d] = value.split('-').map(Number); return new Date(y, m - 1, d, 12); }
+function fmt(date: Date) { return `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${date.getFullYear()}`; }
+
+export default function DashaTimeline({ planets, ascendant, birthDatetime, normalizedDashas, charaOptions }: Props) {
+  const [selectedValue, setSelectedValue] = useState(() => dateValue(new Date()));
+  const birthDate = useMemo(() => parseDateTime(birthDatetime), [birthDatetime]);
+  const selectedDate = useMemo(() => parseDate(selectedValue), [selectedValue]);
+  const snapshots = useMemo(() => birthDate ? calculateDashaEventSnapshots({ eventDate: selectedDate, birthDate, planets, ascendant, charaOptions }) : [], [birthDate, selectedDate, planets, ascendant, charaOptions]);
+  const visible = snapshots.filter(snapshot => normalizedDashas[KEY_TO_SETTING[snapshot.key]]);
+  const windowStart = new Date(selectedDate.getTime() - 10 * 365.25 * DAY_MS);
+  const windowEnd = new Date(selectedDate.getTime() + 10 * 365.25 * DAY_MS);
+  const span = windowEnd.getTime() - windowStart.getTime();
+  const moveYears = (years: number) => { const next = new Date(selectedDate); next.setFullYear(next.getFullYear() + years); setSelectedValue(dateValue(next)); };
+
+  return <section className="space-y-3 rounded-xl border border-zinc-200 bg-zinc-50/70 p-3 dark:border-zinc-700 dark:bg-zinc-950/40">
+    <div className="flex flex-wrap items-center gap-2"><div className="min-w-0 flex-1"><h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Dasha Timeline</h3><p className="text-[10px] text-zinc-500">Active MD–AD–PD on one date · MD bars share a ±10-year scale.</p></div><button type="button" onClick={() => moveYears(-1)} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono dark:border-zinc-700">−1y</button><input type="date" value={selectedValue} onChange={event => { if (event.target.value) setSelectedValue(event.target.value); }} className="rounded border border-zinc-300 bg-white px-2 py-1 text-xs font-mono dark:border-zinc-700 dark:bg-zinc-900"/><button type="button" onClick={() => moveYears(1)} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono dark:border-zinc-700">+1y</button><button type="button" onClick={() => setSelectedValue(dateValue(new Date()))} className="rounded border border-cyan-300 px-2 py-1 text-[10px] font-mono text-cyan-700 dark:border-cyan-700 dark:text-cyan-300">Today</button></div>
+    <div className="relative ml-[112px] h-4 text-[9px] font-mono text-zinc-400"><span className="absolute left-0">{windowStart.getFullYear()}</span><span className="absolute left-1/2 -translate-x-1/2 text-cyan-600">{selectedDate.getFullYear()}</span><span className="absolute right-0">{windowEnd.getFullYear()}</span></div>
+    <div className="space-y-2">{visible.map((snapshot, index) => {
+      const range = snapshot.mdRange;
+      const left = range ? Math.max(0, Math.min(100, (range.startDate.getTime() - windowStart.getTime()) / span * 100)) : 0;
+      const right = range ? Math.max(0, Math.min(100, (range.endDate.getTime() - windowStart.getTime()) / span * 100)) : 0;
+      const width = Math.max(0.75, right - left);
+      return <div key={snapshot.key} className="grid grid-cols-[104px_minmax(0,1fr)] gap-2">
+        <a href={`#dasha-${snapshot.key}`} className="truncate text-[10px] font-semibold text-zinc-600 hover:text-emerald-700 dark:text-zinc-300 dark:hover:text-emerald-300">{snapshot.label} ↘</a>
+        <div className="min-w-0"><div className="relative h-4 overflow-hidden rounded bg-zinc-200 dark:bg-zinc-800"><div className="absolute inset-y-0 left-1/2 z-10 w-px bg-cyan-700"/><div className={`absolute inset-y-0 rounded ${COLORS[index % COLORS.length]} opacity-80`} style={{ left: `${left}%`, width: `${width}%` }} title={range ? `${fmt(range.startDate)}–${fmt(range.endDate)}` : snapshot.note}/></div><div className="mt-0.5 flex flex-wrap gap-x-2 text-[9px] font-mono">{snapshot.levels.map(level => <span key={level.level}><span className="text-zinc-400">{level.level}</span> <span className="font-semibold text-zinc-700 dark:text-zinc-200">{level.value}</span></span>)}{!snapshot.levels.length && <span className="italic text-zinc-400">{snapshot.note ?? 'Outside calculated cycle'}</span>}{range && <span className="ml-auto text-zinc-400">MD {fmt(range.startDate)}–{fmt(range.endDate)}</span>}</div></div>
+      </div>;
+    })}</div>
+  </section>;
+}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,17 @@
 export const CHANGELOG = [
   {
+    version: 'v1.86',
+    date: '2026-08-11',
+    title: 'Unified Dasha Timeline',
+    changes: [
+      'Added one shared timeline above the vertically stacked Dasha panels.',
+      'Added a date selector, ±1-year navigation and Today shortcut for comparing active periods.',
+      'Shows active MD–AD–PD paths and MD ranges for every enabled calculated system on a common ±10-year scale.',
+      'Added direct links from timeline rows to the corresponding Dasha panel.',
+      'Conditional Aṣṭottarī non-applicability is shown directly in the timeline.',
+    ],
+  },
+  {
     version: 'v1.85',
     date: '2026-08-11',
     title: 'Dasha validation and conditional eligibility',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.85';
+export const APP_VERSION = 'v1.86';

--- a/src/lib/dashaEvents.test.ts
+++ b/src/lib/dashaEvents.test.ts
@@ -28,6 +28,8 @@ assert.equal(snapshots[2].levels.length, 3);
 assert.equal(snapshots[3].levels.length, 3);
 assert.equal(snapshots[5].levels.length, 2);
 assert.ok(snapshots.slice(6).every((snapshot) => snapshot.levels.length === 3));
+assert.ok(snapshots.filter(snapshot => snapshot.levels.length).every(snapshot => snapshot.mdRange && snapshot.mdRange.startDate < snapshot.mdRange.endDate));
+assert.ok(snapshots.filter(snapshot => snapshot.mdRange).every(snapshot => snapshot.mdRange!.startDate <= new Date(2001, 0, 1, 12) && snapshot.mdRange!.endDate > new Date(2001, 0, 1, 12)));
 
 const beforeBirth = calculateDashaEventSnapshots({
   birthDate: new Date(2000, 0, 1),

--- a/src/lib/dashaEvents.ts
+++ b/src/lib/dashaEvents.ts
@@ -13,6 +13,7 @@ export interface DashaEventSnapshot {
   key: 'vimshottari' | 'vds' | 'chara' | 'yogini' | 'ashtottari' | 'kalaChakra' | 'narayana' | 'moola' | 'sthira';
   label: string;
   levels: DashaEventLevel[];
+  mdRange?: { startDate: Date; endDate: Date };
   note?: string;
 }
 interface SnapshotInput {
@@ -25,6 +26,10 @@ interface SnapshotInput {
 
 function activeEntry<T extends { startDate: Date; endDate: Date }>(entries: T[], date: Date): T | null {
   return entries.find((entry) => date >= entry.startDate && date < entry.endDate) ?? null;
+}
+function activeRange<T extends { startDate: Date; endDate: Date }>(entries: T[], date: Date) {
+  const md = activeEntry(entries, date);
+  return md ? { startDate: md.startDate, endDate: md.endDate } : undefined;
 }
 function vimshottariLevels(entries: MahadashaEntry[], date: Date): DashaEventLevel[] {
   const md = activeEntry(entries, date);
@@ -80,25 +85,25 @@ export function calculateDashaEventSnapshots(input: SnapshotInput): DashaEventSn
   const sun = planets.find((planet) => planet.name === 'Sun');
   const snapshots: DashaEventSnapshot[] = [];
 
-  snapshots.push(moon ? {
-    key: 'vimshottari', label: 'Vimsottari',
-    levels: vimshottariLevels(calculateVimshottari(moon.longitude, birthDate).entries, eventDate),
+  const vimshottari = moon ? calculateVimshottari(moon.longitude, birthDate).entries : null;
+  snapshots.push(vimshottari ? {
+    key: 'vimshottari', label: 'Vimsottari', levels: vimshottariLevels(vimshottari, eventDate), mdRange: activeRange(vimshottari, eventDate),
   } : { key: 'vimshottari', label: 'Vimsottari', levels: [], note: 'Moon unavailable' });
 
   const planetLongitudes = Object.fromEntries(planets.map((planet) => [planet.name, planet.longitude]));
   const vds = moon && sun ? calculateVds({ moonLongitude: moon.longitude, sunLongitude: sun.longitude, lagnaLongitude: ascendant.longitude, lagnaSign: ascendant.sign, lagnaDegree: ascendant.degree, birthDate, planetLongitudes }) : null;
-  snapshots.push({ key: 'vds', label: 'Vimsottari Original', levels: vds ? vimshottariLevels(vds.entries, eventDate) : [], note: vds ? undefined : 'Calculation unavailable' });
+  snapshots.push({ key: 'vds', label: 'Vimsottari Original', levels: vds ? vimshottariLevels(vds.entries, eventDate) : [], mdRange: vds ? activeRange(vds.entries, eventDate) : undefined, note: vds ? undefined : 'Calculation unavailable' });
 
   const chara = calculateCleanCharaMD(planets, ascendant.sign, birthDate, charaOptions);
-  snapshots.push({ key: 'chara', label: 'Chara Dasha', levels: chara ? charaLevels(chara.entries, eventDate, charaOptions) : [], note: chara ? undefined : 'Calculation unavailable' });
+  snapshots.push({ key: 'chara', label: 'Chara Dasha', levels: chara ? charaLevels(chara.entries, eventDate, charaOptions) : [], mdRange: chara ? activeRange(chara.entries, eventDate) : undefined, note: chara ? undefined : 'Calculation unavailable' });
 
   if (moon) {
     const yogini = calculateYogini(moon.longitude, birthDate);
-    snapshots.push({ key: 'yogini', label: 'Yogini Dasha', levels: nakshatraDashaLevels(yogini.entries, eventDate, calculateYoginiSubDashas) });
+    snapshots.push({ key: 'yogini', label: 'Yogini Dasha', levels: nakshatraDashaLevels(yogini.entries, eventDate, calculateYoginiSubDashas), mdRange: activeRange(yogini.entries, eventDate) });
     const eligibility = evaluateAshtottariEligibility(planets, ascendant.sign);
     const ashtottari = calculateAshtottari(moon.longitude, birthDate);
     snapshots.push(eligibility.eligible
-      ? { key: 'ashtottari', label: 'Ashtottari Dasha', levels: nakshatraDashaLevels(ashtottari.entries, eventDate, calculateAshtottariSubDashas) }
+      ? { key: 'ashtottari', label: 'Ashtottari Dasha', levels: nakshatraDashaLevels(ashtottari.entries, eventDate, calculateAshtottariSubDashas), mdRange: activeRange(ashtottari.entries, eventDate) }
       : { key: 'ashtottari', label: 'Ashtottari Dasha', levels: [], note: `Conditional: not applicable (${eligibility.relativeHouse ?? '?'}H Rahu from Lagna lord)` });
   } else {
     snapshots.push({ key: 'yogini', label: 'Yogini Dasha', levels: [], note: 'Moon unavailable' });
@@ -107,7 +112,7 @@ export function calculateDashaEventSnapshots(input: SnapshotInput): DashaEventSn
 
   if (moon) {
     const kalachakra = calculateKalachakra(moon.longitude, birthDate);
-    snapshots.push({ key: 'kalaChakra', label: 'Kalachakra Dasha', levels: kalachakraLevels(kalachakra.entries, kalachakra.cycle, eventDate) });
+    snapshots.push({ key: 'kalaChakra', label: 'Kalachakra Dasha', levels: kalachakraLevels(kalachakra.entries, kalachakra.cycle, eventDate), mdRange: activeRange(kalachakra.entries, eventDate) });
   } else snapshots.push({ key: 'kalaChakra', label: 'Kalachakra Dasha', levels: [], note: 'Moon unavailable' });
 
   for (const [system, key, label] of [
@@ -116,7 +121,7 @@ export function calculateDashaEventSnapshots(input: SnapshotInput): DashaEventSn
     ['sthira', 'sthira', 'Sthira Dasha'],
   ] as const) {
     const result = calculateRasiDasha(system, planets, ascendant.sign, birthDate);
-    snapshots.push({ key, label, levels: rasiLevels(result.entries, eventDate, planets, system) });
+    snapshots.push({ key, label, levels: rasiLevels(result.entries, eventDate, planets, system), mdRange: activeRange(result.entries, eventDate) });
   }
 
   return snapshots.map((snapshot) => snapshot.levels.length || snapshot.note ? snapshot : { ...snapshot, note: 'Date is outside the calculated cycle' });


### PR DESCRIPTION
## What changed

- adds one shared timeline above the vertically stacked Dasha panels
- compares active MD–AD–PD paths for every enabled calculated system on a selected date
- draws active MD ranges on a common ±10-year scale with one shared date cursor
- adds date input, ±1-year controls, Today shortcut, and direct panel links
- carries conditional Aṣṭottarī non-applicability into the timeline
- bumps bhrigu.code to v1.86

## Why

The separate panels made it slow to compare systems for one date. This gives a single cross-system view without changing the detailed drill-down panels.

## Validation

- focused ESLint: passed
- Next.js 16 production build and TypeScript phase: passed
- timeline range assertions added to Dasha Event snapshot tests