### PR TITLE
Add Rashi Dasha regression validation in v1.89

### DIFF
--- a/src/components/RasiDashaPanel.tsx
+++ b/src/components/RasiDashaPanel.tsx
@@ -5,6 +5,7 @@ import type { PlanetData } from '@/types';
 import type { RasiDashaOptions } from '@/types';
 import { parseDateTime } from '@/lib/bcp';
 import { calculateRasiDasha, calculateRasiSubDashas, type RasiDashaEntry, type RasiDashaSystem } from '@/lib/rasiDashas';
+import { validateRasiDashaRegression } from '@/lib/rasiDashaValidation';
 
 const LEVELS = ['MD', 'AD', 'PD', 'SD', 'PR', 'DE'] as const;
 const TITLES: Record<RasiDashaSystem, string> = { narayana: 'nārāyaṇa daśā', moola: 'mūla daśā', sthira: 'sthira daśā' };
@@ -27,6 +28,7 @@ export default function RasiDashaPanel({ system, planets, ascendant, birthDateti
     const birth = parseDateTime(birthDatetime);
     return birth ? calculateRasiDasha(system, planets, ascendant.sign, birth, options) : null;
   }, [system, planets, ascendant.sign, birthDatetime, options]);
+  const validation = useMemo(() => validateRasiDashaRegression(system), [system]);
   if (!result) return <div className="text-xs font-mono text-zinc-400">Valid birth datetime required.</div>;
 
   const children = (entry: RasiDashaEntry) => calculateRasiSubDashas(entry, planets, system);
