### PR TITLE
Add Dasha method settings in v1.88

### DIFF
--- a/src/components/DashaEventList.tsx
+++ b/src/components/DashaEventList.tsx
@@ -44,12 +44,13 @@ export default function DashaEventList({ planets, ascendant, birthDatetime, dash
   const [name, setName] = useState(''); const [date, setDate] = useState(today); const [category, setCategory] = useState<Category>('work'); const [varga, setVarga] = useState<Varga>('D1');
   const birthDate = parseDateTime(birthDatetime);
   const charaOptions = dashaSettings.charaOptions ?? DEFAULT_DASHA_SETTINGS.charaOptions;
+  const rasiOptions = { ...DEFAULT_DASHA_SETTINGS.rasiOptions, ...dashaSettings.rasiOptions };
 
   useEffect(() => { queueMicrotask(() => { try { const stored = localStorage.getItem(storageKey); const parsed: unknown = stored ? JSON.parse(stored) : []; setEvents(Array.isArray(parsed) ? parsed.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === 'object' && typeof (item as Record<string, unknown>).id === 'string' && typeof (item as Record<string, unknown>).name === 'string' && typeof (item as Record<string, unknown>).date === 'string')).map(item => ({ id: String(item.id), name: String(item.name), date: String(item.date), category: (item.category as Category) || 'other', varga: (item.varga as Varga) || 'D1' })) : []); } catch { setEvents([]); } setStorageLoaded(true); }); }, [storageKey]);
   useEffect(() => { if (storageLoaded) localStorage.setItem(storageKey, JSON.stringify(events)); }, [events, storageKey, storageLoaded]);
 
   const visibleKeys = enabledKeys.filter(key => !hiddenKeys.includes(key));
