### PR TITLE
Fix render loop and settings loss, extract Shadbala, drop dead systems in v2.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     name: Lint, typecheck and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22.x
           cache: npm
@@ -42,9 +42,9 @@ jobs:
     name: Production build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Debug secret length
         shell: bash

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -98,24 +98,41 @@ type CalculationOptions = {
 
 // Handles both the new { dashas: {...} } format and the old
 // { showBcp, showVimshottari, dashaSystem } format from localStorage / saved charts.
+//
+// Two properties matter here:
+// - Every key still present in DashaSettings survives a reload. The previous
+//   version rebuilt the object from bcp/vimshottari/vds only, so the toggles
+//   for all other systems — and charaOptions/rasiOptions entirely — silently
+//   reverted to defaults every time the app started.
+// - Keys removed from DashaSettings (the v2.15 placeholder cleanup) are
+//   dropped, because the copy iterates the default's own keys.
 function migrateDashaSettings(raw: unknown): DashaSettings {
   if (!raw || typeof raw !== 'object') return DEFAULT_DASHA_SETTINGS;
   const obj = raw as Record<string, unknown>;
 
   if (obj.dashas && typeof obj.dashas === 'object') {
-    const d = obj.dashas as Record<string, unknown>;
+    const stored = obj.dashas as Record<string, unknown>;
+    const dashas = { ...DEFAULT_DASHA_SETTINGS.dashas };
+    for (const key of Object.keys(dashas) as (keyof DashaSettings['dashas'])[]) {
+      const value = stored[key];
+      if (typeof value === 'boolean') dashas[key] = value;
+    }
     return {
-      dashas: {
-        bcp:         typeof d.bcp === 'boolean'         ? d.bcp         : true,
-        vimshottari: typeof d.vimshottari === 'boolean' ? d.vimshottari : true,
-        vds:         typeof d.vds === 'boolean'         ? d.vds         : false,
-      },
+      dashas,
+      charaOptions: obj.charaOptions && typeof obj.charaOptions === 'object'
+        ? { ...DEFAULT_DASHA_SETTINGS.charaOptions, ...(obj.charaOptions as DashaSettings['charaOptions']) }
+        : DEFAULT_DASHA_SETTINGS.charaOptions,
+      rasiOptions: obj.rasiOptions && typeof obj.rasiOptions === 'object'
+        ? { ...DEFAULT_DASHA_SETTINGS.rasiOptions, ...(obj.rasiOptions as DashaSettings['rasiOptions']) }
+        : DEFAULT_DASHA_SETTINGS.rasiOptions,
     };
   }
 
   // Old format: showBcp / showVimshottari / dashaSystem
   return {
+    ...DEFAULT_DASHA_SETTINGS,
     dashas: {
+      ...DEFAULT_DASHA_SETTINGS.dashas,
       bcp:         obj.showBcp !== false,
       vimshottari: obj.showVimshottari !== false,
       vds:         obj.dashaSystem === 'vds',
@@ -310,13 +327,19 @@ export default function Home() {
     }));
   }, [chartData, effectiveBnnAge]);
 
