### PR TITLE
Add Event List 2.0 in v1.87

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -924,7 +924,7 @@ export default function Home() {
             {desktopTab === 'dasha' && (
               effectiveBcpResult && chartData
                 ? <div className="space-y-4">
-                    <DashaEventList key={birthDatetime} planets={chartData.planets} ascendant={chartData.ascendant} birthDatetime={birthDatetime} dashaSettings={dashaSettings} />
+                    <DashaEventList key={birthDatetime} planets={chartData.planets} ascendant={chartData.ascendant} birthDatetime={birthDatetime} dashaSettings={dashaSettings} transitPlanets={transitPlanets} transitDatetime={transitDatetime} onSetTransitDatetime={setTransitDatetime} />
                     <DashaPanel
                       bcp={effectiveBcpResult}
                       planets={chartData.planets}
@@ -1028,7 +1028,7 @@ export default function Home() {
           <Panel>
             {effectiveBcpResult && chartData
               ? <div className="space-y-4">
-                  <DashaEventList key={birthDatetime} planets={chartData.planets} ascendant={chartData.ascendant} birthDatetime={birthDatetime} dashaSettings={dashaSettings} />
+                  <DashaEventList key={birthDatetime} planets={chartData.planets} ascendant={chartData.ascendant} birthDatetime={birthDatetime} dashaSettings={dashaSettings} transitPlanets={transitPlanets} transitDatetime={transitDatetime} onSetTransitDatetime={setTransitDatetime} onOpenVargaMatrix={() => { setActiveTab('chart'); window.setTimeout(() => window.dispatchEvent(new CustomEvent('bcp:show-varga-matrix')), 0); }} />
                   <DashaPanel
                     bcp={effectiveBcpResult}
                     planets={chartData.planets}

--- a/src/components/DashaEventList.tsx
+++ b/src/components/DashaEventList.tsx
@@ -4,73 +4,69 @@ import { type FormEvent, useEffect, useMemo, useState } from 'react';
 import type { DashaSettings, PlanetData } from '@/types';
 import { DEFAULT_DASHA_SETTINGS } from '@/types';
 import { parseDateTime } from '@/lib/bcp';
-import { calculateDashaEventSnapshots } from '@/lib/dashaEvents';
+import { calculateDashaEventSnapshots, type DashaEventSnapshot } from '@/lib/dashaEvents';
+import { getVargaSignIndex, SIGN_ABBR } from '@/lib/varga';
 
-interface Props { planets: PlanetData[]; ascendant: { longitude: number; sign: number; degree: number }; birthDatetime: string; dashaSettings: DashaSettings; }
-interface StoredEvent { id: string; name: string; date: string; }
-function today(): string { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`; }
-function parseEventDate(value: string): Date | null {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (!match) return null;
-  const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]), 12);
-  return Number.isNaN(date.getTime()) ? null : date;
+type Category = 'work' | 'money' | 'relationship' | 'health' | 'home' | 'family' | 'spiritual' | 'other';
+type Varga = 'D1' | 'D7' | 'D9' | 'D10' | 'D12' | 'D60';
+type SnapshotKey = DashaEventSnapshot['key'];
+interface Props {
+  planets: PlanetData[];
+  ascendant: { longitude: number; sign: number; degree: number };
+  birthDatetime: string;
+  dashaSettings: DashaSettings;
+  transitPlanets?: PlanetData[];
+  transitDatetime?: string;
+  onSetTransitDatetime?: (value: string) => void;
+  onOpenVargaMatrix?: () => void;
 }
-function formatDate(value: string): string { const [year, month, day] = value.split('-'); return `${day}.${month}.${year}`; }
+interface StoredEvent { id: string; name: string; date: string; category: Category; varga: Varga; }
 
-export default function DashaEventList({ planets, ascendant, birthDatetime, dashaSettings }: Props) {
+const CATEGORY_LABELS: Record<Category, string> = { work: 'Work', money: 'Money', relationship: 'Relationship', health: 'Health', home: 'Home / move', family: 'Family', spiritual: 'Spiritual', other: 'Other' };
+const VARGAS: Varga[] = ['D1', 'D7', 'D9', 'D10', 'D12', 'D60'];
+const KEY_TO_SETTING: Record<SnapshotKey, keyof DashaSettings['dashas']> = { vimshottari: 'vimshottari', vds: 'vds', chara: 'chara', yogini: 'yogini', ashtottari: 'ashtottari', kalaChakra: 'kalaChakra', narayana: 'narayana', moola: 'moola', sthira: 'sthira' };
+
+function today(): string { const d = new Date(); return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`; }
+function parseEventDate(value: string): Date | null { const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value); if (!match) return null; const date = new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]), 12); return Number.isNaN(date.getTime()) ? null : date; }
+function formatDate(value: string): string { const [year, month, day] = value.split('-'); return `${day}.${month}.${year}`; }
+function transitValue(value: string): string { return `${formatDate(value)} 12.00.00`; }
+function transitMatches(value: string, transitDatetime: string) { return transitDatetime.startsWith(formatDate(value)); }
+function download(filename: string, content: string, type: string) { const url = URL.createObjectURL(new Blob([content], { type })); const anchor = document.createElement('a'); anchor.href = url; anchor.download = filename; anchor.click(); URL.revokeObjectURL(url); }
+function csvCell(value: unknown) { return `"${String(value ?? '').replaceAll('"', '""')}"`; }
+
+export default function DashaEventList({ planets, ascendant, birthDatetime, dashaSettings, transitPlanets = [], transitDatetime = '', onSetTransitDatetime, onOpenVargaMatrix }: Props) {
   const storageKey = useMemo(() => `bhrigu:dasha-events:${birthDatetime.trim()}`, [birthDatetime]);
+  const normalizedDashas = useMemo(() => ({ ...DEFAULT_DASHA_SETTINGS.dashas, ...dashaSettings.dashas }), [dashaSettings.dashas]);
+  const enabledKeys = useMemo(() => (Object.keys(KEY_TO_SETTING) as SnapshotKey[]).filter(key => normalizedDashas[KEY_TO_SETTING[key]]), [normalizedDashas]);
   const [events, setEvents] = useState<StoredEvent[]>([]);
+  const [hiddenKeys, setHiddenKeys] = useState<SnapshotKey[]>([]);
   const [storageLoaded, setStorageLoaded] = useState(false);
-  const [name, setName] = useState('');
-  const [date, setDate] = useState(today);
+  const [name, setName] = useState(''); const [date, setDate] = useState(today); const [category, setCategory] = useState<Category>('work'); const [varga, setVarga] = useState<Varga>('D1');
   const birthDate = parseDateTime(birthDatetime);
   const charaOptions = dashaSettings.charaOptions ?? DEFAULT_DASHA_SETTINGS.charaOptions;
 
-  useEffect(() => {
-    queueMicrotask(() => {
-      try {
-        const stored = localStorage.getItem(storageKey);
-        const parsed: unknown = stored ? JSON.parse(stored) : [];
-        setEvents(Array.isArray(parsed) ? parsed.filter((item): item is StoredEvent => Boolean(item && typeof item.id === 'string' && typeof item.name === 'string' && typeof item.date === 'string')) : []);
-      } catch { setEvents([]); }
-      setStorageLoaded(true);
-    });
-  }, [storageKey]);
+  useEffect(() => { queueMicrotask(() => { try { const stored = localStorage.getItem(storageKey); const parsed: unknown = stored ? JSON.parse(stored) : []; setEvents(Array.isArray(parsed) ? parsed.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === 'object' && typeof (item as Record<string, unknown>).id === 'string' && typeof (item as Record<string, unknown>).name === 'string' && typeof (item as Record<string, unknown>).date === 'string')).map(item => ({ id: String(item.id), name: String(item.name), date: String(item.date), category: (item.category as Category) || 'other', varga: (item.varga as Varga) || 'D1' })) : []); } catch { setEvents([]); } setStorageLoaded(true); }); }, [storageKey]);
   useEffect(() => { if (storageLoaded) localStorage.setItem(storageKey, JSON.stringify(events)); }, [events, storageKey, storageLoaded]);
 