-  function snapshotsFor(item: StoredEvent) { const eventDate = parseEventDate(item.date); return birthDate && eventDate ? calculateDashaEventSnapshots({ eventDate, birthDate, planets, ascendant, charaOptions }).filter(snapshot => visibleKeys.includes(snapshot.key)) : []; }
+  function snapshotsFor(item: StoredEvent) { const eventDate = parseEventDate(item.date); return birthDate && eventDate ? calculateDashaEventSnapshots({ eventDate, birthDate, planets, ascendant, charaOptions, rasiOptions }).filter(snapshot => visibleKeys.includes(snapshot.key)) : []; }
   function addEvent(event: FormEvent) { event.preventDefault(); if (!name.trim() || !parseEventDate(date)) return; setEvents(current => [...current, { id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}`, name: name.trim(), date, category, varga }].sort((a, b) => a.date.localeCompare(b.date))); setName(''); }
   function updateEvent(id: string, update: Partial<StoredEvent>) { setEvents(current => current.map(item => item.id === id ? { ...item, ...update } : item)); }
   function toggleKey(key: SnapshotKey) { setHiddenKeys(current => current.includes(key) ? current.filter(item => item !== key) : [...current, key]); }

--- a/src/components/DashaPanel.tsx
+++ b/src/components/DashaPanel.tsx
@@ -16,6 +16,7 @@ interface Props {
 export default function DashaPanel({ bcp, planets, ascendant, birthDatetime, dashaSettings, collapsible = false }: Props) {
   const normalizedDashas = { ...DEFAULT_DASHA_SETTINGS.dashas, ...dashaSettings.dashas };
   const charaOptions = dashaSettings.charaOptions ?? DEFAULT_DASHA_SETTINGS.charaOptions;
+  const rasiOptions = { ...DEFAULT_DASHA_SETTINGS.rasiOptions, ...dashaSettings.rasiOptions };
   const activeDashas = RENDERABLE_DASHAS.filter(d => d.renderer && normalizedDashas[d.key]);
 
   if (activeDashas.length === 0) {
@@ -26,12 +27,12 @@ export default function DashaPanel({ bcp, planets, ascendant, birthDatetime, das
     );
   }
 
-  const ctx: DashaRendererContext = { bcp, planets, ascendant, birthDatetime, charaOptions };
+  const ctx: DashaRendererContext = { bcp, planets, ascendant, birthDatetime, charaOptions, rasiOptions };
 
   if (!collapsible) {
     return (
       <div className="space-y-8">
-        <DashaTimeline planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} normalizedDashas={normalizedDashas} charaOptions={charaOptions} />
+        <DashaTimeline planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} normalizedDashas={normalizedDashas} charaOptions={charaOptions} rasiOptions={rasiOptions} />
         {activeDashas.map(d => (
           <div key={d.key} id={`dasha-${d.key}`} className="min-w-0 scroll-mt-4">
             {d.renderer ? renderDasha(d.renderer, ctx) : null}
@@ -43,7 +44,7 @@ export default function DashaPanel({ bcp, planets, ascendant, birthDatetime, das
 
   return (
     <div className="space-y-2">
-      <DashaTimeline planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} normalizedDashas={normalizedDashas} charaOptions={charaOptions} />
+      <DashaTimeline planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} normalizedDashas={normalizedDashas} charaOptions={charaOptions} rasiOptions={rasiOptions} />
       {activeDashas.map((d, i) => (
         <div key={d.key} id={`dasha-${d.key}`} className="scroll-mt-4"><CollapsibleCard title={d.label} defaultOpen={i === 0}>
           {d.renderer ? renderDasha(d.renderer, ctx) : null}

--- a/src/components/DashaTimeline.tsx
+++ b/src/components/DashaTimeline.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import type { CharaOptions, DashaSettings, PlanetData } from '@/types';
+import type { CharaOptions, DashaSettings, PlanetData, RasiDashaOptions } from '@/types';
 import { calculateDashaEventSnapshots } from '@/lib/dashaEvents';
 import { parseDateTime } from '@/lib/bcp';
 
@@ -11,6 +11,7 @@ interface Props {
   birthDatetime: string;
   normalizedDashas: DashaSettings['dashas'];
   charaOptions: CharaOptions;
+  rasiOptions: RasiDashaOptions;
 }
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -24,11 +25,11 @@ function dateValue(date: Date) { return `${date.getFullYear()}-${String(date.get
 function parseDate(value: string) { const [y, m, d] = value.split('-').map(Number); return new Date(y, m - 1, d, 12); }
 function fmt(date: Date) { return `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${date.getFullYear()}`; }
 
-export default function DashaTimeline({ planets, ascendant, birthDatetime, normalizedDashas, charaOptions }: Props) {
+export default function DashaTimeline({ planets, ascendant, birthDatetime, normalizedDashas, charaOptions, rasiOptions }: Props) {
   const [selectedValue, setSelectedValue] = useState(() => dateValue(new Date()));
   const birthDate = useMemo(() => parseDateTime(birthDatetime), [birthDatetime]);
   const selectedDate = useMemo(() => parseDate(selectedValue), [selectedValue]);
-  const snapshots = useMemo(() => birthDate ? calculateDashaEventSnapshots({ eventDate: selectedDate, birthDate, planets, ascendant, charaOptions }) : [], [birthDate, selectedDate, planets, ascendant, charaOptions]);
+  const snapshots = useMemo(() => birthDate ? calculateDashaEventSnapshots({ eventDate: selectedDate, birthDate, planets, ascendant, charaOptions, rasiOptions }) : [], [birthDate, selectedDate, planets, ascendant, charaOptions, rasiOptions]);
   const visible = snapshots.filter(snapshot => normalizedDashas[KEY_TO_SETTING[snapshot.key]]);
   const windowStart = new Date(selectedDate.getTime() - 10 * 365.25 * DAY_MS);
   const windowEnd = new Date(selectedDate.getTime() + 10 * 365.25 * DAY_MS);

--- a/src/components/RasiDashaPanel.tsx
+++ b/src/components/RasiDashaPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import type { PlanetData } from '@/types';
+import type { RasiDashaOptions } from '@/types';
 import { parseDateTime } from '@/lib/bcp';
 import { calculateRasiDasha, calculateRasiSubDashas, type RasiDashaEntry, type RasiDashaSystem } from '@/lib/rasiDashas';
 
@@ -18,14 +19,14 @@ function fmt(date: Date, withTime: boolean) {
   return withTime ? `${day} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}` : day;
 }
 
-export default function RasiDashaPanel({ system, planets, ascendant, birthDatetime }: { system: RasiDashaSystem; planets: PlanetData[]; ascendant: { sign: number }; birthDatetime: string }) {
+export default function RasiDashaPanel({ system, planets, ascendant, birthDatetime, options }: { system: RasiDashaSystem; planets: PlanetData[]; ascendant: { sign: number }; birthDatetime: string; options: RasiDashaOptions }) {
   const [level, setLevel] = useState(0);
   const [path, setPath] = useState<RasiDashaEntry[]>([]);
   const now = useMemo(() => new Date(), []);
   const result = useMemo(() => {
     const birth = parseDateTime(birthDatetime);
-    return birth ? calculateRasiDasha(system, planets, ascendant.sign, birth) : null;
-  }, [system, planets, ascendant.sign, birthDatetime]);
+    return birth ? calculateRasiDasha(system, planets, ascendant.sign, birth, options) : null;
+  }, [system, planets, ascendant.sign, birthDatetime, options]);
   if (!result) return <div className="text-xs font-mono text-zinc-400">Valid birth datetime required.</div>;
 
   const children = (entry: RasiDashaEntry) => calculateRasiSubDashas(entry, planets, system);

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ChartDisplaySettings, CalculationSettings, DashaSettings, DEFAULT_DASHA_SETTINGS } from '@/types';
+import { ChartDisplaySettings, CalculationSettings, CharaOptions, DashaSettings, DEFAULT_DASHA_SETTINGS, RasiDashaOptions } from '@/types';
 import { type DegreePrecision } from '@/lib/formatDegree';
 import { APP_NAME, APP_VERSION } from '@/lib/config';
 import { DASHA_REGISTRY, DashaKey } from '@/lib/dashaRegistry';
@@ -77,10 +77,26 @@ export default function SettingsPanel(props: Props) {
   } = props;
 
   const [displayOpen, setDisplayOpen] = useState(true);
+  const [methodsOpen, setMethodsOpen] = useState(false);
   const [aboutOpen, setAboutOpen] = useState(false);
   const selectedChartStyle = chartDisplaySettings.chartStyle ?? 'north';
 
   const normalizedDashas = { ...DEFAULT_DASHA_SETTINGS.dashas, ...dashaSettings.dashas };
+  const charaOptions = { ...DEFAULT_DASHA_SETTINGS.charaOptions, ...dashaSettings.charaOptions };
+  const rasiOptions = { ...DEFAULT_DASHA_SETTINGS.rasiOptions, ...dashaSettings.rasiOptions };
+
+  const saveDashaSettings = (next: DashaSettings) => {
+    onUpdateDashaSettings(next);
+    try { localStorage.setItem('dashaSettings', JSON.stringify(next)); } catch {}
+  };
+
+  const updateCharaOption = <K extends keyof CharaOptions,>(key: K, value: CharaOptions[K]) => {
+    saveDashaSettings({ ...dashaSettings, dashas: normalizedDashas, charaOptions: { ...charaOptions, [key]: value }, rasiOptions });
+  };
+
+  const updateRasiOption = <K extends keyof RasiDashaOptions,>(key: K, value: RasiDashaOptions[K]) => {
+    saveDashaSettings({ ...dashaSettings, dashas: normalizedDashas, charaOptions, rasiOptions: { ...rasiOptions, [key]: value } });
+  };
 
   const updateChartStyle = (chartStyle: 'north' | 'south') => {
     onUpdateChartDisplay?.({ chartStyle });
@@ -96,10 +112,10 @@ export default function SettingsPanel(props: Props) {
     const next: DashaSettings = {
       ...dashaSettings,
       dashas: { ...normalizedDashas, [key]: !normalizedDashas[key] },
-      charaOptions: dashaSettings.charaOptions ?? DEFAULT_DASHA_SETTINGS.charaOptions,
+      charaOptions,
+      rasiOptions,
     };
-    onUpdateDashaSettings(next);
-    try { localStorage.setItem('dashaSettings', JSON.stringify(next)); } catch {}
+    saveDashaSettings(next);
     if (key === 'bcp' && typeof window !== 'undefined') {
       window.dispatchEvent(new CustomEvent('bcp:dasha-bcp-toggle', { detail: next.dashas.bcp }));
     }
@@ -248,6 +264,28 @@ export default function SettingsPanel(props: Props) {
             </div>
           </div>
 
+        </div>
+      </Section>
+
+      <Section label="dasha methods" open={methodsOpen} onToggle={() => setMethodsOpen(v => !v)}>
+        <div className="space-y-4">
+          <p className="text-[10px] font-mono text-zinc-400 dark:text-zinc-500">Method choices update Dasha panels, the shared timeline and Event List together.</p>
+          <div className="space-y-2">
+            <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400">Chara Dasha</div>
+            <label className="block text-xs font-mono text-zinc-500">Start sign<select className={`${SELECT} mt-1`} value={charaOptions.start} onChange={e => updateCharaOption('start', e.target.value as CharaOptions['start'])}><option value="lagna">Lagna</option><option value="ak">Atmakaraka</option></select></label>
+            <label className="block text-xs font-mono text-zinc-500">Mahadasha direction<select className={`${SELECT} mt-1`} value={charaOptions.mahadashaDirection} onChange={e => updateCharaOption('mahadashaDirection', e.target.value as CharaOptions['mahadashaDirection'])}><option value="rashi-type">Rashi type</option><option value="odd-even">Odd / even</option></select></label>
+            <label className="block text-xs font-mono text-zinc-500">Antardasha start<select className={`${SELECT} mt-1`} value={charaOptions.antardashaStart} onChange={e => updateCharaOption('antardashaStart', e.target.value as CharaOptions['antardashaStart'])}><option value="next-dasha-rasi">Next Dasha rashi</option><option value="same-dasha-rasi">Same Dasha rashi</option></select></label>
+            <label className="block text-xs font-mono text-zinc-500">Duration count<select className={`${SELECT} mt-1`} value={charaOptions.durationCount} onChange={e => updateCharaOption('durationCount', e.target.value as CharaOptions['durationCount'])}><option value="inclusive">Inclusive</option><option value="exclusive">Exclusive</option></select></label>
+            <div className="flex items-center justify-between gap-3 rounded border border-zinc-200 px-2 py-2 dark:border-zinc-700"><span className="text-xs font-mono text-zinc-500">Exaltation / debilitation adjustment</span><MiniToggle value={charaOptions.exaltDebilAdjust} onToggle={() => updateCharaOption('exaltDebilAdjust', !charaOptions.exaltDebilAdjust)} /></div>
+            <div className="grid grid-cols-2 gap-2"><label className="text-xs font-mono text-zinc-500">Scorpio lord<select className={`${SELECT} mt-1`} value={charaOptions.scorpioLord} onChange={e => updateCharaOption('scorpioLord', e.target.value as CharaOptions['scorpioLord'])}><option value="Ketu">Ketu</option><option value="Mars">Mars</option></select></label><label className="text-xs font-mono text-zinc-500">Aquarius lord<select className={`${SELECT} mt-1`} value={charaOptions.aquariusLord} onChange={e => updateCharaOption('aquariusLord', e.target.value as CharaOptions['aquariusLord'])}><option value="Saturn">Saturn</option><option value="Rahu">Rahu</option></select></label></div>
+          </div>
+          <div className="space-y-2 border-t border-zinc-200 pt-4 dark:border-zinc-700">
+            <div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400">Rashi Dasha seeds</div>
+            <label className="block text-xs font-mono text-zinc-500">Narayana<select className={`${SELECT} mt-1`} value={rasiOptions.narayanaSeed} onChange={e => updateRasiOption('narayanaSeed', e.target.value as RasiDashaOptions['narayanaSeed'])}><option value="stronger-lagna-seventh">PVR / JHora: stronger Lagna or 7th</option><option value="lagna">Research variant: Lagna only</option></select></label>
+            <label className="block text-xs font-mono text-zinc-500">Mula<select className={`${SELECT} mt-1`} value={rasiOptions.moolaSeed} onChange={e => updateRasiOption('moolaSeed', e.target.value as RasiDashaOptions['moolaSeed'])}><option value="stronger-lagna-seventh">PVR / JHora: stronger Lagna or 7th</option><option value="lagna">Research variant: Lagna only</option></select></label>
+            <label className="block text-xs font-mono text-zinc-500">Sthira<select className={`${SELECT} mt-1 opacity-70`} value={rasiOptions.sthiraMethod} disabled><option value="brahma-pvr">PVR / JHora: Brahma seed</option></select></label>
+            <p className="text-[9px] font-mono text-amber-600 dark:text-amber-400">Research variants are exploratory and are identified in the result audit.</p>
+          </div>
         </div>
       </Section>
 

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,17 @@
 export const CHANGELOG = [
   {
+    version: 'v1.88',
+    date: '2026-08-12',
+    title: 'Dasha method settings',
+    changes: [
+      'Added a dedicated Dasha Methods section without restoring the removed Advanced section.',
+      'Restored working Chara method controls for start sign, direction, subperiod start, duration counting, dignity adjustment and co-lords.',
+      'Added Nārāyaṇa and Mūla seed variants with the PVR/JHora-compatible stronger Lagna/7th method as the default.',
+      'Kept Sthira on the implemented PVR/JHora Brahma-seed method and clearly labelled exploratory Lagna-only variants.',
+      'Method selections now remain synchronized across Dasha panels, the shared timeline and Event List exports.',
+    ],
+  },
+  {
     version: 'v1.87',
     date: '2026-08-11',
     title: 'Event List 2.0',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.87';
+export const APP_VERSION = 'v1.88';

--- a/src/lib/dashaEvents.test.ts
+++ b/src/lib/dashaEvents.test.ts
@@ -20,6 +20,7 @@ const snapshots = calculateDashaEventSnapshots({
   planets,
   ascendant: { longitude: 90, sign: 4, degree: 0 },
   charaOptions: DEFAULT_DASHA_SETTINGS.charaOptions,
+  rasiOptions: DEFAULT_DASHA_SETTINGS.rasiOptions,
 });
 
 assert.deepEqual(snapshots.map((snapshot) => snapshot.key), ['vimshottari', 'vds', 'chara', 'yogini', 'ashtottari', 'kalaChakra', 'narayana', 'moola', 'sthira']);
@@ -37,6 +38,7 @@ const beforeBirth = calculateDashaEventSnapshots({
   planets,
   ascendant: { longitude: 90, sign: 4, degree: 0 },
   charaOptions: DEFAULT_DASHA_SETTINGS.charaOptions,
+  rasiOptions: DEFAULT_DASHA_SETTINGS.rasiOptions,
 });
 assert.ok(beforeBirth.every((snapshot) => snapshot.levels.length === 0 && snapshot.note === 'Date is before birth'));
 

--- a/src/lib/dashaEvents.ts
+++ b/src/lib/dashaEvents.ts
@@ -1,4 +1,4 @@
-import type { CharaOptions, PlanetData } from '@/types';
+import type { CharaOptions, PlanetData, RasiDashaOptions } from '@/types';
 import { calculateCleanCharaMD, calculateCleanCharaSubDashas, type CleanCharaEntry } from './charaClean';
 import { calculateKalachakra, calculateKalachakraAntardashas, type KalachakraEntry } from './kalachakra';
 import { calculateVds } from './vds';
@@ -22,6 +22,7 @@ interface SnapshotInput {
   planets: PlanetData[];
   ascendant: { longitude: number; sign: number; degree: number };
   charaOptions: CharaOptions;
+  rasiOptions: RasiDashaOptions;
 }
 
 function activeEntry<T extends { startDate: Date; endDate: Date }>(entries: T[], date: Date): T | null {
@@ -68,7 +69,7 @@ function rasiLevels(entries: RasiDashaEntry[], date: Date, planets: PlanetData[]
 }
 
 export function calculateDashaEventSnapshots(input: SnapshotInput): DashaEventSnapshot[] {
-  const { eventDate, birthDate, planets, ascendant, charaOptions } = input;
+  const { eventDate, birthDate, planets, ascendant, charaOptions, rasiOptions } = input;
   if (eventDate < birthDate) return [
     { key: 'vimshottari', label: 'Vimsottari', levels: [], note: 'Date is before birth' },
     { key: 'vds', label: 'Vimsottari Original', levels: [], note: 'Date is before birth' },
@@ -120,7 +121,7 @@ export function calculateDashaEventSnapshots(input: SnapshotInput): DashaEventSn
     ['moola', 'moola', 'Mūla Dasha'],
     ['sthira', 'sthira', 'Sthira Dasha'],
   ] as const) {
-    const result = calculateRasiDasha(system, planets, ascendant.sign, birthDate);
+    const result = calculateRasiDasha(system, planets, ascendant.sign, birthDate, rasiOptions);
     snapshots.push({ key, label, levels: rasiLevels(result.entries, eventDate, planets, system), mdRange: activeRange(result.entries, eventDate) });
   }
 

--- a/src/lib/dashaRenderers.tsx
+++ b/src/lib/dashaRenderers.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { BcpResult, PlanetData, CharaOptions } from '@/types';
+import { BcpResult, PlanetData, CharaOptions, RasiDashaOptions } from '@/types';
 import { DashaRendererKey } from './dashaRegistry';
 import VimshottariPanel from '@/components/VimshottariPanel';
 import VdsPanel from '@/components/VdsPanel';
@@ -15,6 +15,7 @@ export type DashaRendererContext = {
   ascendant: { longitude: number; sign: number; degree: number };
   birthDatetime: string;
   charaOptions: CharaOptions;
+  rasiOptions: RasiDashaOptions;
 };
 
 const RENDERERS: Record<DashaRendererKey, (ctx: DashaRendererContext) => ReactNode> = {
@@ -36,9 +37,9 @@ const RENDERERS: Record<DashaRendererKey, (ctx: DashaRendererContext) => ReactNo
   ashtottari: ({ planets, ascendant, birthDatetime }) => (
     <AshtottariPanel planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} />
   ),
-  narayana: ({ planets, ascendant, birthDatetime }) => <RasiDashaPanel system="narayana" planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} />,
-  moola: ({ planets, ascendant, birthDatetime }) => <RasiDashaPanel system="moola" planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} />,
-  sthira: ({ planets, ascendant, birthDatetime }) => <RasiDashaPanel system="sthira" planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} />,
+  narayana: ({ planets, ascendant, birthDatetime, rasiOptions }) => <RasiDashaPanel system="narayana" planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} options={rasiOptions} />,
+  moola: ({ planets, ascendant, birthDatetime, rasiOptions }) => <RasiDashaPanel system="moola" planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} options={rasiOptions} />,
+  sthira: ({ planets, ascendant, birthDatetime, rasiOptions }) => <RasiDashaPanel system="sthira" planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} options={rasiOptions} />,
 };
 
 export function renderDasha(rendererKey: DashaRendererKey, ctx: DashaRendererContext) {

--- a/src/lib/rasiDashas.test.ts
+++ b/src/lib/rasiDashas.test.ts
@@ -26,4 +26,8 @@ for (const system of ['narayana', 'moola', 'sthira'] as const) {
 }
 const sthira = calculateRasiDasha('sthira', planets, 4, birth);
 assert.deepEqual(sthira.entries.map(entry => entry.durationYears).sort(), [7,7,7,7,8,8,8,8,9,9,9,9]);
+const lagnaSeed = calculateRasiDasha('narayana', planets, 4, birth, { narayanaSeed: 'lagna', moolaSeed: 'stronger-lagna-seventh', sthiraMethod: 'brahma-pvr' });
+assert.equal(lagnaSeed.seedSign, 3);
+assert.match(lagnaSeed.method, /research variant/);
+assert.match(lagnaSeed.basis, /^Lagna:/);
 console.log('Rasi Dasha tests passed');

--- a/src/lib/rasiDashas.ts
+++ b/src/lib/rasiDashas.ts
@@ -1,3 +1,4 @@
+import type { RasiDashaOptions } from '../types';
 type PlanetData = { name: string; sign: number; degree: number; longitude: number; house?: number };
 
 const YEAR_MS = 365.25 * 24 * 60 * 60 * 1000;
@@ -105,14 +106,20 @@ function brahmaSeed(planets: PlanetData[], ascSign: number): { sign: number; pla
   return { sign: signOf(planets, planet) ?? strong, planet };
 }
 
-export function calculateRasiDasha(system: RasiDashaSystem, planets: PlanetData[], ascSignOneBased: number, birthDate: Date): RasiDashaResult {
+export function calculateRasiDasha(system: RasiDashaSystem, planets: PlanetData[], ascSignOneBased: number, birthDate: Date, options: RasiDashaOptions = { narayanaSeed: 'stronger-lagna-seventh', moolaSeed: 'stronger-lagna-seventh', sthiraMethod: 'brahma-pvr' }): RasiDashaResult {
   const asc = norm(ascSignOneBased - 1);
   let seed = strongerSign(planets, asc, norm(asc + 6));
-  let basis = `stronger of Lagna/7th: ${RASI_NAMES[seed]}`;
+  if (system === 'narayana' && options.narayanaSeed === 'lagna') seed = asc;
+  if (system === 'moola' && options.moolaSeed === 'lagna') seed = asc;
+  let basis = `${system === 'sthira' || options[system === 'narayana' ? 'narayanaSeed' : 'moolaSeed'] === 'stronger-lagna-seventh' ? 'stronger of Lagna/7th' : 'Lagna'}: ${RASI_NAMES[seed]}`;
   let method = 'PVR/JHora-compatible rāśi rules';
   const audit = [`Lagna: ${RASI_NAMES[asc]}`, `7th: ${RASI_NAMES[norm(asc + 6)]}`, `Selected seed: ${RASI_NAMES[seed]}`];
   let order: number[];
-  if (system === 'narayana') order = narayanaOrder(seed, planets);
+  if (system === 'narayana') {
+    order = narayanaOrder(seed, planets);
+    method = options.narayanaSeed === 'lagna' ? 'Nārāyaṇa · Lagna-seed research variant' : 'Nārāyaṇa · PVR/JHora stronger Lagna/7th variant';
+    audit.push(`Seed option: ${options.narayanaSeed === 'lagna' ? 'Lagna only' : 'stronger Lagna/7th'}`);
+  }
   else if (system === 'moola') {
     let direction: 1 | -1 = seed % 2 === 0 ? 1 : -1;
     if (signOf(planets, 'Saturn') === seed) direction = 1;
@@ -120,7 +127,8 @@ export function calculateRasiDasha(system: RasiDashaSystem, planets: PlanetData[
     const offsets = [0,3,6,9,1,4,7,10,2,5,8,11];
     order = offsets.map(offset => norm(seed + direction * offset));
     basis = `Lagna Kendrādi · ${basis}`;
-    method = 'Lagna Kendrādi Rāśi (Mūla) · PVR/JHora variant';
+    method = options.moolaSeed === 'lagna' ? 'Lagna Kendrādi Rāśi (Mūla) · Lagna-seed research variant' : 'Lagna Kendrādi Rāśi (Mūla) · PVR/JHora stronger Lagna/7th variant';
+    audit.push(`Seed option: ${options.moolaSeed === 'lagna' ? 'Lagna only' : 'stronger Lagna/7th'}`);
     audit.push(`Progression direction: ${direction === 1 ? 'forward' : 'reverse'}`, 'Order: kendras → pāṇapharas → apoklimas');
   } else {
     const brahma = brahmaSeed(planets, asc);

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,12 @@ export interface CharaOptions {
   aquariusLord: 'Saturn' | 'Rahu';
 }
 
+export interface RasiDashaOptions {
+  narayanaSeed: 'stronger-lagna-seventh' | 'lagna';
+  moolaSeed: 'stronger-lagna-seventh' | 'lagna';
+  sthiraMethod: 'brahma-pvr';
+}
+
 export interface DashaSettings {
   dashas: {
     bcp: boolean;
@@ -231,6 +237,7 @@ export interface DashaSettings {
     yogaVimshottari?: boolean;
   };
   charaOptions?: CharaOptions;
+  rasiOptions?: RasiDashaOptions;
 }
 
 export const DEFAULT_DASHA_SETTINGS: Required<DashaSettings> = {
@@ -283,5 +290,10 @@ export const DEFAULT_DASHA_SETTINGS: Required<DashaSettings> = {
     exaltDebilAdjust: true,
     scorpioLord: 'Ketu',
     aquariusLord: 'Saturn',
+  },
+  rasiOptions: {
+    narayanaSeed: 'stronger-lagna-seventh',
+    moolaSeed: 'stronger-lagna-seventh',
+    sthiraMethod: 'brahma-pvr',
   },
 };


### PR DESCRIPTION
## Summary
- add a dedicated Dasha Methods section while keeping Advanced removed
- expose implemented Chara calculation controls
- add synchronized Nārāyaṇa and Mūla seed variants with PVR/JHora defaults
- keep Sthira on its implemented Brahma-seed method
- apply selections consistently to panels, timeline and Event List
- bump the app and changelog to v1.88

## Validation
- `npx eslint` on all changed runtime files
- `npm run build`