### PR TITLE
Add Event List imports in v1.92

### DIFF
--- a/src/components/DashaEventList.tsx
+++ b/src/components/DashaEventList.tsx
@@ -7,6 +7,7 @@ import { parseDateTime } from '@/lib/bcp';
 import { calculateDashaEventSnapshots, type DashaEventSnapshot } from '@/lib/dashaEvents';
 import { getVargaSignIndex, SIGN_ABBR } from '@/lib/varga';
 import { analyzeDashaEventPatterns } from '@/lib/dashaEventPatterns';
+import { eventIdentity, parseDashaEventImport, type ImportedEvent } from '@/lib/dashaEventImport';
 
 type Category = 'work' | 'money' | 'relationship' | 'health' | 'home' | 'family' | 'spiritual' | 'other';
 type Varga = 'D1' | 'D7' | 'D9' | 'D10' | 'D12' | 'D60';
@@ -43,6 +44,8 @@ export default function DashaEventList({ planets, ascendant, birthDatetime, dash
   const [hiddenKeys, setHiddenKeys] = useState<SnapshotKey[]>([]);
   const [patternCategory, setPatternCategory] = useState<Category | 'all'>('all');
   const [storageLoaded, setStorageLoaded] = useState(false);
+  const [importPreview, setImportPreview] = useState<{ events: ImportedEvent[]; rejected: number; duplicates: number; format: string } | null>(null);
+  const [importMessage, setImportMessage] = useState('');
   const [name, setName] = useState(''); const [date, setDate] = useState(today); const [category, setCategory] = useState<Category>('work'); const [varga, setVarga] = useState<Varga>('D1');
   const birthDate = parseDateTime(birthDatetime);
   const charaOptions = dashaSettings.charaOptions ?? DEFAULT_DASHA_SETTINGS.charaOptions;
@@ -58,6 +61,22 @@ export default function DashaEventList({ planets, ascendant, birthDatetime, dash
   function updateEvent(id: string, update: Partial<StoredEvent>) { setEvents(current => current.map(item => item.id === id ? { ...item, ...update } : item)); }
   function toggleKey(key: SnapshotKey) { setHiddenKeys(current => current.includes(key) ? current.filter(item => item !== key) : [...current, key]); }
   function openVarga() { if (onOpenVargaMatrix) onOpenVargaMatrix(); else window.dispatchEvent(new CustomEvent('bcp:show-varga-matrix')); }
+  async function previewImport(file: File | undefined) {
+    if (!file) return;
+    if (file.size > 2_000_000) { setImportMessage('File is larger than the 2 MB limit.'); return; }
+    try {
+      const result = parseDashaEventImport(await file.text(), file.name);
+      const existing = new Set(events.map(eventIdentity));
+      const fresh = result.events.filter(item => !existing.has(eventIdentity(item)));
+      setImportPreview({ events: fresh, rejected: result.rejected, duplicates: result.events.length - fresh.length, format: result.format });
+      setImportMessage(result.events.length ? '' : 'No valid events found.');
+    } catch { setImportPreview(null); setImportMessage('Could not read this file. Use a BCP CSV or JSON export.'); }
+  }
+  function confirmImport() {
+    if (!importPreview?.events.length) return;
+    setEvents(current => [...current, ...importPreview.events.map(item => ({ ...item, id: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}` }))].sort((a, b) => a.date.localeCompare(b.date)));
+    setImportMessage(`Imported ${importPreview.events.length} events.`); setImportPreview(null);
+  }
 
   const patternRecords = events.flatMap(item => snapshotsFor(item).map(snapshot => ({ eventId: item.id, category: item.category, snapshot })));
   const patterns = analyzeDashaEventPatterns(patternRecords, patternCategory).slice(0, 12);
@@ -68,7 +87,8 @@ export default function DashaEventList({ planets, ascendant, birthDatetime, dash
   function exportJson() { download('bhrigu-dasha-events.json', JSON.stringify({ version: 1, birthDatetime, visibleDashas: visibleKeys, events: events.map(item => ({ ...item, dashas: snapshotsFor(item) })) }, null, 2), 'application/json'); }
 
   return <section className="space-y-3 rounded-lg border border-zinc-200 bg-zinc-50/70 p-3 dark:border-zinc-700 dark:bg-zinc-950/40">
-    <div className="flex flex-wrap items-start gap-2"><div className="min-w-0 flex-1"><h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Event List 2.0</h3><p className="text-[11px] text-zinc-500 dark:text-zinc-400">Classify events, compare enabled Dashas, connect transits and export the data.</p></div><button type="button" onClick={exportCsv} disabled={!events.length} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono disabled:opacity-30 dark:border-zinc-700">CSV</button><button type="button" onClick={exportJson} disabled={!events.length} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono disabled:opacity-30 dark:border-zinc-700">JSON</button></div>
+    <div className="flex flex-wrap items-start gap-2"><div className="min-w-0 flex-1"><h3 className="text-sm font-semibold text-zinc-800 dark:text-zinc-100">Event List 2.0</h3><p className="text-[11px] text-zinc-500 dark:text-zinc-400">Classify events, compare enabled Dashas, connect transits and import or export the data.</p></div><label className="cursor-pointer rounded border border-cyan-300 px-2 py-1 text-[10px] font-mono text-cyan-700 dark:border-cyan-700 dark:text-cyan-300">Import<input type="file" accept=".csv,.json,text/csv,application/json" onChange={event => { void previewImport(event.target.files?.[0]); event.target.value = ''; }} className="hidden"/></label><button type="button" onClick={exportCsv} disabled={!events.length} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono disabled:opacity-30 dark:border-zinc-700">CSV</button><button type="button" onClick={exportJson} disabled={!events.length} className="rounded border border-zinc-300 px-2 py-1 text-[10px] font-mono disabled:opacity-30 dark:border-zinc-700">JSON</button></div>
+    {(importPreview || importMessage) && <div className="rounded-md border border-cyan-200 bg-cyan-50/50 p-2 text-[10px] dark:border-cyan-900 dark:bg-cyan-950/10">{importPreview ? <div className="flex flex-wrap items-center gap-2"><span className="min-w-0 flex-1">{importPreview.format}: <strong>{importPreview.events.length}</strong> new · {importPreview.duplicates} duplicates skipped · {importPreview.rejected} invalid rejected</span><button type="button" onClick={() => setImportPreview(null)} className="rounded border border-zinc-300 px-2 py-1 dark:border-zinc-700">Cancel</button><button type="button" disabled={!importPreview.events.length} onClick={confirmImport} className="rounded bg-cyan-700 px-2 py-1 font-semibold text-white disabled:opacity-40">Import events</button></div> : <div className="flex items-center gap-2"><span className="flex-1">{importMessage}</span><button type="button" onClick={() => setImportMessage('')} className="text-zinc-400">×</button></div>}</div>}
     <form onSubmit={addEvent} className="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(150px,1fr)_140px_130px_80px_auto]"><input value={name} onChange={event => setName(event.target.value)} placeholder="Event name" aria-label="Event name" className="min-w-0 rounded-md border border-zinc-300 bg-white px-2.5 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-900"/><input type="date" value={date} onChange={event => setDate(event.target.value)} aria-label="Event date" className="rounded-md border border-zinc-300 bg-white px-2.5 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-900"/><select value={category} onChange={event => setCategory(event.target.value as Category)} aria-label="Event category" className="rounded-md border border-zinc-300 bg-white px-2 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-900">{Object.entries(CATEGORY_LABELS).map(([key, label]) => <option key={key} value={key}>{label}</option>)}</select><select value={varga} onChange={event => setVarga(event.target.value as Varga)} aria-label="Event varga" className="rounded-md border border-zinc-300 bg-white px-2 py-2 text-xs dark:border-zinc-700 dark:bg-zinc-900">{VARGAS.map(item => <option key={item}>{item}</option>)}</select><button type="submit" disabled={!name.trim() || !date} className="rounded-md bg-emerald-700 px-3 py-2 text-xs font-semibold text-white disabled:opacity-40">Add</button></form>
     <div><div className="mb-1 text-[9px] font-mono uppercase tracking-widest text-zinc-400">Visible enabled Dashas</div><div className="flex flex-wrap gap-1">{enabledKeys.map(key => <button type="button" key={key} onClick={() => toggleKey(key)} className={`rounded border px-1.5 py-0.5 text-[9px] font-mono ${visibleKeys.includes(key) ? 'border-emerald-400 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-300' : 'border-zinc-300 text-zinc-400 dark:border-zinc-700'}`}>{key}</button>)}</div></div>
     {events.length >= 2 && <details className="rounded-md border border-cyan-200 bg-cyan-50/40 dark:border-cyan-900 dark:bg-cyan-950/10">

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,17 @@
 export const CHANGELOG = [
   {
+    version: 'v1.92',
+    date: '2026-08-12',
+    title: 'Event List import',
+    changes: [
+      'Added CSV and JSON imports for Event List data, including files exported by BCP.',
+      'Added an import preview showing new, duplicate and rejected event counts before data is saved.',
+      'CSV Dasha rows are collapsed back into unique events and existing duplicates are skipped.',
+      'Added validation for event names, ISO dates, categories, vargas and a 2 MB file-size limit.',
+      'Updated the application version to v1.92.',
+    ],
+  },
+  {
     version: 'v1.91',
     date: '2026-08-12',
     title: 'Dasha Date Finder',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v1.91';
+export const APP_VERSION = 'v1.92';

--- a/src/lib/dashaEventImport.test.ts
+++ b/src/lib/dashaEventImport.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import { parseDashaEventImport } from './dashaEventImport';
+
+const csv = 'event,category,date,varga,dasha,MD\n"New job, role",Work,2026-01-02,D10,Vimsottari,Saturn\n"New job, role",Work,2026-01-02,D10,Chara,Cp\nInvalid,Money,no-date,D1,Vimsottari,Mercury';
+const csvResult = parseDashaEventImport(csv, 'events.csv');
+assert.equal(csvResult.events.length, 1);
+assert.equal(csvResult.events[0].name, 'New job, role');
+assert.equal(csvResult.events[0].category, 'work');
+assert.equal(csvResult.rejected, 1);
+
+const jsonResult = parseDashaEventImport(JSON.stringify({ version: 1, events: [{ name: 'Move', date: '2026-02-03', category: 'home', varga: 'D1', dashas: [] }] }), 'events.json');
+assert.deepEqual(jsonResult.events[0], { name: 'Move', date: '2026-02-03', category: 'home', varga: 'D1' });
+assert.throws(() => parseDashaEventImport('{', 'broken.json'));
+console.log('Dasha event import tests passed');

--- a/src/lib/dashaEventImport.ts
+++ b/src/lib/dashaEventImport.ts
@@ -1,0 +1,45 @@
+export const EVENT_CATEGORIES = ['work', 'money', 'relationship', 'health', 'home', 'family', 'spiritual', 'other'] as const;
+export const EVENT_VARGAS = ['D1', 'D7', 'D9', 'D10', 'D12', 'D60'] as const;
+export type ImportedCategory = typeof EVENT_CATEGORIES[number];
+export type ImportedVarga = typeof EVENT_VARGAS[number];
+export interface ImportedEvent { name: string; date: string; category: ImportedCategory; varga: ImportedVarga; }
+export interface ImportResult { events: ImportedEvent[]; rejected: number; format: 'CSV' | 'JSON'; }
+
+const CATEGORY_ALIASES: Record<string, ImportedCategory> = { work: 'work', money: 'money', relationship: 'relationship', health: 'health', home: 'home', 'home / move': 'home', family: 'family', spiritual: 'spiritual', other: 'other' };
+const validDate = (value: unknown) => typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(new Date(`${value}T12:00:00`).getTime());
+const normalize = (item: Record<string, unknown>): ImportedEvent | null => {
+  const name = String(item.name ?? item.event ?? '').trim();
+  const date = String(item.date ?? '').trim();
+  const category = CATEGORY_ALIASES[String(item.category ?? 'other').trim().toLocaleLowerCase()] ?? 'other';
+  const candidateVarga = String(item.varga ?? 'D1').trim().toUpperCase();
+  const varga = EVENT_VARGAS.includes(candidateVarga as ImportedVarga) ? candidateVarga as ImportedVarga : 'D1';
+  return name && validDate(date) ? { name, date, category, varga } : null;
+};
+const unique = (events: ImportedEvent[]) => [...new Map(events.map(item => [`${item.name.toLocaleLowerCase()}|${item.date}|${item.category}|${item.varga}`, item])).values()];
+
+function parseCsvRows(text: string): string[][] {
+  const rows: string[][] = []; let row: string[] = []; let cell = ''; let quoted = false;
+  for (let index = 0; index < text.length; index++) {
+    const char = text[index];
+    if (char === '"' && quoted && text[index + 1] === '"') { cell += '"'; index += 1; }
+    else if (char === '"') quoted = !quoted;
+    else if (char === ',' && !quoted) { row.push(cell); cell = ''; }
+    else if ((char === '\n' || char === '\r') && !quoted) { if (char === '\r' && text[index + 1] === '\n') index += 1; row.push(cell); if (row.some(value => value.trim())) rows.push(row); row = []; cell = ''; }
+    else cell += char;
+  }
+  row.push(cell); if (row.some(value => value.trim())) rows.push(row); return rows;
+}
+
+export function parseDashaEventImport(text: string, filename: string): ImportResult {
+  if (filename.toLocaleLowerCase().endsWith('.json')) {
+    const parsed: unknown = JSON.parse(text);
+    const source = Array.isArray(parsed) ? parsed : parsed && typeof parsed === 'object' && Array.isArray((parsed as { events?: unknown }).events) ? (parsed as { events: unknown[] }).events : [];
+    const normalized = source.map(item => item && typeof item === 'object' ? normalize(item as Record<string, unknown>) : null);
+    return { events: unique(normalized.filter((item): item is ImportedEvent => item != null)), rejected: normalized.filter(item => item == null).length, format: 'JSON' };
+  }
+  const rows = parseCsvRows(text); const headers = rows.shift()?.map(value => value.trim().toLocaleLowerCase().replace(/^\ufeff/, '')) ?? [];
+  const normalized = rows.map(row => normalize(Object.fromEntries(headers.map((header, index) => [header, row[index] ?? '']))));
+  return { events: unique(normalized.filter((item): item is ImportedEvent => item != null)), rejected: normalized.filter(item => item == null).length, format: 'CSV' };
+}
+
+export function eventIdentity(item: ImportedEvent): string { return `${item.name.trim().toLocaleLowerCase()}|${item.date}|${item.category}|${item.varga}`; }


### PR DESCRIPTION
## Summary
- import BCP CSV and JSON Event List exports
- preview new, duplicate and rejected counts before saving
- collapse repeated CSV Dasha rows into unique events
- skip events already stored in the current chart
- validate names, dates, categories and vargas
- cap imported files at 2 MB
- bump the app and changelog to v1.92

## Validation
- import parser tests: passed
- targeted ESLint: passed
- `npm run build`: passed