-  function addEvent(event: FormEvent) {
-    event.preventDefault();
-    if (!name.trim() || !parseEventDate(date)) return;
-    setEvents((current) => [...current, { id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`, name: name.trim(), date }].sort((a, b) => a.date.localeCompare(b.date)));
-    setName('');
-  }
+  const visibleKeys = enabledKeys.filter(key => !hiddenKeys.includes(key));
+  function snapshotsFor(item: StoredEvent) { const eventDate = parseEventDate(item.date); return birthDate && eventDate ? calculateDashaEventSnapshots({ eventDate, birthDate, planets, ascendant, charaOptions }).filter(snapshot => visibleKeys.includes(snapshot.key)) : []; }
+  function addEvent(event: FormEvent) { event.preventDefault(); if (!name.trim() || !parseEventDate(date)) return; setEvents(current => [...current, { id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`, name: name.trim(), date, category, varga }].sort((a, b) => a.date.localeCompare(b.date))); setName(''); }
+  function updateEvent(id: string, update: Partial<StoredEvent>) { setEvents(current => current.map(item => item.id === id ? { ...item, ...update } : item)); }
+  function toggleKey(key: SnapshotKey) { setHiddenKeys(current => current.includes(key) ? current.filter(item => item !== key) : [...current, key]); }
+  function openVarga() { if (onOpenVargaMatrix) onOpenVargaMatrix(); else window.dispatchEvent(new CustomEvent('bcp:show-varga-matrix')); }
 
