### PR TITLE
Add Dasha Date Finder in v1.91

### DIFF
--- a/src/components/DashaDateFinder.tsx
+++ b/src/components/DashaDateFinder.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useState } from 'react';
+import type { CharaOptions, DashaSettings, PlanetData, RasiDashaOptions } from '@/types';
+import { calculateDashaEventSnapshots, type DashaEventSnapshot } from '@/lib/dashaEvents';
+import { groupDailyMatches, snapshotMatches } from '@/lib/dashaDateFinder';
+import { parseDateTime } from '@/lib/bcp';
+
+type Key = DashaEventSnapshot['key'];
+const KEYS: { key: Key | 'all'; label: string }[] = [{ key: 'all', label: 'All enabled systems' }, { key: 'vimshottari', label: 'Vimsottari' }, { key: 'vds', label: 'Vimsottari Original' }, { key: 'chara', label: 'Chara' }, { key: 'yogini', label: 'Yogini' }, { key: 'ashtottari', label: 'Ashtottari' }, { key: 'kalaChakra', label: 'Kalachakra' }, { key: 'narayana', label: 'Narayana' }, { key: 'moola', label: 'Mula' }, { key: 'sthira', label: 'Sthira' }];
+const SETTING: Record<Key, keyof DashaSettings['dashas']> = { vimshottari: 'vimshottari', vds: 'vds', chara: 'chara', yogini: 'yogini', ashtottari: 'ashtottari', kalaChakra: 'kalaChakra', narayana: 'narayana', moola: 'moola', sthira: 'sthira' };
+const DAY = 24 * 60 * 60 * 1000;
+const value = (date: Date) => `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+const fmt = (date: Date) => `${String(date.getDate()).padStart(2, '0')}.${String(date.getMonth() + 1).padStart(2, '0')}.${date.getFullYear()}`;
+
+interface Props { planets: PlanetData[]; ascendant: { longitude: number; sign: number; degree: number }; birthDatetime: string; dashas: DashaSettings['dashas']; charaOptions: CharaOptions; rasiOptions: RasiDashaOptions; }
+
+export default function DashaDateFinder({ planets, ascendant, birthDatetime, dashas, charaOptions, rasiOptions }: Props) {
+  const now = new Date(); const later = new Date(now); later.setFullYear(later.getFullYear() + 2);
+  const [system, setSystem] = useState<Key | 'all'>('vimshottari'); const [start, setStart] = useState(value(now)); const [end, setEnd] = useState(value(later));
+  const [md, setMd] = useState(''); const [ad, setAd] = useState(''); const [pd, setPd] = useState(''); const [minimum, setMinimum] = useState(2);
+  const [results, setResults] = useState<ReturnType<typeof groupDailyMatches>>([]); const [message, setMessage] = useState(''); const [busy, setBusy] = useState(false);
+  async function search() {
+    const birthDate = parseDateTime(birthDatetime); const from = new Date(`${start}T12:00:00`); const to = new Date(`${end}T12:00:00`);
+    if (!birthDate || !start || !end || from > to) return setMessage('Check the date range.');
+    if (!md.trim() && !ad.trim() && !pd.trim()) return setMessage('Enter at least one MD, AD or PD value.');
+    if ((to.getTime() - from.getTime()) / DAY > 5 * 366) return setMessage('One search may cover at most five years.');
+    setBusy(true); setMessage('Searching…'); await new Promise(resolve => setTimeout(resolve, 0));
+    const matches = [];
+    let scanned = 0;
+    for (let time = from.getTime(); time <= to.getTime(); time += DAY) {
+      const date = new Date(time); const snapshots = calculateDashaEventSnapshots({ eventDate: date, birthDate, planets, ascendant, charaOptions, rasiOptions });
+      const candidates = snapshots.filter(snapshot => dashas[SETTING[snapshot.key]] && (system === 'all' || snapshot.key === system) && snapshotMatches(snapshot, { md, ad, pd }));
+      if (candidates.length >= (system === 'all' ? minimum : 1)) matches.push({ date, snapshots: candidates });
+      scanned += 1;
+      if (scanned % 31 === 0) await new Promise(resolve => setTimeout(resolve, 0));
+    }
+    const grouped = groupDailyMatches(matches).slice(0, 100); setResults(grouped); setMessage(grouped.length ? `${grouped.length} matching periods` : 'No matching periods found.'); setBusy(false);
+  }
+  function select(date: Date) { window.dispatchEvent(new CustomEvent('bcp:dasha-date-selected', { detail: value(date) })); document.getElementById('dasha-timeline')?.scrollIntoView({ behavior: 'smooth', block: 'start' }); }
+  return <details className="rounded-xl border border-violet-200 bg-violet-50/40 dark:border-violet-900 dark:bg-violet-950/10"><summary className="cursor-pointer px-3 py-2 text-sm font-semibold text-violet-800 dark:text-violet-300">Dasha Date Finder</summary><div className="space-y-3 border-t border-violet-100 p-3 dark:border-violet-900">
+    <div className="grid gap-2 sm:grid-cols-3"><label className="text-[10px] text-zinc-500">System<select value={system} onChange={event => setSystem(event.target.value as Key | 'all')} className="mt-1 w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-900">{KEYS.map(item => <option key={item.key} value={item.key}>{item.label}</option>)}</select></label><label className="text-[10px] text-zinc-500">From<input type="date" value={start} onChange={event => setStart(event.target.value)} className="mt-1 w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-900"/></label><label className="text-[10px] text-zinc-500">To · max 5 years<input type="date" value={end} onChange={event => setEnd(event.target.value)} className="mt-1 w-full rounded border border-zinc-300 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-900"/></label></div>
+    <div className="grid gap-2 sm:grid-cols-[1fr_1fr_1fr_auto_auto]"><input value={md} onChange={event => setMd(event.target.value)} placeholder="MD e.g. Saturn" aria-label="MD filter" className="rounded border border-zinc-300 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-900"/><input value={ad} onChange={event => setAd(event.target.value)} placeholder="AD e.g. Mercury" aria-label="AD filter" className="rounded border border-zinc-300 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-900"/><input value={pd} onChange={event => setPd(event.target.value)} placeholder="PD e.g. Jupiter" aria-label="PD filter" className="rounded border border-zinc-300 bg-white px-2 py-1.5 text-xs dark:border-zinc-700 dark:bg-zinc-900"/>{system === 'all' && <label className="flex items-center gap-1 text-[10px] text-zinc-500">Min.<input type="number" min="1" max="9" value={minimum} onChange={event => setMinimum(Math.max(1, event.target.valueAsNumber || 1))} className="w-12 rounded border border-zinc-300 bg-white px-1 py-1.5 dark:border-zinc-700 dark:bg-zinc-900"/></label>}<button type="button" disabled={busy} onClick={search} className="rounded bg-violet-700 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-40">{busy ? 'Searching…' : 'Find dates'}</button></div>
+    <div className="text-[10px] text-zinc-500">{message || 'Partial names work. “All” requires the same filters to match in the selected minimum number of systems.'}</div>
+    {results.length > 0 && <div className="max-h-72 space-y-1 overflow-y-auto">{results.map(result => <button type="button" key={`${result.start.toISOString()}-${result.snapshots.map(item => item.key).join('-')}`} onClick={() => select(result.start)} className="w-full rounded border border-violet-100 bg-white px-2 py-2 text-left text-[10px] dark:border-violet-900 dark:bg-zinc-900"><span className="font-semibold text-violet-700 dark:text-violet-300">{fmt(result.start)}{result.end.getTime() !== result.start.getTime() ? `–${fmt(result.end)}` : ''}</span><span className="ml-2 text-zinc-500">{result.snapshots.map(snapshot => `${snapshot.label}: ${snapshot.levels.map(level => `${level.level} ${level.value}`).join(' · ')}`).join(' | ')}</span><span className="float-right text-zinc-400">Open timeline ↘</span></button>)}</div>}
+  </div></details>;
+}

--- a/src/components/DashaEventList.tsx
+++ b/src/components/DashaEventList.tsx
@@ -50,6 +50,7 @@ export default function DashaEventList({ planets, ascendant, birthDatetime, dash
 
   useEffect(() => { queueMicrotask(() => { try { const stored = localStorage.getItem(storageKey); const parsed: unknown = stored ? JSON.parse(stored) : []; setEvents(Array.isArray(parsed) ? parsed.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === 'object' && typeof (item as Record<string, unknown>).id === 'string' && typeof (item as Record<string, unknown>).name === 'string' && typeof (item as Record<string, unknown>).date === 'string')).map(item => ({ id: String(item.id), name: String(item.name), date: String(item.date), category: (item.category as Category) || 'other', varga: (item.varga as Varga) || 'D1' })) : []); } catch { setEvents([]); } setStorageLoaded(true); }); }, [storageKey]);
   useEffect(() => { if (storageLoaded) localStorage.setItem(storageKey, JSON.stringify(events)); }, [events, storageKey, storageLoaded]);
+  useEffect(() => { const select = (event: Event) => setDate((event as CustomEvent<string>).detail); window.addEventListener('bcp:dasha-date-selected', select); return () => window.removeEventListener('bcp:dasha-date-selected', select); }, []);
 
   const visibleKeys = enabledKeys.filter(key => !hiddenKeys.includes(key));
   function snapshotsFor(item: StoredEvent) { const eventDate = parseEventDate(item.date); return birthDate && eventDate ? calculateDashaEventSnapshots({ eventDate, birthDate, planets, ascendant, charaOptions, rasiOptions }).filter(snapshot => visibleKeys.includes(snapshot.key)) : []; }

--- a/src/components/DashaPanel.tsx
+++ b/src/components/DashaPanel.tsx
@@ -3,6 +3,7 @@ import { RENDERABLE_DASHAS } from '@/lib/dashaRegistry';
 import { renderDasha, DashaRendererContext } from '@/lib/dashaRenderers';
 import CollapsibleCard from './CollapsibleCard';
 import DashaTimeline from './DashaTimeline';
+import DashaDateFinder from './DashaDateFinder';
 
 interface Props {
   bcp: BcpResult;
@@ -32,6 +33,7 @@ export default function DashaPanel({ bcp, planets, ascendant, birthDatetime, das
   if (!collapsible) {
     return (
       <div className="space-y-8">
+        <DashaDateFinder planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} dashas={normalizedDashas} charaOptions={charaOptions} rasiOptions={rasiOptions} />
         <DashaTimeline planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} normalizedDashas={normalizedDashas} charaOptions={charaOptions} rasiOptions={rasiOptions} />
         {activeDashas.map(d => (
           <div key={d.key} id={`dasha-${d.key}`} className="min-w-0 scroll-mt-4">
@@ -44,6 +46,7 @@ export default function DashaPanel({ bcp, planets, ascendant, birthDatetime, das
 
   return (
     <div className="space-y-2">
+      <DashaDateFinder planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} dashas={normalizedDashas} charaOptions={charaOptions} rasiOptions={rasiOptions} />
       <DashaTimeline planets={planets} ascendant={ascendant} birthDatetime={birthDatetime} normalizedDashas={normalizedDashas} charaOptions={charaOptions} rasiOptions={rasiOptions} />
       {activeDashas.map((d, i) => (
         <div key={d.key} id={`dasha-${d.key}`} className="scroll-mt-4"><CollapsibleCard title={d.label} defaultOpen={i === 0}>

--- a/src/components/DashaTimeline.tsx
+++ b/src/components/DashaTimeline.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CharaOptions, DashaSettings, PlanetData, RasiDashaOptions } from '@/types';
 import { calculateDashaEventSnapshots } from '@/lib/dashaEvents';
 import { parseDateTime } from '@/lib/bcp';
@@ -27,6 +27,7 @@ function fmt(date: Date) { return `${String(date.getDate()).padStart(2, '0')}.${
 
 export default function DashaTimeline({ planets, ascendant, birthDatetime, normalizedDashas, charaOptions, rasiOptions }: Props) {
   const [selectedValue, setSelectedValue] = useState(() => dateValue(new Date()));
+  useEffect(() => { const select = (event: Event) => setSelectedValue((event as CustomEvent<string>).detail); window.addEventListener('bcp:dasha-date-selected', select); return () => window.removeEventListener('bcp:dasha-date-selected', select); }, []);
   const birthDate = useMemo(() => parseDateTime(birthDatetime), [birthDatetime]);
   const selectedDate = useMemo(() => parseDate(selectedValue), [selectedValue]);
   const snapshots = useMemo(() => birthDate ? calculateDashaEventSnapshots({ eventDate: selectedDate, birthDate, planets, ascendant, charaOptions, rasiOptions }) : [], [birthDate, selectedDate, planets, ascendant, charaOptions, rasiOptions]);
@@ -36,7 +37,7 @@ export default function DashaTimeline({ planets, ascendant, birthDatetime, norma
   const span = windowEnd.getTime() - windowStart.getTime();
   const moveYears = (years: number) => { const next = new Date(selectedDate); next.setFullYear(next.getFullYear() + years); setSelectedValue(dateValue(next)); };
 
-  return <section className="space-y-3 rounded-xl border border-zinc-200 bg-zinc-50/70 p-3 dark:border-zinc-700 dark:bg-zinc-950/40">
+  return <section id="dasha-timeline" className="scroll-mt-4 space-y-3 rounded-xl border border-zinc-200 bg-zinc-50/70 p-3 dark:border-zinc-700 dark:bg-zinc-950/40">
     <div className="flex flex-wrap items-center gap-2"><div className="min-w-0 flex-1"><h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Dasha Timeline</h3><p className="text-[10px] text-zinc-500">Active MD–AD–PD on one date · MD bars share a ±10-year scale.</p></div><button type="button" onClick={() => moveYears(-1)} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono dark:border-zinc-700">−1y</button><input type="date" value={selectedValue} onChange={event => { if (event.target.value) setSelectedValue(event.target.value); }} className="rounded border border-zinc-300 bg-white px-2 py-1 text-xs font-mono dark:border-zinc-700 dark:bg-zinc-900"/><button type="button" onClick={() => moveYears(1)} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono dark:border-zinc-700">+1y</button><button type="button" onClick={() => setSelectedValue(dateValue(new Date()))} className="rounded border border-cyan-300 px-2 py-1 text-[10px] font-mono text-cyan-700 dark:border-cyan-700 dark:text-cyan-300">Today</button></div>
     <div className="relative ml-[112px] h-4 text-[9px] font-mono text-zinc-400"><span className="absolute left-0">{windowStart.getFullYear()}</span><span className="absolute left-1/2 -translate-x-1/2 text-cyan-600">{selectedDate.getFullYear()}</span><span className="absolute right-0">{windowEnd.getFullYear()}</span></div>
     <div className="space-y-2">{visible.map((snapshot, index) => {

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,18 @@
 export const CHANGELOG = [
   {
+    version: 'v1.91',
+    date: '2026-08-12',
+    title: 'Dasha Date Finder',
+    changes: [
+      'Added date-range searches for matching MD, AD and PD periods in every calculated Dasha system.',
+      'Added partial-name matching and combined searches requiring the same criteria in multiple enabled systems.',
+      'Consecutive matching days are grouped into periods instead of shown as duplicate daily rows.',
+      'Finder results can set and open the shared timeline date and prefill the Event List date.',
+      'Searches are capped at five years per run to keep browser-side calculation bounded.',
+      'Updated the application version to v1.91.',
+    ],
+  },
+  {
     version: 'v1.90',
     date: '2026-08-12',
     title: 'Recurring Dasha event patterns',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.90';
+export const APP_VERSION = 'v1.91';

--- a/src/lib/dashaDateFinder.test.ts
+++ b/src/lib/dashaDateFinder.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { groupDailyMatches, snapshotMatches } from './dashaDateFinder';
+
+const snapshot = { key: 'vimshottari' as const, label: 'Vimsottari', levels: [{ level: 'MD', value: 'Saturn' }, { level: 'AD', value: 'Mercury' }, { level: 'PD', value: 'Jupiter' }] };
+assert.equal(snapshotMatches(snapshot, { md: 'sat', ad: 'Merc', pd: '' }), true);
+assert.equal(snapshotMatches(snapshot, { md: 'Venus', ad: '', pd: '' }), false);
+const groups = groupDailyMatches([
+  { date: new Date(2026, 0, 1, 12), snapshots: [snapshot] },
+  { date: new Date(2026, 0, 2, 12), snapshots: [snapshot] },
+  { date: new Date(2026, 0, 4, 12), snapshots: [snapshot] },
+]);
+assert.equal(groups.length, 2);
+assert.equal(groups[0].end.getDate(), 2);
+console.log('Dasha Date Finder tests passed');

--- a/src/lib/dashaDateFinder.ts
+++ b/src/lib/dashaDateFinder.ts
@@ -1,0 +1,25 @@
+import type { DashaEventSnapshot } from './dashaEvents';
+
+export interface DashaDateMatch {
+  date: Date;
+  snapshots: DashaEventSnapshot[];
+}
+
+export function snapshotMatches(snapshot: DashaEventSnapshot, filters: { md: string; ad: string; pd: string }): boolean {
+  const value = (level: string) => snapshot.levels.find(item => item.level === level)?.value.toLocaleLowerCase() ?? '';
+  return (filters.md.trim() === '' || value('MD').includes(filters.md.trim().toLocaleLowerCase()))
+    && (filters.ad.trim() === '' || value('AD').includes(filters.ad.trim().toLocaleLowerCase()))
+    && (filters.pd.trim() === '' || value('PD').includes(filters.pd.trim().toLocaleLowerCase()));
+}
+
+export function groupDailyMatches(matches: DashaDateMatch[]): { start: Date; end: Date; snapshots: DashaEventSnapshot[] }[] {
+  const day = 24 * 60 * 60 * 1000;
+  return matches.reduce<{ start: Date; end: Date; snapshots: DashaEventSnapshot[] }[]>((groups, match) => {
+    const signature = match.snapshots.map(snapshot => `${snapshot.key}:${snapshot.levels.map(level => level.value).join('/')}`).join('|');
+    const previous = groups.at(-1);
+    const previousSignature = previous?.snapshots.map(snapshot => `${snapshot.key}:${snapshot.levels.map(level => level.value).join('/')}`).join('|');
+    if (previous && match.date.getTime() - previous.end.getTime() === day && signature === previousSignature) previous.end = match.date;
+    else groups.push({ start: match.date, end: match.date, snapshots: match.snapshots });
+    return groups;
+  }, []);
+}


### PR DESCRIPTION
## Summary
- search up to five years for matching MD, AD and PD values
- support one Dasha system or concurrent matches across enabled systems
- group consecutive matching days into periods
- open a result directly on the shared timeline
- prefill the Event List date from the selected result
- yield during long searches to keep the browser responsive
- bump the app and changelog to v1.91

## Validation
- Date Finder unit tests: passed
- targeted ESLint: passed
- `npm run build`: passed