@@ -45,8 +47,8 @@ export default function RasiDashaPanel({ system, planets, ascendant, birthDateti
     <div className="flex items-center justify-between gap-2"><div className="font-mono text-xs uppercase tracking-widest text-zinc-500">&gt; {TITLES[system]}</div><button type="button" onClick={openNow} className="rounded border border-cyan-300 px-2 py-1 text-[10px] font-mono text-cyan-700 dark:border-cyan-700 dark:text-cyan-300">NOW</button></div>
     <div className="rounded-lg border border-zinc-200 bg-zinc-50 px-3 py-2 text-[10px] font-mono text-zinc-600 dark:border-zinc-700 dark:bg-zinc-800 dark:text-zinc-300"><div>{result.basis}</div>{activePath.length > 0 && <div className="mt-1 text-cyan-700 dark:text-cyan-300">Now: {activePath.map((entry, i) => `${entry.abbr} ${LEVELS[i]}`).join(' › ')}</div>}</div>
     <details className="rounded-lg border border-zinc-200 bg-white text-[10px] font-mono dark:border-zinc-700 dark:bg-zinc-900">
-      <summary className="cursor-pointer px-3 py-2 text-zinc-600 dark:text-zinc-300">Calculation details · <span className="text-amber-600 dark:text-amber-400">Beta</span></summary>
-      <div className="space-y-1 border-t border-zinc-100 px-3 py-2 text-zinc-500 dark:border-zinc-800 dark:text-zinc-400"><div className="font-semibold text-zinc-700 dark:text-zinc-200">{result.method}</div>{result.audit.map(line => <div key={line}>· {line}</div>)}<p className="pt-1 text-amber-700 dark:text-amber-400">Structural tests pass; external golden-chart parity is not yet certified.</p></div>
+      <summary className="cursor-pointer px-3 py-2 text-zinc-600 dark:text-zinc-300">Calculation details · <span className="text-amber-600 dark:text-amber-400">Beta</span> · <span className={validation.passed ? 'text-emerald-700 dark:text-emerald-300' : 'text-red-700 dark:text-red-300'}>{validation.passed ? 'regression verified' : 'regression failed'}</span></summary>
+      <div className="space-y-1 border-t border-zinc-100 px-3 py-2 text-zinc-500 dark:border-zinc-800 dark:text-zinc-400"><div className="font-semibold text-zinc-700 dark:text-zinc-200">{result.method}</div>{result.audit.map(line => <div key={line}>· {line}</div>)}<p className={validation.passed ? 'pt-1 text-emerald-700 dark:text-emerald-300' : 'pt-1 text-red-700 dark:text-red-300'}>{validation.fixture}: {validation.checks} locked internal regression checks {validation.passed ? 'pass' : 'failed'}.</p><p className="text-amber-700 dark:text-amber-400">This detects accidental calculation changes; independent JHora golden-chart parity is still not certified.</p></div>
     </details>
     <div className="flex items-center justify-between gap-2"><button type="button" onClick={back} disabled={!level} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono disabled:opacity-30 dark:border-zinc-700">← back</button><div className="text-[10px] font-mono uppercase tracking-widest text-zinc-400">{LEVELS[level]} · {rows.length} periods</div></div>
     {path.length > 0 && <div className="text-[10px] font-mono text-emerald-700 dark:text-emerald-300">{path.map((entry, i) => `${entry.abbr} ${LEVELS[i]}`).join(' › ')} › {LEVELS[level]}</div>}

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,16 @@
 export const CHANGELOG = [
   {
+    version: 'v1.89',
+    date: '2026-08-12',
+    title: 'Rashi Dasha regression validation',
+    changes: [
+      'Added locked seed, period-order, continuity and duration checks for Nārāyaṇa, Mūla and Sthira Daśā.',
+      'Added a visible regression verification result and fixture identifier to each Rāśi Daśā calculation audit.',
+      'Kept the systems in Beta and explicitly separated internal regression coverage from independent JHora golden-chart parity.',
+      'Updated the application version to v1.89.',
+    ],
+  },
+  {
     version: 'v1.88',
     date: '2026-08-12',
     title: 'Dasha method settings',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.88';
+export const APP_VERSION = 'v1.89';

--- a/src/lib/rasiDashaValidation.ts
+++ b/src/lib/rasiDashaValidation.ts
@@ -1,0 +1,40 @@
+import { calculateRasiDasha, type RasiDashaSystem } from './rasiDashas';
+
+export type RasiValidationStatus = {
+  passed: boolean;
+  checks: number;
+  fixture: string;
+  scope: 'internal-regression';
+};
+
+const FIXTURE_PLANETS = [
+  { name: 'Sun', sign: 6, house: 3, degree: 20, longitude: 170 },
+  { name: 'Moon', sign: 3, house: 12, degree: 6, longitude: 66 },
+  { name: 'Mars', sign: 6, house: 3, degree: 10, longitude: 160 },
+  { name: 'Mercury', sign: 7, house: 4, degree: 20, longitude: 200 },
+  { name: 'Jupiter', sign: 1, house: 10, degree: 3, longitude: 3 },
+  { name: 'Venus', sign: 7, house: 4, degree: 10, longitude: 190 },
+  { name: 'Saturn', sign: 8, house: 5, degree: 24, longitude: 234 },
+  { name: 'Rahu', sign: 12, house: 9, degree: 8, longitude: 338 },
+  { name: 'Ketu', sign: 6, house: 3, degree: 8, longitude: 158 },
+];
+
+const EXPECTED: Record<RasiDashaSystem, { seed: number; order: string; durations?: string }> = {
+  narayana: { seed: 9, order: 'Cp,Sg,Sc,Li,Vi,Le,Cn,Ge,Ta,Ar,Pi,Aq' },
+  moola: { seed: 9, order: 'Cp,Li,Cn,Ar,Sg,Vi,Ge,Pi,Sc,Le,Ta,Aq' },
+  sthira: { seed: 6, order: 'Li,Sc,Sg,Cp,Aq,Pi,Ar,Ta,Ge,Cn,Le,Vi', durations: '7,8,9,7,8,9,7,8,9,7,8,9' },
+};
+
+export function validateRasiDashaRegression(system: RasiDashaSystem): RasiValidationStatus {
+  const result = calculateRasiDasha(system, FIXTURE_PLANETS, 4, new Date('2000-01-01T10:00:00.000Z'));
+  const expected = EXPECTED[system];
+  const firstCycle = result.entries.slice(0, 12);
+  const checks = [
+    result.seedSign === expected.seed,
+    firstCycle.map(entry => entry.abbr).join(',') === expected.order,
+    firstCycle.length === 12,
+    firstCycle.every((entry, index) => index === 0 || firstCycle[index - 1].endDate.getTime() === entry.startDate.getTime()),
+    expected.durations == null || firstCycle.map(entry => entry.durationYears).join(',') === expected.durations,
+  ];
+  return { passed: checks.every(Boolean), checks: checks.length, fixture: 'BCP-RD-001', scope: 'internal-regression' };
+}

--- a/src/lib/rasiDashas.test.ts
+++ b/src/lib/rasiDashas.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { calculateRasiDasha, calculateRasiSubDashas } from './rasiDashas';
+import { validateRasiDashaRegression } from './rasiDashaValidation';
 
 const planets = [
   { name: 'Sun', sign: 6, house: 3, degree: 20, longitude: 170 },
@@ -30,4 +31,5 @@ const lagnaSeed = calculateRasiDasha('narayana', planets, 4, birth, { narayanaSe
 assert.equal(lagnaSeed.seedSign, 3);
 assert.match(lagnaSeed.method, /research variant/);
 assert.match(lagnaSeed.basis, /^Lagna:/);
+for (const system of ['narayana', 'moola', 'sthira'] as const) assert.equal(validateRasiDashaRegression(system).passed, true);
 console.log('Rasi Dasha tests passed');


### PR DESCRIPTION
## Summary
- add locked internal regression fixtures for Nārāyaṇa, Mūla and Sthira Daśā
- verify seeds, first-cycle order, continuity and Sthira durations
- show the regression result and fixture ID in each calculation audit
- explicitly keep independent JHora golden-chart parity uncertified
- bump the app and changelog to v1.89

## Validation
- Rāśi Daśā test suite: passed
- targeted ESLint: passed
- `npm run build`: passed