-  return (
-    <section className="rounded-lg border border-zinc-200 dark:border-zinc-700 bg-zinc-50/70 dark:bg-zinc-950/40 p-3 space-y-3">
-      <div><h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Event List</h3><p className="text-[11px] text-zinc-500 dark:text-zinc-400">Save dated life events and compare the active periods in every calculated Dasha system.</p></div>
-      <form onSubmit={addEvent} className="grid grid-cols-1 sm:grid-cols-[1fr_150px_auto] gap-2">
-        <input value={name} onChange={(e) => setName(e.target.value)} placeholder="Event name" aria-label="Event name" className="min-w-0 rounded-md border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2.5 py-2 text-xs" />
-        <input type="date" value={date} onChange={(e) => setDate(e.target.value)} aria-label="Event date" className="rounded-md border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2.5 py-2 text-xs" />
-        <button type="submit" disabled={!name.trim() || !date} className="rounded-md bg-emerald-700 px-3 py-2 text-xs font-semibold text-white disabled:opacity-40">Add event</button>
-      </form>
-      {events.length === 0 ? <p className="py-3 text-center text-xs italic text-zinc-400">No saved events yet.</p> : <div className="space-y-2">
-        {events.map((item, index) => {
-          const eventDate = parseEventDate(item.date);
-          const snapshots = birthDate && eventDate ? calculateDashaEventSnapshots({ eventDate, birthDate, planets, ascendant, charaOptions }) : [];
-          return <details key={item.id} open={index === 0} className="group rounded-md border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900">
-            <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2">
-              <span className="text-zinc-400 transition-transform group-open:rotate-90">›</span><span className="min-w-0 flex-1 truncate text-xs font-semibold text-zinc-800 dark:text-zinc-100">{item.name}</span><span className="font-mono text-[11px] text-zinc-500">{formatDate(item.date)}</span>
-              <button type="button" onClick={(e) => { e.preventDefault(); setEvents((current) => current.filter((stored) => stored.id !== item.id)); }} className="rounded px-1.5 py-0.5 text-[11px] text-red-600 hover:bg-red-50 dark:hover:bg-red-950/40" aria-label={`Delete ${item.name}`}>Delete</button>
-            </summary>
-            <div className="border-t border-zinc-100 dark:border-zinc-800 px-3 py-2">
-              {snapshots.length ? <div className="divide-y divide-zinc-100 dark:divide-zinc-800">{snapshots.map((snapshot) => <div key={snapshot.key} className="grid grid-cols-[minmax(105px,0.8fr)_minmax(0,1.4fr)] gap-2 py-1.5 text-[11px]">
-                <span className="font-medium text-zinc-600 dark:text-zinc-300">{snapshot.label}</span>
-                {snapshot.levels.length ? <span className="flex flex-wrap gap-x-2 gap-y-1 font-mono">{snapshot.levels.map((level) => <span key={level.level}><span className="text-zinc-400">{level.level}</span> <span className="font-semibold text-emerald-700 dark:text-green-400">{level.value}</span></span>)}</span> : <span className="italic text-zinc-400">{snapshot.note ?? 'Unavailable'}</span>}
-              </div>)}</div> : <p className="text-xs italic text-zinc-400">Invalid birth or event date.</p>}
-            </div>
-          </details>;
-        })}
-      </div>}
-    </section>
-  );
+  const exportRows = () => events.flatMap(item => snapshotsFor(item).map(snapshot => ({ event: item.name, category: CATEGORY_LABELS[item.category], date: item.date, varga: item.varga, dasha: snapshot.label, MD: snapshot.levels.find(level => level.level === 'MD')?.value ?? '', AD: snapshot.levels.find(level => level.level === 'AD')?.value ?? '', PD: snapshot.levels.find(level => level.level === 'PD')?.value ?? '', note: snapshot.note ?? '' })));
+  function exportCsv() { const rows = exportRows(); const headers = ['event', 'category', 'date', 'varga', 'dasha', 'MD', 'AD', 'PD', 'note']; download('bhrigu-dasha-events.csv', [headers.map(csvCell).join(','), ...rows.map(row => headers.map(header => csvCell(row[header as keyof typeof row])).join(','))].join('\n'), 'text/csv;charset=utf-8'); }
+  function exportJson() { download('bhrigu-dasha-events.json', JSON.stringify({ version: 1, birthDatetime, visibleDashas: visibleKeys, events: events.map(item => ({ ...item, dashas: snapshotsFor(item) })) }, null, 2), 'application/json'); }
+
+  return <section className="space-y-3 rounded-lg border border-zinc-200 bg-zinc-50/70 p-3 dark:border-zinc-700 dark:bg-zinc-950/40">
+    <div className="flex flex-wrap items-start gap-2"><div className="min-w-0 flex-1"><h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Event List 2.0</h3><p className="text-[11px] text-zinc-500 dark:text-zinc-400">Classify events, compare enabled Dashas, connect transits and export the data.</p></div><button type="button" onClick={exportCsv} disabled={!events.length} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono disabled:opacity-30 dark:border-zinc-700">CSV</button><button type="button" onClick={exportJson} disabled={!events.length} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono disabled:opacity-30 dark:border-zinc-700">JSON</button></div>
+    <form onSubmit={addEvent} className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(150px,1fr)_140px_130px_80px_auto]"><input value={name} onChange={event => setName(event.target.value)} placeholder="Event name" aria-label="Event name" className="min-w-0 rounded-md border border-zinc-300 bg-white px-2.5 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-900"/><input type="date" value={date} onChange={event => setDate(event.target.value)} aria-label="Event date" className="rounded-md border border-zinc-300 bg-white px-2.5 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-900"/><select value={category} onChange={event => setCategory(event.target.value as Category)} aria-label="Event category" className="rounded-md border border-zinc-300 bg-white px-2 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-900">{Object.entries(CATEGORY_LABELS).map(([key, label]) => <option key={key} value={key}>{label}</option>)}</select><select value={varga} onChange={event => setVarga(event.target.value as Varga)} aria-label="Event varga" className="rounded-md border border-zinc-300 bg-white px-2 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-900">{VARGAS.map(item => <option key={item}>{item}</option>)}</select><button type="submit" disabled={!name.trim() || !date} className="rounded-md bg-emerald-700 px-3 py-2 text-xs font-semibold text-white disabled:opacity-40">Add</button></form>
+    <div><div className="mb-1 text-[9px] font-mono uppercase tracking-widest text-zinc-400">Visible enabled Dashas</div><div className="flex flex-wrap gap-1">{enabledKeys.map(key => <button type="button" key={key} onClick={() => toggleKey(key)} className={`rounded border px-1.5 py-0.5 text-[9px] font-mono ${visibleKeys.includes(key) ? 'border-emerald-400 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-300' : 'border-zinc-300 text-zinc-400 dark:border-zinc-700'}`}>{key}</button>)}</div></div>
+    {!events.length ? <p className="py-3 text-center text-xs italic text-zinc-400">No saved events yet.</p> : <div className="space-y-2">{events.map((item, index) => { const snapshots = snapshotsFor(item); const matchingTransit = transitMatches(item.date, transitDatetime); const division = Number(item.varga.slice(1)); return <details key={item.id} open={index === 0} className="group rounded-md border border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900"><summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2"><span className="text-zinc-400 transition-transform group-open:rotate-90">›</span><span className="min-w-0 flex-1 truncate text-xs font-semibold">{item.name}</span><span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[9px] text-zinc-500 dark:bg-zinc-800">{CATEGORY_LABELS[item.category]}</span><span className="font-mono text-[11px] text-zinc-500">{formatDate(item.date)}</span><button type="button" onClick={event => { event.preventDefault(); setEvents(current => current.filter(stored => stored.id !== item.id)); }} className="rounded px-1.5 py-0.5 text-[11px] text-red-600" aria-label={`Delete ${item.name}`}>Delete</button></summary>
+      <div className="space-y-3 border-t border-zinc-100 px-3 py-2 dark:border-zinc-800"><div className="flex flex-wrap items-center gap-2"><label className="text-[10px] text-zinc-500">Category <select value={item.category} onChange={event => updateEvent(item.id, { category: event.target.value as Category })} className="ml-1 rounded border border-zinc-300 bg-white px-1.5 py-1 dark:border-zinc-700 dark:bg-zinc-900">{Object.entries(CATEGORY_LABELS).map(([key, label]) => <option key={key} value={key}>{label}</option>)}</select></label><label className="text-[10px] text-zinc-500">Varga <select value={item.varga} onChange={event => updateEvent(item.id, { varga: event.target.value as Varga })} className="ml-1 rounded border border-zinc-300 bg-white px-1.5 py-1 dark:border-zinc-700 dark:bg-zinc-900">{VARGAS.map(value => <option key={value}>{value}</option>)}</select></label><button type="button" onClick={openVarga} className="rounded border border-zinc-300 px-2 py-1 text-[10px] dark:border-zinc-700">Open Varga Matrix</button>{onSetTransitDatetime && <button type="button" onClick={() => onSetTransitDatetime(transitValue(item.date))} className="rounded border border-violet-300 px-2 py-1 text-[10px] text-violet-700 dark:border-violet-700 dark:text-violet-300">Set as transit</button>}</div>
+      <div className="text-[9px] font-mono text-zinc-400">{item.varga}: {planets.map(planet => `${planet.name.slice(0, 2)} ${SIGN_ABBR[getVargaSignIndex(planet.longitude, division)]}`).join(' · ')}</div>
+      {matchingTransit && <div className="rounded border border-violet-200 bg-violet-50/50 p-2 text-[9px] font-mono text-violet-700 dark:border-violet-900 dark:bg-violet-950/20 dark:text-violet-300">Transit {transitDatetime}: {transitPlanets.length ? transitPlanets.map(planet => `${planet.name.slice(0, 2)} ${SIGN_ABBR[planet.sign - 1]}`).join(' · ') : 'calculating or unavailable'}</div>}
+      {snapshots.length ? <div className="divide-y divide-zinc-100 dark:divide-zinc-800">{snapshots.map(snapshot => <div key={snapshot.key} className="grid grid-cols-[minmax(105px,0.8fr)_minmax(0,1.4fr)] gap-2 py-1.5 text-[11px]"><span className="font-medium text-zinc-600 dark:text-zinc-300">{snapshot.label}</span>{snapshot.levels.length ? <span className="flex flex-wrap gap-x-2 gap-y-1 font-mono">{snapshot.levels.map(level => <span key={level.level}><span className="text-zinc-400">{level.level}</span> <span className="font-semibold text-emerald-700 dark:text-green-400">{level.value}</span></span>)}</span> : <span className="italic text-zinc-400">{snapshot.note ?? 'Unavailable'}</span>}</div>)}</div> : <p className="text-xs italic text-zinc-400">No visible Dasha systems or invalid date.</p>}</div></details>; })}</div>}
+  </section>;
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,18 @@
 export const CHANGELOG = [
   {
+    version: 'v1.87',
+    date: '2026-08-11',
+    title: 'Event List 2.0',
+    changes: [
+      'Added editable event categories and D1/D7/D9/D10/D12/D60 analysis contexts.',
+      'The Event List now shows only enabled Dasha systems and provides additional per-system visibility filters.',
+      'Added CSV and JSON exports containing events and active MD–AD–PD periods.',
+      'Added Set as transit to calculate the existing transit view for an event date and show the resulting transit positions in the event.',
+      'Added calculated natal varga positions and a direct Open Varga Matrix action for every event.',
+      'Existing saved events migrate automatically with Other and D1 defaults.',
+    ],
+  },
+  {
     version: 'v1.86',
     date: '2026-08-11',
     title: 'Unified Dasha Timeline',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.86';
+export const APP_VERSION = 'v1.87';


### PR DESCRIPTION
## What changed

- adds editable event categories and D1/D7/D9/D10/D12/D60 analysis contexts
- limits Event List results to enabled Dasha systems and adds local visibility filters
- adds CSV and JSON exports with active MD–AD–PD periods
- connects Set as transit to the app's existing automatic transit calculation and displays matching transit positions
- calculates selected natal varga positions per event and links to Varga Matrix
- migrates existing saved events with safe Other/D1 defaults
- bumps bhrigu.code to v1.87

## Why

The first Event List only stored a name and date and always rendered every calculated system. Event List 2.0 makes the stored data reusable and connects it to the app's actual transit and varga workflows.

## Validation

- focused Event List ESLint: passed
- Next.js 16 production build and TypeScript phase: passed