+  // Recompute BCP when the target or birth date changes, but only if a chart
+  // has already produced a result. The previous version had bcpResult in the
+  // dependency array while also setting it to a fresh object, which looped the
+  // effect until React aborted with "Maximum update depth exceeded" on every
+  // calculated chart. The functional update reads the previous result without
+  // depending on it.
   useEffect(() => {
-    if (useManualBcpMode || !bcpResult) return;
+    if (useManualBcpMode) return;
     const birthDate = parseDateTime(birthDatetime);
     const target = parseTargetDateString(targetDate);
     if (!birthDate || !target) return;
-    setBcpResult(calculateBcp(birthDate, target));
-  }, [targetDate, birthDatetime, useManualBcpMode, bcpResult]);
+    setBcpResult((previous) => (previous ? calculateBcp(birthDate, target) : previous));
+  }, [targetDate, birthDatetime, useManualBcpMode]);
 
   // Restore persisted display/calculation/dasha settings on mount
   useEffect(() => {

--- a/src/components/AshtakavargaPanel.tsx
+++ b/src/components/AshtakavargaPanel.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import type { ChartData } from '@/types';
 import { buildAshtakavarga, mapAshtakavargaHousesToSigns } from '@/lib/ashtakavarga';
-import type { AshtakavargaPlanet, AshtakavargaSystem } from '@/lib/ashtakavarga';
+import type { AshtakavargaPlanet } from '@/lib/ashtakavarga';
 
 const SIGNS = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
 const PLANET_ABBR: Record<string, string> = {
@@ -72,9 +72,8 @@ function NorthIndianAvChart({ houses, ascendantSign, label, isSav }: { houses: n
 export default function AshtakavargaPanel({ chart }: { chart: ChartData }) {
   const ascendantSign = chart.ascendant.sign;
   const [view, setView] = useState<'table' | 'north'>('table');
-  const [system, setSystem] = useState<AshtakavargaSystem>('parashara');
   const [selection, setSelection] = useState<AvSelection>('SAV');
-  const { bav, sav } = buildAshtakavarga(chart, system);
+  const { bav, sav } = buildAshtakavarga(chart);
   const selectedRow = selection === 'SAV' ? null : bav.find((row) => row.planet === selection);
   const selectedHouses = selectedRow?.houses ?? sav.houses;
 
@@ -91,11 +90,6 @@ export default function AshtakavargaPanel({ chart }: { chart: ChartData }) {
         </div>
       </div>
 
-      <div className="mb-3 flex gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800">
-        <button type="button" onClick={() => setSystem('parashara')} className={`flex-1 rounded px-2.5 py-1.5 text-[10px] font-mono ${system === 'parashara' ? 'bg-white text-emerald-700 shadow-sm dark:bg-zinc-700 dark:text-emerald-400' : 'text-zinc-500'}`}>Parāśara</button>
-        <button type="button" onClick={() => setSystem('varahamihira')} className={`flex-1 rounded px-2.5 py-1.5 text-[10px] font-mono ${system === 'varahamihira' ? 'bg-white text-emerald-700 shadow-sm dark:bg-zinc-700 dark:text-emerald-400' : 'text-zinc-500'}`}>Varāhamihira</button>
-      </div>
-
       {view === 'north' ? (
         <div>
           <label className="mb-3 block text-[10px] font-mono uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
@@ -105,7 +99,7 @@ export default function AshtakavargaPanel({ chart }: { chart: ChartData }) {
               {bav.map((row) => <option key={row.planet} value={row.planet}>{row.planet} BAV</option>)}
             </select>
           </label>
-          <NorthIndianAvChart houses={selectedHouses} ascendantSign={ascendantSign} label={`${system === 'parashara' ? 'Parāśara' : 'Varāhamihira'} · ${selection === 'SAV' ? 'SAV' : `${selection} BAV`}`} isSav={selection === 'SAV'} />
+          <NorthIndianAvChart houses={selectedHouses} ascendantSign={ascendantSign} label={`Parāśara · ${selection === 'SAV' ? 'SAV' : `${selection} BAV`}`} isSav={selection === 'SAV'} />
         </div>
       ) : (
       <div className="overflow-x-auto">

--- a/src/lib/ashtakavarga.test.ts
+++ b/src/lib/ashtakavarga.test.ts
@@ -124,33 +124,9 @@ CONTRIBUTOR_ORDER.forEach((contributor, contributorIndex) => {
   }
 });
 
-// ---------------------------------------------------------------------------
-// Varahamihira variant. It shares the Parashara totals; only the Venus/Mars
-// contributor row differs, so per-house distribution can diverge while the
-// totals stay put.
-// ---------------------------------------------------------------------------
-const variantChart = chartWithOffsets(4, [0, 1, 2, 3, 4, 5, 6]);
-const parashara = buildAshtakavarga(variantChart, 'parashara');
-const varahamihira = buildAshtakavarga(variantChart, 'varahamihira');
-
-assert.deepEqual(
-  parashara.bav.map((row) => row.total),
-  Object.values(CLASSICAL_BAV_TOTALS),
-);
-assert.deepEqual(
-  varahamihira.bav.map((row) => row.total),
-  Object.values(CLASSICAL_BAV_TOTALS),
-);
-assert.equal(parashara.sav.total, CLASSICAL_SAV_TOTAL);
-assert.equal(varahamihira.sav.total, CLASSICAL_SAV_TOTAL);
-
-const parasharaVenus = parashara.bav.find((row) => row.planet === 'Venus')!;
-const varahamihiraVenus = varahamihira.bav.find((row) => row.planet === 'Venus')!;
-assert.notDeepEqual(
-  parasharaVenus.houses,
-  varahamihiraVenus.houses,
-  'the Venus/Mars row must actually change the Venus BAV distribution',
-);
+// The Varahamihira system variant was removed in v2.15 — after the v2.14
+// Parashara fix it differed by one unverified row, so the selector implied a
+// sourced Brihat Jataka table that did not exist. See ashtakavarga.ts.
 
 // ---------------------------------------------------------------------------
 // House-to-sign mapping

--- a/src/lib/ashtakavarga.ts
+++ b/src/lib/ashtakavarga.ts
@@ -1,5 +1,4 @@
 export type AshtakavargaPlanet = 'Sun' | 'Moon' | 'Mars' | 'Mercury' | 'Jupiter' | 'Venus' | 'Saturn';
-export type AshtakavargaSystem = 'parashara' | 'varahamihira';
 export type AvMode = 'off' | 'sav' | AshtakavargaPlanet;
 
 export type AshtakavargaChartPlanet = {
@@ -121,21 +120,13 @@ const PARASHARA_AV: Record<AshtakavargaPlanet, Record<Contributor, number[]>> = 
   },
 };
 
-// Brihat Jataka IX differs from the Parashara table in the entries below.
-// Unchanged contributor rows intentionally inherit the Parashara values.
-//
-// NOTE: this table previously also overrode the Sun, Mars and Mercury Ascendant
-// rows. Those were in fact the correct *Parashara* values, and PARASHARA_AV had
-// been left holding a placeholder copy of the generic [1,2,4,7,8,9,10,11] row —
-// which inflated the Parashara totals to 50/42/55 (SAV 343) instead of the
-// classical 48/39/54 (SAV 337). The values now live in PARASHARA_AV where they
-// belong. Only the Venus/Mars row below is a genuine Brihat Jataka variant that
-// has been checked; the rest of the Varahamihira table still needs an
-// independent source review before this system can be treated as certified.
-const VARAHAMIHIRA_AV: Record<AshtakavargaPlanet, Record<Contributor, number[]>> = {
-  ...PARASHARA_AV,
-  Venus: { ...PARASHARA_AV.Venus, Mars: [3, 5, 6, 9, 11, 12] },
-};
+// A "Varahamihira" system variant was removed in v2.15. After the v2.14
+// Parashara fix its table differed from PARASHARA_AV by a single row — Venus
+// from Mars as [3,5,6,9,11,12] instead of [3,4,6,9,11,12] — which made the UI
+// selector suggest a fully independent Brihat Jataka table that did not exist.
+// Re-add the system only once the complete Brihat Jataka IX table has been
+// verified against a primary source; the one-row delta above is preserved here
+// so that work does not start from zero.
 
 function getPlanet(chart: AshtakavargaChartLike, name: string): AshtakavargaChartPlanet | undefined {
   return chart.planets?.find((planet) => planet.name === name);
@@ -172,13 +163,9 @@ function getSavStrength(bindu: number): AshtakavargaOverlayCell['strength'] {
   return 'low';
 }
 
-export function buildBhinnaAshtakavarga(
-  chart: AshtakavargaChartLike,
-  system: AshtakavargaSystem = 'parashara',
-): BhinnaAshtakavargaRow[] {
-  const ruleSet = system === 'varahamihira' ? VARAHAMIHIRA_AV : PARASHARA_AV;
+export function buildBhinnaAshtakavarga(chart: AshtakavargaChartLike): BhinnaAshtakavargaRow[] {
   return PLANETS.map((planetName) => {
-    const rules = ruleSet[planetName];
+    const rules = PARASHARA_AV[planetName];
 
     const houses = Array.from({ length: 12 }, (_, index) => {
       const house = index + 1;
@@ -236,11 +223,8 @@ export function buildSarvaAshtakavarga(chart: AshtakavargaChartLike, bav: Bhinna
   };
 }
 
-export function buildAshtakavarga(
-  chart: AshtakavargaChartLike,
-  system: AshtakavargaSystem = 'parashara',
-): AshtakavargaResult {
-  const bav = buildBhinnaAshtakavarga(chart, system);
+export function buildAshtakavarga(chart: AshtakavargaChartLike): AshtakavargaResult {
+  const bav = buildBhinnaAshtakavarga(chart);
   const sav = buildSarvaAshtakavarga(chart, bav);
   return { bav, sav };
 }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,18 @@
 export const CHANGELOG = [
   {
+    version: 'v2.15',
+    date: '2026-08-13',
+    title: 'Render loop fix and settings that survive reload',
+    changes: [
+      'Fixed a render loop that fired "Maximum update depth exceeded" in the browser console on every calculated chart.',
+      'Fixed settings restore: Dasha toggles beyond BCP/Vimśottarī and all Chara and Rāśi method options previously reverted to defaults on every reload.',
+      'Moved the Ṣaḍbala engine from the Varga Matrix page component into a typed calculation module with the other engines.',
+      'Removed the Varāhamihira Aṣṭakavarga selector: after the v2.14 correction it differed from Parāśara by a single unverified row, so the choice was misleading. It returns if the Brihat Jataka table is verified against a primary source.',
+      'Removed 22 never-implemented placeholder Dasha systems from the internal registry.',
+      'Updated the application version to v2.15.',
+    ],
+  },
+  {
     version: 'v2.14',
     date: '2026-08-13',
     title: 'Ashtakavarga correction and a working test suite',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v2.14';
+export const APP_VERSION = 'v2.15';

--- a/src/lib/dashaRegistry.ts
+++ b/src/lib/dashaRegistry.ts
@@ -1,7 +1,7 @@
 import { DashaSettings } from '@/types';
 
 export type DashaKey = keyof DashaSettings['dashas'];
-export type DashaStatus = 'implemented' | 'beta' | 'placeholder';
+export type DashaStatus = 'implemented' | 'beta';
 export type DashaRendererKey = 'vimshottari' | 'vds' | 'chara' | 'kalachakra' | 'yogini' | 'ashtottari' | 'narayana' | 'moola' | 'sthira';
 
 export type DashaRegistryItem = {
@@ -25,30 +25,12 @@ export const DASHA_REGISTRY: DashaRegistryItem[] = [
   { key: 'narayana', label: 'Nārāyaṇa Daśā', group: 'Core', status: 'beta', renderer: 'narayana', kind: 'rasi' },
   { key: 'moola', label: 'Mūla Daśā', group: 'Core', status: 'beta', renderer: 'moola', kind: 'rasi' },
   { key: 'sthira', label: 'Sthira Daśā', group: 'Core', status: 'beta', renderer: 'sthira', kind: 'rasi' },
-
-  { key: 'tara', label: 'Tara Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'shodashottari', label: 'Shodashottari Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'dwadashottari', label: 'Dwadashottari Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'panchottari', label: 'Panchottari Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'shatabdika', label: 'Shatabdika Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'chaturashitiSama', label: 'Chaturashiti Sama Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'dwisaptatiSama', label: 'Dwisaptati Sama Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'shashtihayani', label: 'Shashtihayani Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'shattrimshaSama', label: 'Shattrimsha Sama Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'charaBeta', label: 'Chara Dasha old beta', group: 'Other systems', status: 'placeholder' },
-  { key: 'sudarshanaChakra', label: 'Sudarshana Chakra Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'naisargika', label: 'Naisargika Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'pinda', label: 'Pinda Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'mandooka', label: 'Mandooka Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'manduka', label: 'Manduka Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'brahma', label: 'Brahma Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'drig', label: 'Drig Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'trikona', label: 'Trikona Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'kendradi', label: 'Kendradi Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'karaka', label: 'Karaka Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'lagnaKendradiRashi', label: 'Lagna Kendradi Rashi Dasha', group: 'Other systems', status: 'placeholder' },
-  { key: 'atmakarakaKendradiRashi', label: 'Atmakaraka Kendradi Rashi Dasha', group: 'Other systems', status: 'placeholder' },
 ];
+// v2.15: dropped the 22 "Other systems" placeholder rows (Tara, Brahma, Drig,
+// Shodashottari, …). They had no renderer, rendered nowhere (SettingsPanel
+// filters group === 'Core'), and each one cost a dead key in DashaSettings.
+// When a new system is actually implemented, add its row here with a renderer
+// and its key to DashaSettings in the same commit.
 
 export const DASHA_GROUPS = DASHA_REGISTRY.reduce<{ title: string; items: DashaRegistryItem[] }[]>((groups, item) => {
   const group = groups.find((g) => g.title === item.group);

--- a/src/lib/shadbala.test.ts
+++ b/src/lib/shadbala.test.ts
@@ -1,13 +1,13 @@
 import assert from 'node:assert/strict';
-// These come from the real engine in src/pages/VargaMatrix.jsx. An earlier
-// version of this file declared its own local copies of the constants and its
-// own reimplementations of the percentage/status helpers, so every assertion
+// These come from the real engine in src/lib/shadbala.ts. An earlier version of
+// this file declared its own local copies of the constants and its own
+// reimplementations of the percentage/status helpers, so every assertion
 // compared a literal against itself and the suite could not fail no matter what
 // the application computed.
 import {
-  NAISARGIKA_BALA_VIRUPA as NAISARGIKA_RAW,
-  SHADBALA_REQUIRED_VIRUPA as REQUIRED_RAW,
-  DIG_BALA_MAX_HOUSE as DIG_HOUSE_RAW,
+  NAISARGIKA_BALA_VIRUPA,
+  SHADBALA_REQUIRED_VIRUPA,
+  DIG_BALA_MAX_HOUSE,
   buildShadbalaRows,
   calculateDigBalaVirupa,
   calculateUcchaBalaVirupa,
@@ -16,45 +16,37 @@ import {
   calculateDrekkanaBalaVirupa,
   calculateSaptavargajaBalaVirupa,
   virupaToRupa,
-} from '@/pages/VargaMatrix';
+  type ShadbalaPlanet,
+  type ShadbalaRow,
+} from './shadbala';
 
-// VargaMatrix.jsx is untyped JavaScript, so these arrive as fixed object
-// literals. Widen them to keyed lookups for the loops below.
-const NAISARGIKA_BALA_VIRUPA: Record<string, number> = NAISARGIKA_RAW;
-const SHADBALA_REQUIRED_VIRUPA: Record<string, number> = REQUIRED_RAW;
-const DIG_BALA_MAX_HOUSE: Record<string, number> = DIG_HOUSE_RAW;
-
-const PLANETS = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn'] as const;
+const PLANETS: readonly ShadbalaPlanet[] = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn'];
 
 // ---------------------------------------------------------------------------
 // Golden vectors — fixed classical virupa values (BPHS)
 // ---------------------------------------------------------------------------
-const CLASSICAL_NAISARGIKA: Record<string, number> = {
+const CLASSICAL_NAISARGIKA: Record<ShadbalaPlanet, number> = {
   Sun: 60, Moon: 51, Venus: 43, Jupiter: 34, Mercury: 26, Mars: 17, Saturn: 9,
 };
 
-const CLASSICAL_REQUIRED: Record<string, number> = {
+const CLASSICAL_REQUIRED: Record<ShadbalaPlanet, number> = {
   Sun: 390, Moon: 360, Mars: 300, Mercury: 420, Jupiter: 390, Venus: 330, Saturn: 300,
 };
 
 // Dig Bala is full in the direction each planet owns: Sun and Mars in the 10th,
 // Moon and Venus in the 4th, Jupiter and Mercury in the 1st, Saturn in the 7th.
-const CLASSICAL_DIG_HOUSE: Record<string, number> = {
+const CLASSICAL_DIG_HOUSE: Record<ShadbalaPlanet, number> = {
   Sun: 10, Mars: 10, Moon: 4, Venus: 4, Jupiter: 1, Mercury: 1, Saturn: 7,
 };
 
-for (const [planet, virupa] of Object.entries(CLASSICAL_NAISARGIKA)) {
-  assert.equal(NAISARGIKA_BALA_VIRUPA[planet], virupa, `Naisargika Bala for ${planet}`);
-}
-for (const [planet, virupa] of Object.entries(CLASSICAL_REQUIRED)) {
-  assert.equal(SHADBALA_REQUIRED_VIRUPA[planet], virupa, `required Shadbala for ${planet}`);
-}
-for (const [planet, house] of Object.entries(CLASSICAL_DIG_HOUSE)) {
-  assert.equal(DIG_BALA_MAX_HOUSE[planet], house, `Dig Bala best house for ${planet}`);
+for (const planet of PLANETS) {
+  assert.equal(NAISARGIKA_BALA_VIRUPA[planet], CLASSICAL_NAISARGIKA[planet], `Naisargika Bala for ${planet}`);
+  assert.equal(SHADBALA_REQUIRED_VIRUPA[planet], CLASSICAL_REQUIRED[planet], `required Shadbala for ${planet}`);
+  assert.equal(DIG_BALA_MAX_HOUSE[planet], CLASSICAL_DIG_HOUSE[planet], `Dig Bala best house for ${planet}`);
 }
 
 // Naisargika strictly descends Sun → Moon → Venus → Jupiter → Mercury → Mars → Saturn.
-const NAISARGIKA_ORDER = ['Sun', 'Moon', 'Venus', 'Jupiter', 'Mercury', 'Mars', 'Saturn'];
+const NAISARGIKA_ORDER: readonly ShadbalaPlanet[] = ['Sun', 'Moon', 'Venus', 'Jupiter', 'Mercury', 'Mars', 'Saturn'];
 for (let index = 0; index < NAISARGIKA_ORDER.length - 1; index += 1) {
   const stronger = NAISARGIKA_BALA_VIRUPA[NAISARGIKA_ORDER[index]];
   const weaker = NAISARGIKA_BALA_VIRUPA[NAISARGIKA_ORDER[index + 1]];
@@ -120,21 +112,7 @@ const chart = {
   ],
 };
 
-type ShadbalaRow = {
-  planet: string;
-  sthanaBreakdown: { uccha: number; saptavargaja: number; ojhayugma: number; kendradi: number; drekkana: number; total: number };
-  kalaBreakdown: { natonnata: number; paksha: number; tribhaaga: number; varsheshadi: number; ayana: number; total: number };
-  digVirupa: number;
-  cheshtaVirupa: number;
-  naisargikaVirupa: number;
-  drikVirupa: number;
-  totalVirupa: number;
-  total: number;
-  requiredVirupa: number;
-  ratio: number;
-};
-
-const rows = buildShadbalaRows(chart) as ShadbalaRow[];
+const rows: ShadbalaRow[] = buildShadbalaRows(chart);
 assert.equal(rows.length, 7, 'every classical planet must produce a row');
 
 for (const row of rows) {

--- a/src/lib/shadbala.ts
+++ b/src/lib/shadbala.ts
@@ -1,0 +1,366 @@
+// Ṣaḍbala engine (beta).
+//
+// Extracted from src/pages/VargaMatrix.jsx, where the calculation grew inside
+// the card component as untyped JavaScript. The maths is unchanged; this module
+// only gives it types and a home alongside the other calculation code so the
+// fixtures in shadbala.test.ts can exercise it directly.
+//
+// Exactness follows the labels shown in the UI: Uccha, Ojhayugma, Kendradi,
+// Drekkana, Paksha, Naisargika and Vara are table-exact; Saptavargaja, Dig,
+// Natonnata, Tribhaga, Ayana, Cheshta and Drig are documented approximations.
+
+import { getVargaSignIndex, getDegreesInSign } from './varga';
+import { normalizeLongitude } from './varga/utils';
+
+export type ShadbalaPlanet = 'Sun' | 'Moon' | 'Mars' | 'Mercury' | 'Jupiter' | 'Venus' | 'Saturn';
+export type Dignity = 'exalted' | 'own' | 'friend' | 'neutral' | 'enemy' | 'debilitated' | 'none';
+
+export type ShadbalaChartPlanet = {
+  name: string;
+  longitude?: number;
+  sign?: number;
+  house?: number;
+  isRetrograde?: boolean;
+};
+
+export type ShadbalaChartLike = {
+  ascendant?: { sign?: number; longitude?: number };
+  planets?: ShadbalaChartPlanet[];
+  debug?: { inputDateTime?: string; ayanamsa?: number };
+};
+
+export type SthanaBalaBreakdown = {
+  uccha: number;
+  saptavargaja: number;
+  ojhayugma: number;
+  kendradi: number;
+  drekkana: number;
+  total: number;
+};
+
+export type KalaBalaBreakdown = {
+  sect: 'day' | 'night' | 'unknown';
+  natonnata: number;
+  paksha: number;
+  tribhaaga: number;
+  tribhagaLord: string | null;
+  varsheshadi: number;
+  ayana: number;
+  total: number;
+};
+
+export type ShadbalaRow = {
+  planet: ShadbalaPlanet;
+  house: number | null;
+  retrograde: boolean;
+  sthana: number;
+  sthanaBreakdown: SthanaBalaBreakdown;
+  dig: number;
+  digVirupa: number;
+  kala: number;
+  kalaBreakdown: KalaBalaBreakdown;
+  cheshta: number;
+  cheshtaVirupa: number;
+  naisargika: number;
+  naisargikaVirupa: number;
+  drik: number;
+  drikVirupa: number;
+  total: number;
+  totalVirupa: number;
+  requiredVirupa: number;
+  ratio: number;
+};
+
+export const SCORE_PLANETS: readonly ShadbalaPlanet[] = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn'];
+const BENEFICS: readonly ShadbalaPlanet[] = ['Moon', 'Mercury', 'Jupiter', 'Venus'];
+
+const SIGN_LORDS = ['Mars', 'Venus', 'Mercury', 'Moon', 'Sun', 'Mercury', 'Venus', 'Mars', 'Jupiter', 'Saturn', 'Saturn', 'Jupiter'];
+const OWN_SIGNS: Record<ShadbalaPlanet, number[]> = { Sun: [4], Moon: [3], Mars: [0, 7], Mercury: [2, 5], Jupiter: [8, 11], Venus: [1, 6], Saturn: [9, 10] };
+const EXALTATION_SIGNS: Record<ShadbalaPlanet, number> = { Sun: 0, Moon: 1, Mars: 9, Mercury: 5, Jupiter: 3, Venus: 11, Saturn: 6 };
+const DEBILITATION_SIGNS: Record<ShadbalaPlanet, number> = { Sun: 6, Moon: 7, Mars: 3, Mercury: 11, Jupiter: 9, Venus: 5, Saturn: 0 };
+const EXALTATION_LONGITUDES: Record<ShadbalaPlanet, number> = { Sun: 10, Moon: 33, Mars: 298, Mercury: 165, Jupiter: 95, Venus: 357, Saturn: 200 };
+
+export const SHADBALA_REQUIRED_VIRUPA: Record<ShadbalaPlanet, number> = { Sun: 390, Moon: 360, Mars: 300, Mercury: 420, Jupiter: 390, Venus: 330, Saturn: 300 };
+export const NAISARGIKA_BALA_VIRUPA: Record<ShadbalaPlanet, number> = { Sun: 60, Moon: 51, Venus: 43, Jupiter: 34, Mercury: 26, Mars: 17, Saturn: 9 };
+export const DIG_BALA_MAX_HOUSE: Record<ShadbalaPlanet, number> = { Sun: 10, Mars: 10, Moon: 4, Venus: 4, Jupiter: 1, Mercury: 1, Saturn: 7 };
+
+const ODD_EVEN_STRENGTH: Record<ShadbalaPlanet, 'odd' | 'even' | 'both'> = { Sun: 'odd', Mars: 'odd', Jupiter: 'odd', Moon: 'even', Venus: 'even', Mercury: 'both', Saturn: 'both' };
+const DREKKANA_STRENGTH: Record<ShadbalaPlanet, number> = { Sun: 1, Mars: 1, Jupiter: 1, Mercury: 2, Saturn: 2, Moon: 3, Venus: 3 };
+const DAY_NIGHT_STRENGTH: Record<ShadbalaPlanet, 'day' | 'night' | 'both'> = { Sun: 'day', Jupiter: 'day', Venus: 'day', Moon: 'night', Mars: 'night', Saturn: 'night', Mercury: 'both' };
+
+const NATURAL_RELATIONS: Record<ShadbalaPlanet, { friends: string[]; neutral: string[]; enemies: string[] }> = {
+  Sun: { friends: ['Moon', 'Mars', 'Jupiter'], neutral: ['Mercury'], enemies: ['Venus', 'Saturn'] },
+  Moon: { friends: ['Sun', 'Mercury'], neutral: ['Mars', 'Jupiter', 'Venus', 'Saturn'], enemies: [] },
+  Mars: { friends: ['Sun', 'Moon', 'Jupiter'], neutral: ['Venus', 'Saturn'], enemies: ['Mercury'] },
+  Mercury: { friends: ['Sun', 'Venus'], neutral: ['Mars', 'Jupiter', 'Saturn'], enemies: ['Moon'] },
+  Jupiter: { friends: ['Sun', 'Moon', 'Mars'], neutral: ['Saturn'], enemies: ['Mercury', 'Venus'] },
+  Venus: { friends: ['Mercury', 'Saturn'], neutral: ['Mars', 'Jupiter'], enemies: ['Sun', 'Moon'] },
+  Saturn: { friends: ['Mercury', 'Venus'], neutral: ['Jupiter'], enemies: ['Sun', 'Moon', 'Mars'] },
+};
+
+// Classical Saptavargaja Bala virupa per dignity (BPHS Ch.27). Used as per-varga weights;
+// the sum across 7 vargas is divided by 7 so max = 45 (exalted in all 7).
+// Exact (table-based). Moolatrikona treated as own since getDignity() doesn't distinguish it.
+const SAPTAVARGAJA_VIRUPA: Record<Dignity, number> = { exalted: 45, own: 30, friend: 22.5, neutral: 7.5, enemy: 3.75, debilitated: 0, none: 0 };
+
+function isShadbalaPlanet(name: string): name is ShadbalaPlanet {
+  return (SCORE_PLANETS as readonly string[]).includes(name);
+}
+
+export function virupaToRupa(virupa: number): number {
+  return virupa / 60;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function getPlanet(chart: ShadbalaChartLike, name: string): ShadbalaChartPlanet | undefined {
+  return (chart?.planets ?? []).find((planet) => planet.name === name);
+}
+
+function getPlanetHouse(planet: ShadbalaChartPlanet | undefined, ascendantSign: number | undefined): number | null {
+  if (typeof planet?.house === 'number') return planet.house;
+  if (typeof planet?.sign !== 'number' || typeof ascendantSign !== 'number') return null;
+  return ((planet.sign - ascendantSign + 12) % 12) + 1;
+}
+
+function circularHouseDistance(a: number, b: number): number {
+  const raw = Math.abs(a - b) % 12;
+  return Math.min(raw, 12 - raw);
+}
+
+function circularDegreeDistance(a: number, b: number): number {
+  const raw = Math.abs(normalizeLongitude(a) - normalizeLongitude(b));
+  return Math.min(raw, 360 - raw);
+}
+
+export function getDignity(planet: string, signIndex: number | null | undefined): Dignity {
+  if (!isShadbalaPlanet(planet) || typeof signIndex !== 'number') return 'none';
+  if (DEBILITATION_SIGNS[planet] === signIndex) return 'debilitated';
+  if (EXALTATION_SIGNS[planet] === signIndex) return 'exalted';
+  if (OWN_SIGNS[planet]?.includes(signIndex)) return 'own';
+  const signLord = SIGN_LORDS[signIndex];
+  const relation = NATURAL_RELATIONS[planet];
+  if (relation?.friends.includes(signLord)) return 'friend';
+  if (relation?.enemies.includes(signLord)) return 'enemy';
+  return 'neutral';
+}
+
+export function calculateDigBalaVirupa(planetName: string, house: number | null | undefined): number {
+  const maxHouse = isShadbalaPlanet(planetName) ? DIG_BALA_MAX_HOUSE[planetName] : undefined;
+  if (!maxHouse || typeof house !== 'number') return 0;
+  return clamp(60 * (1 - circularHouseDistance(house, maxHouse) / 6), 0, 60);
+}
+
+export function calculateUcchaBalaVirupa(planetName: string, longitude: number | undefined): number {
+  const exaltLongitude = isShadbalaPlanet(planetName) ? EXALTATION_LONGITUDES[planetName] : undefined;
+  if (typeof exaltLongitude !== 'number' || typeof longitude !== 'number') return 0;
+  return clamp(60 * (1 - circularDegreeDistance(longitude, exaltLongitude) / 180), 0, 60);
+}
+
+export function calculateSaptavargajaBalaVirupa(planetName: string, longitude: number | undefined): number {
+  if (typeof longitude !== 'number') return 0;
+  return [1, 2, 3, 7, 9, 12, 30].reduce(
+    (sum, division) => sum + (SAPTAVARGAJA_VIRUPA[getDignity(planetName, getVargaSignIndex(longitude, division))] ?? 0),
+    0,
+  ) / 7;
+}
+
+export function calculateOjhayugmaBalaVirupa(planetName: string, longitude: number | undefined): number {
+  const preference = isShadbalaPlanet(planetName) ? ODD_EVEN_STRENGTH[planetName] : undefined;
+  if (!preference || typeof longitude !== 'number') return 0;
+  if (preference === 'both') return 15;
+  const signMatches = (signIndex: number) => (preference === 'odd' ? signIndex % 2 === 0 : signIndex % 2 === 1);
+  return (signMatches(getVargaSignIndex(longitude, 1)) ? 15 : 0) + (signMatches(getVargaSignIndex(longitude, 9)) ? 15 : 0);
+}
+
+export function calculateKendradiBalaVirupa(house: number | null | undefined): number {
+  if (typeof house !== 'number') return 0;
+  if ([1, 4, 7, 10].includes(house)) return 60;
+  if ([2, 5, 8, 11].includes(house)) return 30;
+  return 15;
+}
+
+export function calculateDrekkanaBalaVirupa(planetName: string, longitude: number | undefined): number {
+  const preferred = isShadbalaPlanet(planetName) ? DREKKANA_STRENGTH[planetName] : undefined;
+  if (!preferred || typeof longitude !== 'number') return 0;
+  return Math.floor(getDegreesInSign(longitude) / 10) + 1 === preferred ? 15 : 0;
+}
+
+export function calculateSthanaBalaBreakdown(planetName: string, planet: ShadbalaChartPlanet | undefined, house: number | null): SthanaBalaBreakdown {
+  const longitude = planet?.longitude;
+  const uccha = calculateUcchaBalaVirupa(planetName, longitude);
+  const saptavargaja = calculateSaptavargajaBalaVirupa(planetName, longitude);
+  const ojhayugma = calculateOjhayugmaBalaVirupa(planetName, longitude);
+  const kendradi = calculateKendradiBalaVirupa(house);
+  const drekkana = calculateDrekkanaBalaVirupa(planetName, longitude);
+  return { uccha, saptavargaja, ojhayugma, kendradi, drekkana, total: uccha + saptavargaja + ojhayugma + kendradi + drekkana };
+}
+
+function estimateSectFromSunHouse(chart: ShadbalaChartLike): 'day' | 'night' | 'unknown' {
+  const sunHouse = getPlanetHouse(getPlanet(chart, 'Sun'), chart?.ascendant?.sign);
+  if (typeof sunHouse !== 'number') return 'unknown';
+  return [7, 8, 9, 10, 11, 12].includes(sunHouse) ? 'day' : 'night';
+}
+
+function calculateNatonnataBalaVirupa(planetName: ShadbalaPlanet, sect: 'day' | 'night' | 'unknown'): number {
+  const pref = DAY_NIGHT_STRENGTH[planetName];
+  if (pref === 'both') return 60;
+  if (sect === 'unknown') return 0;
+  return pref === sect ? 60 : 0;
+}
+
+function calculatePakshaBalaVirupa(chart: ShadbalaChartLike): Partial<Record<ShadbalaPlanet, number>> {
+  const sun = getPlanet(chart, 'Sun');
+  const moon = getPlanet(chart, 'Moon');
+  if (typeof sun?.longitude !== 'number' || typeof moon?.longitude !== 'number') return {};
+  const elongation = normalizeLongitude(moon.longitude - sun.longitude);
+  const bright = elongation <= 180 ? (elongation / 180) * 60 : ((360 - elongation) / 180) * 60;
+  const dark = 60 - bright;
+  return { Moon: bright, Venus: bright, Jupiter: bright, Mercury: bright, Sun: dark, Mars: dark, Saturn: dark };
+}
+
+// Returns the Tribhaga lord for the given birth time.
+// Day (6am–6pm) thirds: Mercury (6–10am), Sun (10am–2pm), Saturn (2–6pm).
+// Night (6pm–6am) thirds: Moon (6–10pm), Venus (10pm–2am), Mars (2–6am).
+// Jupiter is strong in all six thirds. Approximation: assumes 6am sunrise/sunset.
+function getTribhagaLord(chart: ShadbalaChartLike): string | null {
+  const input = chart?.debug?.inputDateTime;
+  if (!input) return null;
+  const timeParts = input.split(' ')[1]?.split(':');
+  if (!timeParts) return null;
+  const localHour = parseInt(timeParts[0] ?? '0') + parseInt(timeParts[1] ?? '0') / 60;
+  const DAY_LORDS = ['Mercury', 'Sun', 'Saturn'];
+  const NIGHT_LORDS = ['Moon', 'Venus', 'Mars'];
+  if (localHour >= 6 && localHour < 18) return DAY_LORDS[Math.min(Math.floor((localHour - 6) / 4), 2)];
+  const nightHour = localHour >= 18 ? localHour - 18 : localHour + 6;
+  return NIGHT_LORDS[Math.min(Math.floor(nightHour / 4), 2)];
+}
+
+function calculateTribhaagaBalaVirupa(planetName: ShadbalaPlanet, chart: ShadbalaChartLike): number {
+  if (planetName === 'Jupiter') return 60;
+  return planetName === getTribhagaLord(chart) ? 60 : 0;
+}
+
+function calculateVarsheshadiBalaVirupa(planetName: ShadbalaPlanet, chart: ShadbalaChartLike): number {
+  const input = chart?.debug?.inputDateTime;
+  const date = input ? new Date(input) : null;
+  const dayLords = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn'];
+  const lord = date && !Number.isNaN(date.getTime()) ? dayLords[date.getDay()] : null;
+  if (!lord) return 0;
+  if (planetName === lord) return 60;
+  if (NATURAL_RELATIONS[planetName]?.friends.includes(lord)) return 30;
+  if (NATURAL_RELATIONS[planetName]?.enemies.includes(lord)) return 0;
+  return 15;
+}
+
+// Approximation of declination-based Ayana Bala. Uses sin(tropical longitude) as a proxy for
+// declination; valid near the ecliptic. Ayanamsha comes from chart.debug.ayanamsa (exact for date).
+function calculateAyanaBalaVirupa(planet: ShadbalaChartPlanet | undefined, ayanamsa: number | undefined): number {
+  if (typeof planet?.longitude !== 'number') return 0;
+  const ayan = typeof ayanamsa === 'number' ? ayanamsa : 24;
+  const tropicalLongitude = normalizeLongitude(planet.longitude + ayan);
+  return clamp(30 + 30 * Math.sin((tropicalLongitude * Math.PI) / 180), 0, 60);
+}
+
+export function calculateKalaBalaBreakdown(planetName: ShadbalaPlanet, chart: ShadbalaChartLike, planet: ShadbalaChartPlanet | undefined): KalaBalaBreakdown {
+  const sect = estimateSectFromSunHouse(chart);
+  const pakshaMap = calculatePakshaBalaVirupa(chart);
+  const natonnata = calculateNatonnataBalaVirupa(planetName, sect);
+  const paksha = pakshaMap[planetName] ?? 0;
+  const tribhaaga = calculateTribhaagaBalaVirupa(planetName, chart);
+  const tribhagaLord = getTribhagaLord(chart);
+  const varsheshadi = calculateVarsheshadiBalaVirupa(planetName, chart);
+  const ayana = calculateAyanaBalaVirupa(planet, chart?.debug?.ayanamsa);
+  return { sect, natonnata, paksha, tribhaaga, tribhagaLord, varsheshadi, ayana, total: natonnata + paksha + tribhaaga + varsheshadi + ayana };
+}
+
+// Approximation. Classical Cheshta Bala requires planet speed categories (Vakra/Sama/etc.).
+// Outer planets: retrograde (Vakra) = 60 virupa; direct = distance-from-Sun proxy.
+// Inner planets: distance-from-Sun proxy (elongation). Sun=30 (fixed); Moon=60 (fixed).
+export function calculateCheshtaBalaVirupa(planetName: ShadbalaPlanet, chart: ShadbalaChartLike, planet: ShadbalaChartPlanet | undefined): number {
+  if (planetName === 'Sun') return 30;
+  if (planetName === 'Moon') return 60;
+  const sun = getPlanet(chart, 'Sun');
+  if (typeof sun?.longitude !== 'number' || typeof planet?.longitude !== 'number') return 0;
+  const distance = circularDegreeDistance(planet.longitude, sun.longitude);
+  if (planetName === 'Mars' || planetName === 'Jupiter' || planetName === 'Saturn') {
+    if (planet.isRetrograde) return 60;
+    return clamp((distance / 180) * 60, 0, 60);
+  }
+  return clamp(60 * (1 - Math.abs(distance - 60) / 120), 0, 60);
+}
+
+function aspectOrbStrength(diff: number, exact: number, orb = 30): number {
+  const delta = Math.abs(diff - exact);
+  return delta <= orb ? 1 - delta / orb : 0;
+}
+
+function getAspectStrength(fromName: ShadbalaPlanet, fromLongitude: number, toLongitude: number): number {
+  const diff = normalizeLongitude(toLongitude - fromLongitude);
+  let strength = aspectOrbStrength(diff, 180, 45);
+  if (fromName === 'Mars') strength = Math.max(strength, aspectOrbStrength(diff, 90, 35), aspectOrbStrength(diff, 210, 35));
+  if (fromName === 'Jupiter') strength = Math.max(strength, aspectOrbStrength(diff, 120, 35), aspectOrbStrength(diff, 240, 35));
+  if (fromName === 'Saturn') strength = Math.max(strength, aspectOrbStrength(diff, 60, 35), aspectOrbStrength(diff, 270, 35));
+  return clamp(strength, 0, 1);
+}
+
+// Approximation. Classical Drig Bala uses drishti-pinda (aspect points) with fixed weights.
+// Here: +45 virupa per benefic aspect, −30 per malefic aspect. No arbitrary base score.
+// Aspect orbs are custom (not classical exact-aspect). Negative values allowed per classical convention.
+export function calculateDrikBalaVirupa(targetName: ShadbalaPlanet, chart: ShadbalaChartLike): number {
+  const target = getPlanet(chart, targetName);
+  if (typeof target?.longitude !== 'number') return 0;
+  const targetLongitude = target.longitude;
+  let score = 0;
+  SCORE_PLANETS.forEach((fromName) => {
+    if (fromName === targetName) return;
+    const from = getPlanet(chart, fromName);
+    if (typeof from?.longitude !== 'number') return;
+    const aspect = getAspectStrength(fromName, from.longitude, targetLongitude);
+    if (!aspect) return;
+    score += (BENEFICS.includes(fromName) ? 45 : -30) * aspect;
+  });
+  return score;
+}
+
+export function buildShadbalaRows(chart: ShadbalaChartLike): ShadbalaRow[] {
+  const ascendantSign = chart?.ascendant?.sign;
+  return SCORE_PLANETS
+    .map((planetName): ShadbalaRow | null => {
+      const planet = getPlanet(chart, planetName);
+      if (!planet) return null;
+      const house = getPlanetHouse(planet, ascendantSign);
+      const sthanaBreakdown = calculateSthanaBalaBreakdown(planetName, planet, house);
+      const kalaBreakdown = calculateKalaBalaBreakdown(planetName, chart, planet);
+      const naisargikaVirupa = NAISARGIKA_BALA_VIRUPA[planetName] ?? 0;
+      const digVirupa = calculateDigBalaVirupa(planetName, house);
+      const cheshtaVirupa = calculateCheshtaBalaVirupa(planetName, chart, planet);
+      const drikVirupa = calculateDrikBalaVirupa(planetName, chart);
+      const totalVirupa = sthanaBreakdown.total + digVirupa + kalaBreakdown.total + cheshtaVirupa + naisargikaVirupa + drikVirupa;
+      const requiredVirupa = SHADBALA_REQUIRED_VIRUPA[planetName] ?? 0;
+      return {
+        planet: planetName,
+        house,
+        retrograde: planet.isRetrograde ?? false,
+        sthana: virupaToRupa(sthanaBreakdown.total),
+        sthanaBreakdown,
+        dig: virupaToRupa(digVirupa),
+        digVirupa,
+        kala: virupaToRupa(kalaBreakdown.total),
+        kalaBreakdown,
+        cheshta: virupaToRupa(cheshtaVirupa),
+        cheshtaVirupa,
+        naisargika: virupaToRupa(naisargikaVirupa),
+        naisargikaVirupa,
+        drik: virupaToRupa(drikVirupa),
+        drikVirupa,
+        total: virupaToRupa(totalVirupa),
+        totalVirupa,
+        requiredVirupa,
+        ratio: requiredVirupa ? totalVirupa / requiredVirupa : 0,
+      };
+    })
+    .filter((row): row is ShadbalaRow => row !== null);
+}

--- a/src/pages/VargaMatrix.jsx
+++ b/src/pages/VargaMatrix.jsx
@@ -1,40 +1,17 @@
 'use client';
 
 import { useState, Fragment } from 'react';
-import { getVargaSignIndex, getSignIndex, getDegreesInSign } from '@/lib/varga';
+import { getVargaSignIndex } from '@/lib/varga';
 import { buildClassicalBhavaBala } from '@/lib/bhavaBala';
+// The Shadbala engine used to live in this file as untyped one-liners; it now
+// has types and fixtures in src/lib/shadbala.ts. This file keeps only the UI
+// cards plus the varga-matrix and Vimsopaka display calculations.
+import { buildShadbalaRows, getDignity, SCORE_PLANETS } from '@/lib/shadbala';
 
 const SIGN_ABBR = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
 const DEFAULT_DIVISIONS = [1, 2, 3, 4, 7, 9, 10, 12, 16, 20, 24, 27, 30, 40, 45, 60];
 const ROW_ORDER = ['Lagna', 'Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn', 'Rahu', 'Ketu'];
-const SCORE_PLANETS = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn'];
-const BENEFICS = ['Moon', 'Mercury', 'Jupiter', 'Venus'];
-const MALEFICS = ['Sun', 'Mars', 'Saturn'];
-const SIGN_LORDS = ['Mars', 'Venus', 'Mercury', 'Moon', 'Sun', 'Mercury', 'Venus', 'Mars', 'Jupiter', 'Saturn', 'Saturn', 'Jupiter'];
-const OWN_SIGNS = { Sun: [4], Moon: [3], Mars: [0, 7], Mercury: [2, 5], Jupiter: [8, 11], Venus: [1, 6], Saturn: [9, 10] };
-const EXALTATION_SIGNS = { Sun: 0, Moon: 1, Mars: 9, Mercury: 5, Jupiter: 3, Venus: 11, Saturn: 6 };
-const DEBILITATION_SIGNS = { Sun: 6, Moon: 7, Mars: 3, Mercury: 11, Jupiter: 9, Venus: 5, Saturn: 0 };
-const EXALTATION_LONGITUDES = { Sun: 10, Moon: 33, Mars: 298, Mercury: 165, Jupiter: 95, Venus: 357, Saturn: 200 };
-const SHADBALA_REQUIRED_VIRUPA = { Sun: 390, Moon: 360, Mars: 300, Mercury: 420, Jupiter: 390, Venus: 330, Saturn: 300 };
-const NAISARGIKA_BALA_VIRUPA = { Sun: 60, Moon: 51, Venus: 43, Jupiter: 34, Mercury: 26, Mars: 17, Saturn: 9 };
-const DIG_BALA_MAX_HOUSE = { Sun: 10, Mars: 10, Moon: 4, Venus: 4, Jupiter: 1, Mercury: 1, Saturn: 7 };
-const ODD_EVEN_STRENGTH = { Sun: 'odd', Mars: 'odd', Jupiter: 'odd', Moon: 'even', Venus: 'even', Mercury: 'both', Saturn: 'both' };
-const DREKKANA_STRENGTH = { Sun: 1, Mars: 1, Jupiter: 1, Mercury: 2, Saturn: 2, Moon: 3, Venus: 3 };
-const DAY_NIGHT_STRENGTH = { Sun: 'day', Jupiter: 'day', Venus: 'day', Moon: 'night', Mars: 'night', Saturn: 'night', Mercury: 'both' };
-const NATURAL_RELATIONS = {
-  Sun: { friends: ['Moon', 'Mars', 'Jupiter'], neutral: ['Mercury'], enemies: ['Venus', 'Saturn'] },
-  Moon: { friends: ['Sun', 'Mercury'], neutral: ['Mars', 'Jupiter', 'Venus', 'Saturn'], enemies: [] },
-  Mars: { friends: ['Sun', 'Moon', 'Jupiter'], neutral: ['Venus', 'Saturn'], enemies: ['Mercury'] },
-  Mercury: { friends: ['Sun', 'Venus'], neutral: ['Mars', 'Jupiter', 'Saturn'], enemies: ['Moon'] },
-  Jupiter: { friends: ['Sun', 'Moon', 'Mars'], neutral: ['Saturn'], enemies: ['Mercury', 'Venus'] },
-  Venus: { friends: ['Mercury', 'Saturn'], neutral: ['Mars', 'Jupiter'], enemies: ['Sun', 'Moon'] },
-  Saturn: { friends: ['Mercury', 'Venus'], neutral: ['Jupiter'], enemies: ['Sun', 'Moon', 'Mars'] },
-};
 const DIGNITY_VISWA = { exalted: 20, own: 20, friend: 15, neutral: 10, enemy: 7, debilitated: 0, none: 0 };
-// Classical Saptavargaja Bala virupa per dignity (BPHS Ch.27). Used as per-varga weights;
-// the sum across 7 vargas is divided by 7 so max = 45 (exalted in all 7).
-// Exact (table-based). Moolatrikona treated as own since getDignity() doesn't distinguish it.
-const SAPTAVARGAJA_VIRUPA = { exalted: 45, own: 30, friend: 22.5, neutral: 7.5, enemy: 3.75, debilitated: 0, none: 0 };
 const DIGNITY_LABELS = { exalted: 'Ex', own: 'Own', friend: 'Fr', neutral: 'Neu', enemy: 'En', debilitated: 'Deb', none: '—' };
 const VIMSOPAKA_SCHEMES = {
   shadvarga: { label: 'Ṣaḍvarga', weights: { D1: 6, D2: 2, D3: 4, D9: 5, D12: 2, D30: 1 } },
@@ -43,54 +20,10 @@ const VIMSOPAKA_SCHEMES = {
   shodasavarga: { label: 'Ṣoḍaśavarga', weights: { D1: 3.5, D2: 1, D3: 1, D4: 0.5, D7: 0.5, D9: 3, D10: 0.5, D12: 0.5, D16: 2, D20: 0.5, D24: 0.5, D27: 0.5, D30: 1, D40: 0.5, D45: 0.5, D60: 4 } },
 };
 
-export { getSignIndex, getDegreesInSign };
 export function getVargaSign(longitude, division) { return getVargaSignIndex(longitude, division); }
-// See src/lib/varga/utils.ts — the ((x % 360) + 360) % 360 form loses low mantissa
-// bits on values that were already in range.
-function normalizeDegrees(value) { const wrapped = value % 360; return wrapped < 0 ? wrapped + 360 : wrapped; }
-function virupaToRupa(virupa) { return virupa / 60; }
 function formatScore(value) { return Number.isFinite(value) ? value.toFixed(2).replace(/\.00$/, '') : '—'; }
-function clamp(value, min, max) { return Math.max(min, Math.min(max, value)); }
-function getPlanet(chart, name) { return (chart?.planets ?? []).find((p) => p.name === name); }
-function getPlanetHouse(planet, ascendantSign) { if (typeof planet?.house === 'number') return planet.house; if (typeof planet?.sign !== 'number' || typeof ascendantSign !== 'number') return null; return ((planet.sign - ascendantSign + 12) % 12) + 1; }
-function circularHouseDistance(a, b) { const raw = Math.abs(a - b) % 12; return Math.min(raw, 12 - raw); }
-function circularDegreeDistance(a, b) { const raw = Math.abs(normalizeDegrees(a) - normalizeDegrees(b)); return Math.min(raw, 360 - raw); }
-
-function getDignity(planet, signIndex) { if (!SCORE_PLANETS.includes(planet) || typeof signIndex !== 'number') return 'none'; if (DEBILITATION_SIGNS[planet] === signIndex) return 'debilitated'; if (EXALTATION_SIGNS[planet] === signIndex) return 'exalted'; if (OWN_SIGNS[planet]?.includes(signIndex)) return 'own'; const signLord = SIGN_LORDS[signIndex]; const relation = NATURAL_RELATIONS[planet]; if (relation?.friends.includes(signLord)) return 'friend'; if (relation?.enemies.includes(signLord)) return 'enemy'; return 'neutral'; }
 function getDignityCellClass(dignity) { switch (dignity) { case 'exalted': case 'own': return 'bg-emerald-50 dark:bg-emerald-950/35 text-emerald-800 dark:text-emerald-200 border-emerald-200 dark:border-emerald-800/70'; case 'friend': return 'bg-lime-50 dark:bg-lime-950/25 text-lime-800 dark:text-lime-200 border-lime-200 dark:border-lime-800/50'; case 'neutral': return 'bg-zinc-50 dark:bg-zinc-800/45 text-zinc-700 dark:text-zinc-300 border-zinc-100 dark:border-zinc-800'; case 'enemy': return 'bg-orange-50 dark:bg-orange-950/30 text-orange-800 dark:text-orange-200 border-orange-200 dark:border-orange-800/60'; case 'debilitated': return 'bg-red-50 dark:bg-red-950/35 text-red-800 dark:text-red-200 border-red-200 dark:border-red-800/70'; default: return 'text-zinc-700 dark:text-zinc-300 border-zinc-100 dark:border-zinc-800'; } }
 
-function calculateDigBalaVirupa(planetName, house) { const maxHouse = DIG_BALA_MAX_HOUSE[planetName]; if (!maxHouse || typeof house !== 'number') return 0; return clamp(60 * (1 - circularHouseDistance(house, maxHouse) / 6), 0, 60); }
-function calculateUcchaBalaVirupa(planetName, longitude) { const exaltLongitude = EXALTATION_LONGITUDES[planetName]; if (typeof exaltLongitude !== 'number' || typeof longitude !== 'number') return 0; return clamp(60 * (1 - circularDegreeDistance(longitude, exaltLongitude) / 180), 0, 60); }
-function calculateSaptavargajaBalaVirupa(planetName, longitude) { return [1, 2, 3, 7, 9, 12, 30].reduce((sum, d) => sum + (SAPTAVARGAJA_VIRUPA[getDignity(planetName, getVargaSign(longitude, d))] ?? 0), 0) / 7; }
-function calculateOjhayugmaBalaVirupa(planetName, longitude) { const preference = ODD_EVEN_STRENGTH[planetName]; if (!preference || typeof longitude !== 'number') return 0; if (preference === 'both') return 15; const signMatches = (signIndex) => preference === 'odd' ? signIndex % 2 === 0 : signIndex % 2 === 1; return (signMatches(getVargaSign(longitude, 1)) ? 15 : 0) + (signMatches(getVargaSign(longitude, 9)) ? 15 : 0); }
-function calculateKendradiBalaVirupa(house) { if (typeof house !== 'number') return 0; if ([1, 4, 7, 10].includes(house)) return 60; if ([2, 5, 8, 11].includes(house)) return 30; return 15; }
-function calculateDrekkanaBalaVirupa(planetName, longitude) { const preferred = DREKKANA_STRENGTH[planetName]; if (!preferred || typeof longitude !== 'number') return 0; return Math.floor(getDegreesInSign(longitude) / 10) + 1 === preferred ? 15 : 0; }
-function calculateSthanaBalaBreakdown(planetName, planet, house) { const longitude = planet?.longitude; const uccha = calculateUcchaBalaVirupa(planetName, longitude); const saptavargaja = calculateSaptavargajaBalaVirupa(planetName, longitude); const ojhayugma = calculateOjhayugmaBalaVirupa(planetName, longitude); const kendradi = calculateKendradiBalaVirupa(house); const drekkana = calculateDrekkanaBalaVirupa(planetName, longitude); return { uccha, saptavargaja, ojhayugma, kendradi, drekkana, total: uccha + saptavargaja + ojhayugma + kendradi + drekkana }; }
-function estimateSectFromSunHouse(chart) { const sunHouse = getPlanetHouse(getPlanet(chart, 'Sun'), chart?.ascendant?.sign); if (typeof sunHouse !== 'number') return 'unknown'; return [7, 8, 9, 10, 11, 12].includes(sunHouse) ? 'day' : 'night'; }
-function calculateNatonnataBalaVirupa(planetName, sect) { const pref = DAY_NIGHT_STRENGTH[planetName]; if (pref === 'both') return 60; if (sect === 'unknown') return 0; return pref === sect ? 60 : 0; }
-function calculatePakshaBalaVirupa(chart) { const sun = getPlanet(chart, 'Sun'); const moon = getPlanet(chart, 'Moon'); if (typeof sun?.longitude !== 'number' || typeof moon?.longitude !== 'number') return {}; const elongation = normalizeDegrees(moon.longitude - sun.longitude); const bright = elongation <= 180 ? (elongation / 180) * 60 : ((360 - elongation) / 180) * 60; const dark = 60 - bright; return { Moon: bright, Venus: bright, Jupiter: bright, Mercury: bright, Sun: dark, Mars: dark, Saturn: dark }; }
-// Returns the Tribhaga lord for the given birth time.
-// Day (6am–6pm) thirds: Mercury (6–10am), Sun (10am–2pm), Saturn (2–6pm).
-// Night (6pm–6am) thirds: Moon (6–10pm), Venus (10pm–2am), Mars (2–6am).
-// Jupiter is strong in all six thirds. Approximation: assumes 6am sunrise/sunset.
-function getTribhagaLord(chart) { const input = chart?.debug?.inputDateTime; if (!input) return null; const timeParts = input.split(' ')[1]?.split(':'); if (!timeParts) return null; const localHour = parseInt(timeParts[0] ?? '0') + parseInt(timeParts[1] ?? '0') / 60; const DAY_LORDS = ['Mercury', 'Sun', 'Saturn']; const NIGHT_LORDS = ['Moon', 'Venus', 'Mars']; if (localHour >= 6 && localHour < 18) return DAY_LORDS[Math.min(Math.floor((localHour - 6) / 4), 2)]; const nightHour = localHour >= 18 ? localHour - 18 : localHour + 6; return NIGHT_LORDS[Math.min(Math.floor(nightHour / 4), 2)]; }
-function calculateTribhaagaBalaVirupa(planetName, chart) { if (planetName === 'Jupiter') return 60; return planetName === getTribhagaLord(chart) ? 60 : 0; }
-function calculateVarsheshadiBalaVirupa(planetName, chart) { const input = chart?.debug?.inputDateTime; const d = input ? new Date(input) : null; const dayLords = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn']; const lord = d && !Number.isNaN(d.getTime()) ? dayLords[d.getDay()] : null; if (!lord) return 0; if (planetName === lord) return 60; if (NATURAL_RELATIONS[planetName]?.friends.includes(lord)) return 30; if (NATURAL_RELATIONS[planetName]?.enemies.includes(lord)) return 0; return 15; }
-// Approximation of declination-based Ayana Bala. Uses sin(tropical longitude) as a proxy for
-// declination; valid near the ecliptic. Ayanamsha comes from chart.debug.ayanamsa (exact for date).
-function calculateAyanaBalaVirupa(planet, ayanamsa) { if (typeof planet?.longitude !== 'number') return 0; const ayan = typeof ayanamsa === 'number' ? ayanamsa : 24; const tropicalLongitude = normalizeDegrees(planet.longitude + ayan); return clamp(30 + 30 * Math.sin((tropicalLongitude * Math.PI) / 180), 0, 60); }
-function calculateKalaBalaBreakdown(planetName, chart, planet) { const sect = estimateSectFromSunHouse(chart); const pakshaMap = calculatePakshaBalaVirupa(chart); const natonnata = calculateNatonnataBalaVirupa(planetName, sect); const paksha = pakshaMap[planetName] ?? 0; const tribhaaga = calculateTribhaagaBalaVirupa(planetName, chart); const tribhagaLord = getTribhagaLord(chart); const varsheshadi = calculateVarsheshadiBalaVirupa(planetName, chart); const ayana = calculateAyanaBalaVirupa(planet, chart?.debug?.ayanamsa); return { sect, natonnata, paksha, tribhaaga, tribhagaLord, varsheshadi, ayana, total: natonnata + paksha + tribhaaga + varsheshadi + ayana }; }
-// Approximation. Classical Cheshta Bala requires planet speed categories (Vakra/Sama/etc.).
-// Outer planets: retrograde (Vakra) = 60 virupa; direct = distance-from-Sun proxy.
-// Inner planets: distance-from-Sun proxy (elongation). Sun=30 (fixed); Moon=60 (fixed).
-function calculateCheshtaBalaVirupa(planetName, chart, planet) { if (planetName === 'Sun') return 30; if (planetName === 'Moon') return 60; const sun = getPlanet(chart, 'Sun'); if (typeof sun?.longitude !== 'number' || typeof planet?.longitude !== 'number') return 0; const distance = circularDegreeDistance(planet.longitude, sun.longitude); if (['Mars', 'Jupiter', 'Saturn'].includes(planetName)) { if (planet.isRetrograde) return 60; return clamp((distance / 180) * 60, 0, 60); } if (['Mercury', 'Venus'].includes(planetName)) return clamp(60 * (1 - Math.abs(distance - 60) / 120), 0, 60); return 0; }
-function aspectOrbStrength(diff, exact, orb = 30) { const delta = Math.abs(diff - exact); return delta <= orb ? 1 - delta / orb : 0; }
-function getAspectStrength(fromName, fromLongitude, toLongitude) { const diff = normalizeDegrees(toLongitude - fromLongitude); let strength = aspectOrbStrength(diff, 180, 45); if (fromName === 'Mars') strength = Math.max(strength, aspectOrbStrength(diff, 90, 35), aspectOrbStrength(diff, 210, 35)); if (fromName === 'Jupiter') strength = Math.max(strength, aspectOrbStrength(diff, 120, 35), aspectOrbStrength(diff, 240, 35)); if (fromName === 'Saturn') strength = Math.max(strength, aspectOrbStrength(diff, 60, 35), aspectOrbStrength(diff, 270, 35)); return clamp(strength, 0, 1); }
-// Approximation. Classical Drig Bala uses drishti-pinda (aspect points) with fixed weights.
-// Here: +45 virupa per benefic aspect, −30 per malefic aspect. No arbitrary base score.
-// Aspect orbs are custom (not classical exact-aspect). Negative values allowed per classical convention.
-function calculateDrikBalaVirupa(targetName, chart) { const target = getPlanet(chart, targetName); if (typeof target?.longitude !== 'number') return 0; let score = 0; SCORE_PLANETS.forEach((fromName) => { if (fromName === targetName) return; const from = getPlanet(chart, fromName); if (typeof from?.longitude !== 'number') return; const aspect = getAspectStrength(fromName, from.longitude, target.longitude); if (!aspect) return; score += (BENEFICS.includes(fromName) ? 45 : -30) * aspect; }); return score; }
-function buildShadbalaRows(chart) { const ascendantSign = chart?.ascendant?.sign; return SCORE_PLANETS.map((planetName) => { const planet = getPlanet(chart, planetName); if (!planet) return null; const house = getPlanetHouse(planet, ascendantSign); const sthanaBreakdown = calculateSthanaBalaBreakdown(planetName, planet, house); const kalaBreakdown = calculateKalaBalaBreakdown(planetName, chart, planet); const naisargikaVirupa = NAISARGIKA_BALA_VIRUPA[planetName] ?? 0; const digVirupa = calculateDigBalaVirupa(planetName, house); const cheshtaVirupa = calculateCheshtaBalaVirupa(planetName, chart, planet); const drikVirupa = calculateDrikBalaVirupa(planetName, chart); const totalVirupa = sthanaBreakdown.total + digVirupa + kalaBreakdown.total + cheshtaVirupa + naisargikaVirupa + drikVirupa; const totalRupa = virupaToRupa(totalVirupa); const requiredVirupa = SHADBALA_REQUIRED_VIRUPA[planetName] ?? 0; return { planet: planetName, house, retrograde: planet.isRetrograde ?? false, sthana: virupaToRupa(sthanaBreakdown.total), sthanaBreakdown, dig: virupaToRupa(digVirupa), digVirupa, kala: virupaToRupa(kalaBreakdown.total), kalaBreakdown, cheshta: virupaToRupa(cheshtaVirupa), cheshtaVirupa, naisargika: virupaToRupa(naisargikaVirupa), naisargikaVirupa, drik: virupaToRupa(drikVirupa), drikVirupa, total: totalRupa, totalVirupa, requiredVirupa, ratio: requiredVirupa ? totalVirupa / requiredVirupa : 0 }; }).filter(Boolean); }
 
 
 export function buildVargaMatrix(planets = {}, lagna, divisions = DEFAULT_DIVISIONS) { const source = { Lagna: lagna, ...planets }; const matrix = {}; ROW_ORDER.forEach((name) => { matrix[name] = {}; divisions.forEach((division) => { const key = `D${division}`; const longitude = source[name]; if (typeof longitude !== 'number') { matrix[name][key] = { sign: '—', signIndex: null, dignity: 'none' }; return; } const signIndex = getVargaSign(longitude, division); matrix[name][key] = { sign: SIGN_ABBR[signIndex], signIndex, dignity: getDignity(name, signIndex) }; }); }); return matrix; }
@@ -178,23 +111,6 @@ export function VargaStrengthCard({ chart }) {
     </div>
   );
 }
-
-// Exported for src/lib/shadbala.test.ts. The Shadbala engine lives in this file
-// rather than in src/lib because the card grew around it; the tests import the
-// pure pieces directly so they exercise the real implementation.
-export {
-  NAISARGIKA_BALA_VIRUPA,
-  SHADBALA_REQUIRED_VIRUPA,
-  DIG_BALA_MAX_HOUSE,
-  buildShadbalaRows,
-  calculateDigBalaVirupa,
-  calculateUcchaBalaVirupa,
-  calculateKendradiBalaVirupa,
-  calculateOjhayugmaBalaVirupa,
-  calculateDrekkanaBalaVirupa,
-  calculateSaptavargajaBalaVirupa,
-  virupaToRupa,
-};
 
 export function ShadbalaCard({ chart }) {
   const [showDebug, setShowDebug] = useState(false);

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,45 +196,22 @@ export interface RasiDashaOptions {
   sthiraMethod: 'brahma-pvr';
 }
 
+// v2.15 removed the 20+ never-implemented placeholder keys (tara, brahma,
+// drig, …) that only ever existed in this type and in the registry's
+// "Other systems" group. Stored settings containing them still parse:
+// migrateDashaSettings keeps the keys below and drops the rest.
 export interface DashaSettings {
   dashas: {
     bcp: boolean;
     vimshottari: boolean;
     vds: boolean;
-    tara?: boolean;
-    yogini?: boolean;
     chara?: boolean;
-    charaBeta?: boolean;
-    narayana?: boolean;
-    kaalChakra?: boolean;
-    kalaChakra?: boolean;
+    yogini?: boolean;
     ashtottari?: boolean;
-    shodashottari?: boolean;
-    dwadashottari?: boolean;
-    panchottari?: boolean;
-    shatabdika?: boolean;
-    chaturashitiSama?: boolean;
-    dwisaptatiSama?: boolean;
-    shashtihayani?: boolean;
-    shattrimshaSama?: boolean;
-    sudarshanaChakra?: boolean;
+    kalaChakra?: boolean;
+    narayana?: boolean;
     moola?: boolean;
-    naisargika?: boolean;
-    pinda?: boolean;
-    mandooka?: boolean;
-    manduka?: boolean;
     sthira?: boolean;
-    brahma?: boolean;
-    drig?: boolean;
-    trikona?: boolean;
-    kendradi?: boolean;
-    karaka?: boolean;
-    lagnaKendradiRashi?: boolean;
-    atmakarakaKendradiRashi?: boolean;
-    shoola?: boolean;
-    muktashtaka?: boolean;
-    gangadhar?: boolean;
-    yogaVimshottari?: boolean;
   };
   charaOptions?: CharaOptions;
   rasiOptions?: RasiDashaOptions;
@@ -245,40 +222,13 @@ export const DEFAULT_DASHA_SETTINGS: Required<DashaSettings> = {
     bcp: true,
     vimshottari: true,
     vds: false,
-    tara: false,
-    yogini: true,
     chara: false,
-    charaBeta: false,
-    narayana: true,
-    kaalChakra: false,
-    kalaChakra: false,
+    yogini: true,
     ashtottari: true,
-    shodashottari: false,
-    dwadashottari: false,
-    panchottari: false,
-    shatabdika: false,
-    chaturashitiSama: false,
-    dwisaptatiSama: false,
-    shashtihayani: false,
-    shattrimshaSama: false,
-    sudarshanaChakra: false,
+    kalaChakra: false,
+    narayana: true,
     moola: true,
-    naisargika: false,
-    pinda: false,
-    mandooka: false,
-    manduka: false,
     sthira: true,
-    brahma: false,
-    drig: false,
-    trikona: false,
-    kendradi: false,
-    karaka: false,
-    lagnaKendradiRashi: false,
-    atmakarakaKendradiRashi: false,
-    shoola: false,
-    muktashtaka: false,
-    gangadhar: false,
-    yogaVimshottari: false,
   },
   charaOptions: {
     start: 'lagna',


### PR DESCRIPTION
Items 1–5 from the post-v2.14 review, verified end to end in the browser.

## 1. Render loop — production bug, now gone

The BCP recompute effect in `page.tsx` had `bcpResult` in its own dependency array while calling `setBcpResult(calculateBcp(...))` with a fresh object every run, so **every calculated chart** looped the effect until React aborted with `Maximum update depth exceeded` (present on pristine v2.13/v2.14). Rewritten as a functional update, `bcpResult` removed from the deps.

**Verified:** calculating a chart on this branch produces zero console errors; the identical flow on v2.14 produced dozens.

## 2. Settings loss on reload — found while doing item 5

`migrateDashaSettings` rebuilt stored settings from `bcp`/`vimshottari`/`vds` only. Every other system toggle and **all Chara/Rāśi method options** silently reverted to defaults on each app start. The migration now copies every key present in `DashaSettings` and merges `charaOptions`/`rasiOptions` over the defaults.

**Verified E2E:** wrote non-default settings (Chara on, Yoginī off, Aṣṭottarī off, Kālachakra on, Scorpio lord = Mars) plus junk keys (`brahma`, `tara`) to localStorage, reloaded — every toggle and the method option survived, junk keys dropped cleanly.

## 3. Shadbala engine extracted

Moved from the untyped 458-line `VargaMatrix.jsx` into typed `src/lib/shadbala.ts` — maths unchanged, UI cards stay in the jsx, `shadbala.test.ts` imports the typed module directly (no more `Record` widening).

## 4. Varāhamihira selector removed

After the v2.14 Parashara fix the variant table differed by one unverified row, so the selector implied a sourced Brihat Jataka table that doesn't exist. Selector and table removed; the one-row Venus/Mars delta is documented in a comment for future re-add once verified against a primary source. AV tab verified: values still classical (SAV 337).

## 5. Registry cleanup

Removed the 22 never-implemented "Other systems" placeholder rows and their dead `DashaSettings` keys (plus five orphan keys nothing read: `kaalChakra`, `shoola`, `muktashtaka`, `gangadhar`, `yogaVimshottari`). Settings panel shows the same nine real systems as before.

Also: `actions/checkout` and `actions/setup-node` bumped v4 → v5 in both workflows (Node 20 runner deprecation).

## Verification

- `npm test` — 22/22 pass
- `npm run typecheck` — clean
- `npm run build` — succeeds
- Browser: v2.15 renders, chart calculation clean console, settings survive reload, AV table correct
- Lint: same 11 pre-existing errors, none added (the set-state-in-effect rule still flags the rewritten effect syntactically even though the runtime loop is proven gone — lint stays non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
