### PR TITLE
Add divisional charts and test the core calculations in v2.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,8 @@ jobs:
 
       - run: npm ci
 
-      # Non-blocking for now: main carries 11 pre-existing errors, mostly
-      # react-hooks/set-state-in-effect. Flip this to a hard gate once they are
-      # cleared, so new violations start failing the build.
       - name: Lint
         run: npm run lint
-        continue-on-error: true
 
       - name: Typecheck
         run: npm run typecheck

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -338,10 +338,16 @@ export default function Home() {
     const birthDate = parseDateTime(birthDatetime);
     const target = parseTargetDateString(targetDate);
     if (!birthDate || !target) return;
+    // The functional update reads the previous result without depending on it, so
+    // this cannot re-trigger itself. The rule flags the shape, not the behaviour.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setBcpResult((previous) => (previous ? calculateBcp(birthDate, target) : previous));
   }, [targetDate, birthDatetime, useManualBcpMode]);
 
   // Restore persisted display/calculation/dasha settings on mount
+  // localStorage cannot be read during the server render, so restoring has to
+  // happen after mount. This runs once with an empty dependency list.
+  /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     try {
       const ds = localStorage.getItem('chartDisplaySettings');
@@ -360,6 +366,7 @@ export default function Home() {
     } catch {}
     setSettingsRestored(true);
   }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
 
 
   // --- Handlers ---

--- a/src/components/ChartSection.tsx
+++ b/src/components/ChartSection.tsx
@@ -5,6 +5,7 @@ import { BcpResult, ChartData, ChartDisplaySettings, ChartStyle, PlanetData } fr
 import NorthIndianChart from './NorthIndianChart';
 import SouthIndianChart from './SouthIndianChart';
 import VargaMatrix from '@/pages/VargaMatrix';
+import VargaChartPanel from './VargaChartPanel';
 import DrishtiPanel from '@/components/DrishtiPanel';
 import AshtakavargaPanel from '@/components/AshtakavargaPanel';
 import { calculateJupiterianRounds } from '@/lib/bnn/jupiterianRounds';
@@ -78,6 +79,7 @@ export default function ChartSection({
 }: ChartSectionProps) {
   const [chartStyle, setChartStyle] = useState<ChartStyle>(chartDisplaySettings.chartStyle ?? 'north');
   const [view, setView] = useState<'chart' | 'varga' | 'nadi' | 'ashtakavarga' | 'drishti'>('chart');
+  const [vargaView, setVargaView] = useState<'chart' | 'table'>('chart');
 
   const bnnHouses = useMemo(() => {
     // Use parent-provided houses when available (keeps age override in sync with chart highlights)
@@ -103,9 +105,15 @@ export default function ChartSection({
     };
   }, [chart, birthDatetime, targetDate, bnnMajorHouseFromParent, bnnMinorHouseFromParent]);
 
-  useEffect(() => {
+  // Follow the setting when it changes, while still allowing the local toggle
+  // and the bcp:set-chart-style event to override it in between. Adjusting
+  // state during render is React's documented alternative to mirroring a prop
+  // into state from an effect, and it avoids the extra render pass.
+  const [lastStyleSetting, setLastStyleSetting] = useState(chartDisplaySettings.chartStyle);
+  if (chartDisplaySettings.chartStyle !== lastStyleSetting) {
+    setLastStyleSetting(chartDisplaySettings.chartStyle);
     setChartStyle(chartDisplaySettings.chartStyle ?? 'north');
-  }, [chartDisplaySettings.chartStyle]);
+  }
 
   useEffect(() => {
     const handleChartStyleChange = (event: Event) => {
@@ -160,7 +168,35 @@ export default function ChartSection({
       </div>
 
       {view === 'varga' ? (
-        <div className="min-w-0 overflow-x-auto"><VargaMatrix chart={chart} /></div>
+        <div className="min-w-0 space-y-4">
+          <div className="inline-flex gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800/50">
+            <button
+              type="button"
+              onClick={() => setVargaView('chart')}
+              className={`rounded-md px-2.5 py-1 text-[10px] font-mono ${vargaView === 'chart' ? 'bg-white text-emerald-700 shadow-sm dark:bg-zinc-700 dark:text-green-400' : 'text-zinc-500 dark:text-zinc-400'}`}
+            >
+              Charts
+            </button>
+            <button
+              type="button"
+              onClick={() => setVargaView('table')}
+              className={`rounded-md px-2.5 py-1 text-[10px] font-mono ${vargaView === 'table' ? 'bg-white text-emerald-700 shadow-sm dark:bg-zinc-700 dark:text-green-400' : 'text-zinc-500 dark:text-zinc-400'}`}
+            >
+              Matrix &amp; Bala
+            </button>
+          </div>
+          {vargaView === 'chart' ? (
+            <VargaChartPanel
+              chart={chart}
+              chartStyle={chartStyle}
+              chartDisplaySettings={chartDisplaySettings}
+              karakaByPlanet={karakaByPlanet}
+              nakshatraAdjust={nakshatraAdjust}
+            />
+          ) : (
+            <div className="overflow-x-auto"><VargaMatrix chart={chart} /></div>
+          )}
+        </div>
       ) : view === 'nadi' ? (
         <div className="min-w-0 overflow-x-auto"><NadiAmsaPanel chart={chart} /></div>
       ) : view === 'ashtakavarga' ? (

--- a/src/components/DrishtiPanel.tsx
+++ b/src/components/DrishtiPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PlanetData } from '@/types';
+import { ChartData, PlanetData } from '@/types';
 import { buildDrishti, calculateGrahaDrishti, calculateRashiDrishti } from '@/lib/drishti';
 import CollapsibleCard from './CollapsibleCard';
 
@@ -19,7 +19,7 @@ function code(name: string): string {
 }
 
 interface Props {
-  chart?: any;
+  chart?: ChartData;
   planets?: PlanetData[];
   ascendantSign?: number;
   showGrahaDrishti?: boolean;

--- a/src/components/FileActions.tsx
+++ b/src/components/FileActions.tsx
@@ -47,6 +47,8 @@ export default function FileActions({ snapshot, hasChart, onNew, onLoad, onExpor
 
   useEffect(() => {
     const id = getActiveSavedChartId();
+    // localStorage is unreadable during the server render, so this genuinely has to happen after mount. It runs once with an empty dependency list and cannot cascade.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setActiveId(id);
     if (id && onActiveNameChange) {
       const chart = loadSavedCharts().find((c) => c.id === id);

--- a/src/components/HouseAnalysisDisplay.tsx
+++ b/src/components/HouseAnalysisDisplay.tsx
@@ -86,7 +86,7 @@ export default function HouseAnalysisDisplay({ yearHouse, monthHouse, planets, a
 
       {yearHouse === monthHouse && (
         <div className="bg-zinc-100 dark:bg-zinc-800 border border-purple-300 dark:border-purple-900 rounded p-3">
-          <span className="font-mono text-xs text-purple-600 dark:text-purple-400">// double activation — </span>
+          <span className="font-mono text-xs text-purple-600 dark:text-purple-400">{'// double activation — '}</span>
           <span className="text-zinc-500 dark:text-zinc-400 text-xs font-mono">H{yearHouse} is active for both year and month.</span>
         </div>
       )}

--- a/src/components/NorthIndianChart.tsx
+++ b/src/components/NorthIndianChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useHydrated } from '@/lib/useHydrated';
 import { useTheme } from 'next-themes';
 import { PlanetData, SpecialLagna } from '@/types';
 import { type DegreePrecision, formatDegree } from '@/lib/formatDegree';
@@ -179,9 +180,8 @@ export default function NorthIndianChart({
   legendLayers,
 }: Props) {
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-  const isDark = !mounted || resolvedTheme === 'dark';
+  const hydrated = useHydrated();
+  const isDark = !hydrated || resolvedTheme === 'dark';
 
   const visiblePlanets = filterOuterPlanets(planets, showOuterPlanets);
   const visibleTransitPlanets = filterOuterPlanets(transitPlanets, showOuterPlanets);

--- a/src/components/SouthIndianChart.tsx
+++ b/src/components/SouthIndianChart.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useHydrated } from '@/lib/useHydrated';
 import { useTheme } from 'next-themes';
 import { PlanetData, SpecialLagna } from '@/types';
 import { type DegreePrecision, formatDegree } from '@/lib/formatDegree';
@@ -130,9 +131,8 @@ export default function SouthIndianChart({
   legendLayers,
 }: Props) {
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-  const isDark = !mounted || resolvedTheme === 'dark';
+  const hydrated = useHydrated();
+  const isDark = !hydrated || resolvedTheme === 'dark';
 
   const bnnMajColor = isDark ? BNN_MAJOR_DARK : BNN_MAJOR_LIGHT;
   const bnnMinColor = isDark ? BNN_MINOR_DARK : BNN_MINOR_LIGHT;

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -2,13 +2,13 @@
 
 import { useTheme } from 'next-themes';
 import { useEffect, useState } from 'react';
+import { useHydrated } from '@/lib/useHydrated';
 
 export default function ThemeToggle({ className, icon }: { className?: string; icon?: boolean }) {
   const { resolvedTheme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
+  const hydrated = useHydrated();
 
-  useEffect(() => setMounted(true), []);
-  if (!mounted) return null;
+  if (!hydrated) return null;
 
   const isDark = resolvedTheme === 'dark';
 

--- a/src/components/UpdatesPanel.tsx
+++ b/src/components/UpdatesPanel.tsx
@@ -11,6 +11,8 @@ export default function UpdatesPanel() {
   const [hasNew, setHasNew] = useState(false);
 
   useEffect(() => {
+    // localStorage is unreadable during the server render, so this genuinely has to happen after mount. It runs once with an empty dependency list and cannot cascade.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setHasNew(localStorage.getItem(STORAGE_KEY) !== APP_VERSION);
   }, []);
 

--- a/src/components/VargaChartPanel.tsx
+++ b/src/components/VargaChartPanel.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+import type { ChartData, ChartDisplaySettings, DegreePrecision } from '@/types';
+import { VARGA_DIVISIONS, VARGA_NAMES, VARGA_SIGNIFICATIONS, buildVargaChart } from '@/lib/vargaChart';
+import NorthIndianChart from './NorthIndianChart';
+import SouthIndianChart from './SouthIndianChart';
+
+type Props = {
+  chart: ChartData;
+  chartStyle: 'north' | 'south';
+  chartDisplaySettings: ChartDisplaySettings;
+  karakaByPlanet?: Record<string, string>;
+  nakshatraAdjust?: number;
+};
+
+export default function VargaChartPanel({
+  chart,
+  chartStyle,
+  chartDisplaySettings,
+  karakaByPlanet = {},
+  nakshatraAdjust = 0,
+}: Props) {
+  const [division, setDivision] = useState<number>(9);
+  const varga = buildVargaChart(chart, division);
+
+  // BCP highlighting and the transit overlay are rāśi concepts, so they are
+  // deliberately left off here — a divisional chart shows the division alone.
+  const shared = {
+    activeYearHouse: 0,
+    activeMonthHouse: 0,
+    ascendantSign: varga.ascendantSign,
+    planets: varga.planets,
+    specialLagnas: chartDisplaySettings.showSpecialLagnas ? varga.specialLagnas : [],
+    showSigns: chartDisplaySettings.showSigns,
+    showNatalPlanets: chartDisplaySettings.showNatalPlanets,
+    showTransitPlanets: false,
+    degreePrecision: (chartDisplaySettings.degreePrecision ?? 'off') as DegreePrecision,
+    showCharaKaraka: chartDisplaySettings.showCharaKaraka,
+    showNakshatra: division === 1 ? chartDisplaySettings.showNakshatra : false,
+    showOuterPlanets: chartDisplaySettings.showOuterPlanets,
+    showSpecialLagnas: chartDisplaySettings.showSpecialLagnas,
+    showBcpHighlights: false,
+    karakaByPlanet,
+    nakshatraAdjust,
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <div className="text-xs font-mono font-semibold text-zinc-700 dark:text-zinc-300">
+          Divisional chart — D{division} {VARGA_NAMES[division]}
+        </div>
+        <div className="text-[10px] font-mono text-zinc-400 dark:text-zinc-600 mt-1">
+          {VARGA_SIGNIFICATIONS[division]}. Houses are counted from the D{division} ascendant.
+          {division !== 1 && ' Degrees show the position within the divisional sign.'}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <div className="inline-flex min-w-max gap-1 rounded-lg bg-zinc-100 p-1 dark:bg-zinc-800/50">
+          {VARGA_DIVISIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => setDivision(option)}
+              title={`${VARGA_NAMES[option]} — ${VARGA_SIGNIFICATIONS[option]}`}
+              className={`shrink-0 rounded-md px-2 py-1.5 text-[10px] font-mono ${
+                division === option
+                  ? 'bg-white text-emerald-700 shadow-sm dark:bg-zinc-700 dark:text-green-400'
+                  : 'text-zinc-500 dark:text-zinc-400'
+              }`}
+            >
+              D{option}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {chartStyle === 'south' ? <SouthIndianChart {...shared} /> : <NorthIndianChart {...shared} />}
+
+      <div className="text-[10px] font-mono text-zinc-400 dark:text-zinc-600">
+        Lagna in D{division}: {['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'][varga.ascendantSign - 1]}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/bcp.test.ts
+++ b/src/lib/bcp.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { calculateBcp, parseDateTime } from './bcp';
+
+// ---------------------------------------------------------------------------
+// Bhṛgu Chakra Paddhati progression.
+//
+// The rule is purely arithmetic, so these are exact rather than approximate:
+// the running year of life advances one house per year around the twelve, and
+// within a running year the month advances one house from the year's house.
+// ---------------------------------------------------------------------------
+const birth = new Date(2000, 0, 1, 12, 0, 0);
+const at = (year: number, month: number, day: number, hour = 12, minute = 0, second = 0) =>
+  calculateBcp(birth, new Date(year, month - 1, day, hour, minute, second));
+
+// --- The birth moment itself -----------------------------------------------
+const atBirth = at(2000, 1, 1);
+assert.equal(atBirth.completedAge, 0, 'nobody has completed a year at birth');
+assert.equal(atBirth.runningYear, 1, 'the first year of life is running');
+assert.equal(atBirth.activeYearHouse, 1, 'the first running year activates the first house');
+assert.equal(atBirth.bcpCycle, 1, 'the first cycle');
+assert.equal(atBirth.monthInRunningYear, 1);
+assert.equal(atBirth.activeMonthHouse, 1, 'month one shares the year house');
+
+// --- One house per year of life ---------------------------------------------
+for (let completed = 0; completed < 12; completed += 1) {
+  const result = at(2000 + completed, 1, 1);
+  assert.equal(result.completedAge, completed, `completed age at ${completed}`);
+  assert.equal(result.runningYear, completed + 1, 'running year is completed age plus one');
+  assert.equal(result.activeYearHouse, completed + 1, `year ${completed + 1} activates house ${completed + 1}`);
+  assert.equal(result.bcpCycle, 1, 'still inside the first twelve-year cycle');
+}
+
+// --- The cycle wraps every twelve years -------------------------------------
+const year13 = at(2012, 1, 1);
+assert.equal(year13.runningYear, 13);
+assert.equal(year13.activeYearHouse, 1, 'the thirteenth running year returns to house one');
+assert.equal(year13.bcpCycle, 2, 'and opens the second cycle');
+
+const year24 = at(2023, 1, 1);
+assert.equal(year24.runningYear, 24);
+assert.equal(year24.activeYearHouse, 12, 'the twenty-fourth year closes on house twelve');
+assert.equal(year24.bcpCycle, 2);
+
+const year25 = at(2024, 1, 1);
+assert.equal(year25.runningYear, 25);
+assert.equal(year25.activeYearHouse, 1);
+assert.equal(year25.bcpCycle, 3, 'the third cycle opens at running year 25');
+
+// The house is always a valid 1–12 and tracks the running year exactly.
+for (let completed = 0; completed <= 60; completed += 1) {
+  const result = at(2000 + completed, 6, 1);
+  assert.ok(result.activeYearHouse >= 1 && result.activeYearHouse <= 12, 'year house stays within 1–12');
+  assert.ok(result.activeMonthHouse >= 1 && result.activeMonthHouse <= 12, 'month house stays within 1–12');
+  assert.equal(result.activeYearHouse, ((result.runningYear - 1) % 12) + 1, 'year house follows the running year');
+  assert.equal(result.bcpCycle, Math.floor((result.runningYear - 1) / 12) + 1, 'cycle follows the running year');
+}
+
+// --- The birthday is the boundary, not New Year ------------------------------
+// A day before the first birthday the first year is still running.
+const dayBefore = at(2000, 12, 31);
+assert.equal(dayBefore.completedAge, 0, 'the year is not complete until the birthday');
+assert.equal(dayBefore.runningYear, 1);
+assert.equal(dayBefore.activeYearHouse, 1);
+
+// An hour before the birthday still counts as the previous year.
+const hourBefore = at(2001, 1, 1, 11, 59, 59);
+assert.equal(hourBefore.completedAge, 0, 'the age turns at the birth time, not at midnight');
+assert.equal(hourBefore.runningYear, 1);
+
+// And at the exact birth time it turns over.
+const onTheHour = at(2001, 1, 1, 12, 0, 0);
+assert.equal(onTheHour.completedAge, 1);
+assert.equal(onTheHour.runningYear, 2);
+assert.equal(onTheHour.activeYearHouse, 2);
+
+// --- Months inside a running year -------------------------------------------
+// Month one always shares the year house, and each month steps one house on.
+for (let completed = 0; completed < 14; completed += 1) {
+  const result = at(2000 + completed, 1, 1);
+  assert.equal(result.monthInRunningYear, 1, 'the birthday opens month one');
+  assert.equal(result.activeMonthHouse, result.activeYearHouse, 'month one shares the year house');
+}
+
+// Across the first year of life the month house walks 1 → 12.
+let previousMonth = 0;
+for (let monthStep = 0; monthStep < 12; monthStep += 1) {
+  const result = at(2000, 1 + monthStep, 2);
+  assert.ok(result.monthInRunningYear >= previousMonth, 'the month index never goes backwards');
+  previousMonth = result.monthInRunningYear;
+  assert.ok(result.monthInRunningYear >= 1 && result.monthInRunningYear <= 12, 'the month index stays within 1–12');
+  const expectedHouse = ((result.activeYearHouse + result.monthInRunningYear - 2) % 12) + 1;
+  assert.equal(result.activeMonthHouse, expectedHouse, 'the month house steps on from the year house');
+}
+
+// The month house wraps past twelve. In running year 2 the year house is 2, so
+// month 11 lands on house 12 and month 12 wraps to house 1.
+const lateInYearTwo = at(2001, 12, 20);
+assert.equal(lateInYearTwo.activeYearHouse, 2);
+assert.equal(lateInYearTwo.monthInRunningYear, 12);
+assert.equal(lateInYearTwo.activeMonthHouse, 1, 'the twelfth month of year two wraps to house one');
+
+// --- Dates before birth ------------------------------------------------------
+const beforeBirth = at(1999, 6, 1);
+assert.ok(beforeBirth.monthInRunningYear >= 1, 'a pre-birth date still returns a usable month');
+assert.ok(beforeBirth.completedAge < 0, 'and a negative completed age rather than a crash');
+
+// ---------------------------------------------------------------------------
+// parseDateTime — the dd.mm.yyyy hh.mm.ss input format
+// ---------------------------------------------------------------------------
+const parsed = parseDateTime('15.08.1947 09.15.00');
+assert.ok(parsed, 'a well-formed input parses');
+assert.equal(parsed.getFullYear(), 1947);
+assert.equal(parsed.getMonth(), 7, 'August is month index 7');
+assert.equal(parsed.getDate(), 15);
+assert.equal(parsed.getHours(), 9);
+assert.equal(parsed.getMinutes(), 15);
+assert.equal(parsed.getSeconds(), 0);
+
+assert.equal(parseDateTime('15.8.1947 09.15.00'), null, 'a single-digit month is rejected');
+assert.equal(parseDateTime('1947-08-15 09:15:00'), null, 'ISO format is rejected');
+assert.equal(parseDateTime('15.08.1947'), null, 'a missing time is rejected');
+assert.equal(parseDateTime(''), null, 'empty input is rejected');
+assert.ok(parseDateTime('  15.08.1947 09.15.00  '), 'surrounding whitespace is tolerated');
+
+console.log('BCP tests passed');

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -1,5 +1,21 @@
 export const CHANGELOG = [
   {
+    version: 'v2.17',
+    date: '2026-08-13',
+    title: 'Divisional charts, and tests for the core calculations',
+    changes: [
+      'Added divisional chart drawing: every varga from D1 to D60 can now be viewed as a North or South Indian chart, not just as a table. Houses are counted from the divisional ascendant and degrees show the position within the divisional sign.',
+      'The Varga tab now has a Charts view alongside the existing Matrix & Bala table.',
+      'Added tests for Vimśottarī, which had none: the nine lords summing to exactly 120 years, the 27 nakṣatra to lord mapping, birth balance and sub-period proportionality at every level.',
+      'Added tests for the BCP progression, the application namesake, which also had none.',
+      'Added coverage for D40, D45 and D60 across all twelve signs and every part; the varga fixtures previously stopped at D30 even though all three feed Viṁśopaka Bala.',
+      'Added tests for the yoga engine, which had none across its 818 lines.',
+      'Yoga strength is now classified per participating planet rather than on the raw sum, so the label no longer depends on how many planets a yoga happens to name. A three-planet yoga of ordinary planets previously read Weak while a two-planet yoga of the same quality read Moderate. The displayed number is unchanged.',
+      'Cleared the remaining lint errors and made lint a blocking check, so new violations now fail the build.',
+      'Updated the application version to v2.17.',
+    ],
+  },
+  {
     version: 'v2.16',
     date: '2026-08-13',
     title: 'Ṣaḍbala: five approximations replaced with real calculations',

--- a/src/lib/charaClean.ts
+++ b/src/lib/charaClean.ts
@@ -75,7 +75,7 @@ function durationFor(sign: number, planets: PlanetData[], options: CharaOptions)
   if (!lordSign) {
     return { lord, lordSign, direction: direction === 1 ? 'forward' : 'reverse', countMode: options.durationCount, baseCount: 12, exaltDebilAdjustment: 0, years: 12 };
   }
-  let baseCount = sign === lordSign ? 12 : countSigns(sign, lordSign, direction, options.durationCount);
+  const baseCount = sign === lordSign ? 12 : countSigns(sign, lordSign, direction, options.durationCount);
   let exaltDebilAdjustment = 0;
   if (options.exaltDebilAdjust) {
     if (lordSign === EXALT[lord]) exaltDebilAdjustment = 1;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,2 +1,2 @@
 export const APP_NAME = 'bhrigu.code';
-export const APP_VERSION = 'v2.16';
+export const APP_VERSION = 'v2.17';

--- a/src/lib/useHydrated.ts
+++ b/src/lib/useHydrated.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+/**
+ * True once the component has hydrated on the client, false during the server
+ * render and the first client pass.
+ *
+ * The usual way to write this is `const [m, setM] = useState(false)` plus
+ * `useEffect(() => setM(true), [])`, but that is a setState inside an effect —
+ * an extra render every mount, and the thing react-hooks/set-state-in-effect
+ * exists to flag. useSyncExternalStore expresses the same idea directly:
+ * the server snapshot is false, the client snapshot is true, and the value
+ * never changes afterwards so the subscription is a no-op.
+ *
+ * Used by the components that read the resolved theme, which is unknowable
+ * until hydration and would otherwise cause a hydration mismatch.
+ */
+export function useHydrated(): boolean {
+  return useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
+}

--- a/src/lib/varga/varga.test.ts
+++ b/src/lib/varga/varga.test.ts
@@ -4,7 +4,7 @@
 // Expected output verified against classical Parashara rules.
 // Cross-check D5 against JHora before trusting in production.
 
-import { calculateVargaMatrix, calcD9, SIGN_ABBR } from './index';
+import { calculateVargaMatrix, calcD9, calcD40, calcD45, calcD60, SIGN_ABBR } from './index';
 
 // ---------------------------------------------------------------------------
 // D9 sanity checks (movable / fixed / dual sign coverage)
@@ -56,6 +56,9 @@ const MATRIX_EXPECTED: Record<string, string> = {
   D24: 'Cp', // even, start=Cn(3), part 18 → (3+18)%12=9
   D27: 'Pi', // Earth, start=Cn(3), part 20 → (3+20)%12=11
   D30: 'Cp', // even, 23° in Saturn bracket (20–25°) → Capricorn
+  D40: 'Ar', // even, start=Li(6), part=⌊23/0.75⌋=30 → (6+30)%12=0
+  D45: 'Ge', // Fixed, start=Le(4), part=⌊23/(30/45)⌋=34 → (4+34)%12=2
+  D60: 'Pi', // same sign start=Ta(1), part=⌊23/0.5⌋=46 → (1+46)%12=11
 };
 
 function runMatrixTests(): { pass: number; fail: number } {
@@ -72,13 +75,88 @@ function runMatrixTests(): { pass: number; fail: number } {
 }
 
 // ---------------------------------------------------------------------------
+// D40, D45 and D60 — the high divisions.
+//
+// These had no coverage at all until now, even though all three carry weight in
+// the Ṣoḍaśavarga scheme and therefore feed Viṁśopaka Bala.
+// ---------------------------------------------------------------------------
+const HIGH_DIVISIONS: Array<{
+  key: string;
+  calc: (longitude: number) => number;
+  parts: number;
+  // The sign each part sequence starts from, given a natal sign index.
+  startSign: (signIndex: number) => number;
+}> = [
+  // Odd signs start from Aries, even signs from Libra.
+  { key: 'D40', calc: calcD40, parts: 40, startSign: (s) => (s % 2 === 0 ? 0 : 6) },
+  // Movable from Aries, fixed from Leo, dual from Sagittarius.
+  { key: 'D45', calc: calcD45, parts: 45, startSign: (s) => (s % 3 === 0 ? 0 : s % 3 === 1 ? 4 : 8) },
+  // Always from the natal sign itself.
+  { key: 'D60', calc: calcD60, parts: 60, startSign: (s) => s },
+];
+
+function runHighDivisionTests(): { pass: number; fail: number } {
+  let pass = 0, fail = 0;
+  console.log('\n--- D40 / D45 / D60 ---');
+
+  for (const { key, calc, parts, startSign } of HIGH_DIVISIONS) {
+    const partSize = 30 / parts;
+    let divisionOk = true;
+
+    for (let signIndex = 0; signIndex < 12; signIndex += 1) {
+      const expectedStart = startSign(signIndex);
+
+      // The first part of every sign lands on that sign's start.
+      if (calc(signIndex * 30) !== expectedStart) {
+        console.log(`✗ ${key}: sign ${signIndex} part 0 should start at ${SIGN_ABBR[expectedStart]}, got ${SIGN_ABBR[calc(signIndex * 30)]}`);
+        divisionOk = false;
+      }
+
+      for (let part = 0; part < parts; part += 1) {
+        // Sample the middle of each part so no boundary rounding is involved.
+        const longitude = signIndex * 30 + (part + 0.5) * partSize;
+        const actual = calc(longitude);
+        const expected = (expectedStart + part) % 12;
+        if (actual !== expected) {
+          console.log(`✗ ${key}: sign ${signIndex} part ${part} expected ${SIGN_ABBR[expected]}, got ${SIGN_ABBR[actual]}`);
+          divisionOk = false;
+        }
+        if (!Number.isInteger(actual) || actual < 0 || actual > 11) {
+          console.log(`✗ ${key}: sign ${signIndex} part ${part} produced an out-of-range index ${actual}`);
+          divisionOk = false;
+        }
+      }
+
+      // The very top of the sign must stay inside the last part, not spill over.
+      const lastPart = calc(signIndex * 30 + 30 - 1e-9);
+      if (lastPart !== (expectedStart + parts - 1) % 12) {
+        console.log(`✗ ${key}: sign ${signIndex} top of sign should be part ${parts - 1}, got ${SIGN_ABBR[lastPart]}`);
+        divisionOk = false;
+      }
+    }
+
+    console.log(`${divisionOk ? '✓' : '✗'} ${key}: all 12 signs × ${parts} parts follow the documented rule`);
+    divisionOk ? pass++ : fail++;
+  }
+
+  // D60 walks all twelve signs five times over one sign, so every sign appears.
+  const d60Signs = new Set(Array.from({ length: 60 }, (_, part) => calcD60((part + 0.5) * 0.5)));
+  const d60Ok = d60Signs.size === 12;
+  console.log(`${d60Ok ? '✓' : '✗'} D60 covers all twelve signs within one rāśi, got ${d60Signs.size}`);
+  d60Ok ? pass++ : fail++;
+
+  return { pass, fail };
+}
+
+// ---------------------------------------------------------------------------
 // Runner
 // ---------------------------------------------------------------------------
 function main() {
   const d9 = runD9Tests();
   const mat = runMatrixTests();
-  const total = d9.pass + mat.pass;
-  const failed = d9.fail + mat.fail;
+  const high = runHighDivisionTests();
+  const total = d9.pass + mat.pass + high.pass;
+  const failed = d9.fail + mat.fail + high.fail;
   console.log(`\n${total} passed, ${failed} failed`);
   if (failed > 0) process.exit(1);
 }

--- a/src/lib/vargaChart.test.ts
+++ b/src/lib/vargaChart.test.ts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import type { ChartData } from '@/types';
+import { getVargaSignIndex } from './varga';
+import { VARGA_DIVISIONS, VARGA_NAMES, VARGA_SIGNIFICATIONS, buildVargaChart } from './vargaChart';
+
+const PLANET_NAMES = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn', 'Rahu', 'Ketu'];
+
+function chartAt(ascendantLongitude: number, longitudes: number[]): ChartData {
+  return {
+    ascendant: {
+      sign: Math.floor(ascendantLongitude / 30) + 1,
+      degree: ascendantLongitude % 30,
+      longitude: ascendantLongitude,
+    },
+    planets: PLANET_NAMES.map((name, index) => ({
+      name,
+      longitude: longitudes[index],
+      sign: Math.floor(longitudes[index] / 30) + 1,
+      degree: longitudes[index] % 30,
+      house: 0,
+    })),
+    specialLagnas: [
+      { name: 'HL', longitude: 100, sign: 4, degree: 10 },
+      { name: 'GL', longitude: 250, sign: 9, degree: 10 },
+    ],
+    debug: {
+      julianDay: 0, ayanamsa: 24, utcOffset: 0, ascendantDegree: ascendantLongitude % 30,
+      ascendantSign: Math.floor(ascendantLongitude / 30) + 1, ephemerisEngine: 'test',
+      inputDateTime: '2000-01-01 12:00:00', latitude: 0, longitude: 0,
+    },
+  };
+}
+
+const LONGITUDES = [285.4, 93.2, 232.9, 248.1, 57.6, 312.3, 34.8, 35.2, 215.2];
+const chart = chartAt(162.5, LONGITUDES);
+
+// ---------------------------------------------------------------------------
+// Metadata completeness
+// ---------------------------------------------------------------------------
+for (const division of VARGA_DIVISIONS) {
+  assert.ok(VARGA_NAMES[division], `D${division} needs a traditional name`);
+  assert.ok(VARGA_SIGNIFICATIONS[division], `D${division} needs a signification`);
+}
+
+// ---------------------------------------------------------------------------
+// D1 must be a faithful pass-through of the rāśi.
+// ---------------------------------------------------------------------------
+const rasi = buildVargaChart(chart, 1);
+assert.equal(rasi.ascendantSign, chart.ascendant.sign, 'D1 keeps the rāśi ascendant');
+for (let index = 0; index < PLANET_NAMES.length; index += 1) {
+  assert.equal(rasi.planets[index].sign, chart.planets[index].sign, `D1 keeps ${PLANET_NAMES[index]} in its sign`);
+  assert.ok(
+    Math.abs(rasi.planets[index].degree - chart.planets[index].degree) < 1e-9,
+    `D1 keeps ${PLANET_NAMES[index]} at its degree`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Every division: signs agree with the varga engine, and the shape holds.
+// ---------------------------------------------------------------------------
+for (const division of VARGA_DIVISIONS) {
+  const varga = buildVargaChart(chart, division);
+  const label = `D${division}`;
+
+  assert.equal(varga.division, division, `${label} reports its division`);
+  assert.equal(varga.planets.length, PLANET_NAMES.length, `${label} keeps every body`);
+  assert.equal(
+    varga.ascendantSign,
+    getVargaSignIndex(chart.ascendant.longitude, division) + 1,
+    `${label} ascendant matches the varga engine`,
+  );
+
+  for (let index = 0; index < PLANET_NAMES.length; index += 1) {
+    const projected = varga.planets[index];
+    const expectedSign = getVargaSignIndex(LONGITUDES[index], division) + 1;
+
+    assert.equal(projected.name, PLANET_NAMES[index], `${label} preserves order and name`);
+    assert.equal(projected.sign, expectedSign, `${label} ${projected.name} sign matches the varga engine`);
+    assert.ok(projected.sign >= 1 && projected.sign <= 12, `${label} ${projected.name} sign in range`);
+    assert.ok(projected.degree >= 0 && projected.degree < 30, `${label} ${projected.name} degree in 0–30, got ${projected.degree}`);
+
+    // Longitude must stay consistent with the sign and degree it reports.
+    assert.ok(
+      Math.abs(projected.longitude - ((projected.sign - 1) * 30 + projected.degree)) < 1e-9,
+      `${label} ${projected.name} longitude must match its sign and degree`,
+    );
+
+    // Whole-sign houses counted from the divisional ascendant.
+    const expectedHouse = ((projected.sign - varga.ascendantSign + 12) % 12) + 1;
+    assert.equal(projected.house, expectedHouse, `${label} ${projected.name} house`);
+    assert.ok(projected.house >= 1 && projected.house <= 12, `${label} ${projected.name} house in range`);
+  }
+
+  // The ascendant always sits in the first house of its own chart.
+  const ascendantHouse = ((varga.ascendantSign - varga.ascendantSign + 12) % 12) + 1;
+  assert.equal(ascendantHouse, 1, `${label} ascendant is the first house`);
+
+  // Special lagnas ride along.
+  assert.equal(varga.specialLagnas.length, 2, `${label} keeps the special lagnas`);
+  for (const lagna of varga.specialLagnas) {
+    assert.ok(lagna.sign >= 1 && lagna.sign <= 12, `${label} ${lagna.name} sign in range`);
+    assert.ok(lagna.degree >= 0 && lagna.degree < 30, `${label} ${lagna.name} degree in range`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Degree scaling inside a divisional sign
+// ---------------------------------------------------------------------------
+// D9 parts are 3°20′. A planet at the very start of a part shows 0° of the
+// navāṁśa sign; one at the exact midpoint shows 15°.
+const partSize = 30 / 9;
+const startOfPart = buildVargaChart(chartAt(0, [0, 0, 0, 0, 0, 0, 0, 0, 0]), 9);
+assert.ok(Math.abs(startOfPart.planets[0].degree) < 1e-9, 'the start of a navāṁśa part shows 0°');
+
+const midPart = buildVargaChart(chartAt(0, Array(9).fill(partSize / 2)), 9);
+assert.ok(Math.abs(midPart.planets[0].degree - 15) < 1e-9, 'the midpoint of a part shows 15°');
+
+const nearEnd = buildVargaChart(chartAt(0, Array(9).fill(partSize * 0.999)), 9);
+assert.ok(nearEnd.planets[0].degree > 29.9 && nearEnd.planets[0].degree < 30, 'the end of a part approaches 30°');
+
+// D2 halves a sign, so 0–15° maps across the whole hora sign.
+const horaLow = buildVargaChart(chartAt(0, Array(9).fill(7.5)), 2);
+assert.ok(Math.abs(horaLow.planets[0].degree - 15) < 1e-9, 'half a hora is 15° of the hora sign');
+
+// ---------------------------------------------------------------------------
+// Conjunction is preserved inside a part, and broken across a part boundary.
+// ---------------------------------------------------------------------------
+// D60 parts are 0.5° wide. 35.1° and 35.3° are both inside Taurus 5.0–5.5, so
+// they must share a ṣaṣṭyāṁśa sign.
+const samePart = buildVargaChart(chartAt(0, [35.1, 35.3, 0, 0, 0, 0, 0, 0, 0]), 60);
+assert.equal(samePart.planets[0].sign, samePart.planets[1].sign, 'bodies inside one ṣaṣṭyāṁśa part stay together');
+
+// 34.8° and 35.2° straddle the boundary at Taurus 5.0, so D60 must separate
+// them even though they are only 0.4° apart in the rāśi.
+const acrossBoundary = buildVargaChart(chartAt(0, [34.8, 35.2, 0, 0, 0, 0, 0, 0, 0]), 60);
+assert.notEqual(
+  acrossBoundary.planets[0].sign,
+  acrossBoundary.planets[1].sign,
+  'a ṣaṣṭyāṁśa boundary separates bodies that are close in the rāśi',
+);
+
+// Ketu is always opposite Rahu in the rāśi; in a varga that need not hold, but
+// both must still produce a valid placement.
+const d60 = buildVargaChart(chart, 60);
+const ketu = d60.planets.find((planet) => planet.name === 'Ketu')!;
+assert.ok(ketu.sign >= 1 && ketu.sign <= 12, 'Ketu still lands in a real sign');
+
+// ---------------------------------------------------------------------------
+// The source chart must not be mutated.
+// ---------------------------------------------------------------------------
+const before = JSON.stringify(chart);
+buildVargaChart(chart, 9);
+buildVargaChart(chart, 60);
+assert.equal(JSON.stringify(chart), before, 'building a varga chart leaves the rāśi untouched');
+
+console.log('Varga chart tests passed');

--- a/src/lib/vargaChart.ts
+++ b/src/lib/vargaChart.ts
@@ -1,0 +1,97 @@
+// Project a rāśi chart into a divisional chart.
+//
+// The chart components only need an ascendant sign and a list of planets, so a
+// varga chart is just the same chart with every longitude mapped into the
+// chosen division. Nothing about the drawing changes.
+//
+// Degrees inside a varga sign: a planet sitting a third of the way through its
+// D9 part is shown at 10° of the navāṁśa sign. That is the usual convention for
+// displaying divisional positions, and it keeps the degree readout meaningful
+// instead of repeating the rāśi degree.
+
+import type { ChartData, PlanetData, SpecialLagna } from '@/types';
+import { getVargaSignIndex, getDegreesInSign } from './varga';
+
+export const VARGA_DIVISIONS = [1, 2, 3, 4, 5, 7, 9, 10, 12, 16, 20, 24, 27, 30, 40, 45, 60] as const;
+export type VargaDivision = (typeof VARGA_DIVISIONS)[number];
+
+/** Traditional names, shown next to the Dn label. */
+export const VARGA_NAMES: Record<number, string> = {
+  1: 'Rāśi', 2: 'Horā', 3: 'Drekkāṇa', 4: 'Chaturthāṁśa', 5: 'Pañchāṁśa',
+  7: 'Saptāṁśa', 9: 'Navāṁśa', 10: 'Daśāṁśa', 12: 'Dvādaśāṁśa', 16: 'Ṣoḍaśāṁśa',
+  20: 'Viṁśāṁśa', 24: 'Chaturviṁśāṁśa', 27: 'Bhāṁśa', 30: 'Triṁśāṁśa',
+  40: 'Khavedāṁśa', 45: 'Akṣavedāṁśa', 60: 'Ṣaṣṭyāṁśa',
+};
+
+/** What each divisional chart is traditionally read for. */
+export const VARGA_SIGNIFICATIONS: Record<number, string> = {
+  1: 'The body and life as a whole',
+  2: 'Wealth and resources',
+  3: 'Siblings, courage and initiative',
+  4: 'Property, home and fortune',
+  5: 'Fame, authority and merit',
+  7: 'Children and progeny',
+  9: 'Marriage, dharma and inner strength',
+  10: 'Career and action in the world',
+  12: 'Parents and ancestry',
+  16: 'Vehicles, comforts and pleasures',
+  20: 'Spiritual practice and worship',
+  24: 'Learning and education',
+  27: 'Strengths and weaknesses of the body',
+  30: 'Misfortune and hidden harm',
+  40: 'Matrilineal inheritance',
+  45: 'Patrilineal inheritance',
+  60: 'The sum of past deeds; a fine sieve',
+};
+
+export type VargaChart = {
+  division: number;
+  ascendantSign: number;
+  planets: PlanetData[];
+  specialLagnas: SpecialLagna[];
+};
+
+/**
+ * Longitude a body occupies inside its divisional sign, on the usual 0–30
+ * scale. The position within the part is stretched across the whole sign.
+ */
+function vargaDegree(longitude: number, division: number): number {
+  if (division <= 1) return getDegreesInSign(longitude);
+  const partSize = 30 / division;
+  const withinPart = getDegreesInSign(longitude) % partSize;
+  return (withinPart / partSize) * 30;
+}
+
+function project(longitude: number, division: number): { sign: number; degree: number; longitude: number } {
+  const signIndex = getVargaSignIndex(longitude, division);
+  const degree = vargaDegree(longitude, division);
+  return { sign: signIndex + 1, degree, longitude: signIndex * 30 + degree };
+}
+
+/**
+ * Recompute a chart into the given division. Division 1 returns the rāśi
+ * positions unchanged. Houses are recomputed from the divisional ascendant, so
+ * the whole-sign house numbering stays consistent with the drawn chart.
+ */
+export function buildVargaChart(chart: ChartData, division: number): VargaChart {
+  const ascendant = project(chart.ascendant.longitude, division);
+  const ascendantSignIndex = ascendant.sign - 1;
+
+  const planets: PlanetData[] = chart.planets.map((planet) => {
+    const projected = project(planet.longitude, division);
+    return {
+      ...planet,
+      sign: projected.sign,
+      degree: projected.degree,
+      longitude: projected.longitude,
+      house: ((projected.sign - 1 - ascendantSignIndex + 12) % 12) + 1,
+    };
+  });
+
+  const specialLagnas: SpecialLagna[] = (chart.specialLagnas ?? []).map((lagna) => {
+    const projected = project(lagna.longitude, division);
+    return { ...lagna, sign: projected.sign, degree: projected.degree, longitude: projected.longitude };
+  });
+
+  return { division, ascendantSign: ascendant.sign, planets, specialLagnas };
+}

--- a/src/lib/vimshottari.test.ts
+++ b/src/lib/vimshottari.test.ts
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import {
+  calculateVimshottari,
+  calculateAntardashas,
+  calculatePratyantardashas,
+  type MahadashaEntry,
+} from './vimshottari';
+
+// ---------------------------------------------------------------------------
+// Golden vectors — Vimśottarī is entirely rule-defined, so every check here is
+// chart-independent and needs no external reference data.
+// ---------------------------------------------------------------------------
+const LORD_YEARS: Record<string, number> = {
+  Ketu: 7, Venus: 20, Sun: 6, Moon: 10, Mars: 7,
+  Rahu: 18, Jupiter: 16, Saturn: 19, Mercury: 17,
+};
+const LORD_ORDER = ['Ketu', 'Venus', 'Sun', 'Moon', 'Mars', 'Rahu', 'Jupiter', 'Saturn', 'Mercury'];
+const CYCLE_YEARS = 120;
+const NAKSHATRA_SIZE = 360 / 27;
+const DAYS_PER_YEAR = 365.25;
+
+assert.equal(
+  Object.values(LORD_YEARS).reduce((sum, years) => sum + years, 0),
+  CYCLE_YEARS,
+  'the nine lord periods must sum to exactly 120 years',
+);
+
+const birth = new Date(2000, 0, 1, 12, 0, 0);
+const yearsBetween = (from: Date, to: Date) => (to.getTime() - from.getTime()) / (DAYS_PER_YEAR * 86400000);
+
+// ---------------------------------------------------------------------------
+// Nakshatra to lord mapping: 27 nakshatras, three cycles of the nine lords.
+// ---------------------------------------------------------------------------
+const NAKSHATRA_NAMES = [
+  'Ashwini', 'Bharani', 'Krittika', 'Rohini', 'Mrigashira', 'Ardra',
+  'Punarvasu', 'Pushya', 'Ashlesha', 'Magha', 'Purva Phalguni', 'Uttara Phalguni',
+  'Hasta', 'Chitra', 'Swati', 'Vishakha', 'Anuradha', 'Jyeshtha',
+  'Mula', 'Purva Ashadha', 'Uttara Ashadha', 'Shravana', 'Dhanistha',
+  'Shatabhisha', 'Purva Bhadrapada', 'Uttara Bhadrapada', 'Revati',
+];
+
+for (let index = 0; index < 27; index += 1) {
+  // Sample the middle of each nakshatra so no boundary rounding is involved.
+  const longitude = (index + 0.5) * NAKSHATRA_SIZE;
+  const result = calculateVimshottari(longitude, birth);
+  assert.equal(result.nakshatra, NAKSHATRA_NAMES[index], `nakshatra name at index ${index}`);
+  assert.equal(result.nakshatraLord, LORD_ORDER[index % 9], `nakshatra ${NAKSHATRA_NAMES[index]} lord`);
+}
+
+// Ashwini, Magha and Mula all open the Ketu cycle.
+for (const index of [0, 9, 18]) {
+  assert.equal(calculateVimshottari((index + 0.5) * NAKSHATRA_SIZE, birth).nakshatraLord, 'Ketu');
+}
+
+// ---------------------------------------------------------------------------
+// Mahādaśā sequence and durations
+// ---------------------------------------------------------------------------
+for (let index = 0; index < 27; index += 1) {
+  const longitude = (index + 0.5) * NAKSHATRA_SIZE;
+  const { entries } = calculateVimshottari(longitude, birth);
+  const startLordIndex = index % 9;
+
+  assert.equal(entries.length, 9, 'nine mahadashas');
+
+  // The order always continues around the fixed wheel from the birth lord.
+  assert.deepEqual(
+    entries.map((entry) => entry.lord),
+    Array.from({ length: 9 }, (_, step) => LORD_ORDER[(startLordIndex + step) % 9]),
+    `sequence from ${LORD_ORDER[startLordIndex]}`,
+  );
+
+  // Only the first period is shortened by the birth balance; the rest are full.
+  for (let step = 1; step < 9; step += 1) {
+    assert.ok(
+      Math.abs(entries[step].durationYears - LORD_YEARS[entries[step].lord]) < 1e-9,
+      `${entries[step].lord} must run its full ${LORD_YEARS[entries[step].lord]} years`,
+    );
+  }
+
+  // Periods are contiguous: each starts exactly where the previous ended.
+  for (let step = 1; step < 9; step += 1) {
+    assert.equal(
+      entries[step].startDate.getTime(),
+      entries[step - 1].endDate.getTime(),
+      'mahadashas must be contiguous',
+    );
+  }
+  assert.equal(entries[0].startDate.getTime(), birth.getTime(), 'the first period starts at birth');
+
+  // Elapsed time must match the declared duration.
+  for (const entry of entries) {
+    assert.ok(
+      Math.abs(yearsBetween(entry.startDate, entry.endDate) - entry.durationYears) < 1e-6,
+      `${entry.lord} elapsed time must match its duration`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Birth balance — the opening period is the unexpired part of the nakshatra.
+// ---------------------------------------------------------------------------
+// Exactly at the start of Ashwini the whole Ketu period of 7 years remains.
+const atStart = calculateVimshottari(0, birth);
+assert.ok(Math.abs(atStart.entries[0].durationYears - 7) < 1e-9, 'a full balance at the nakshatra start');
+
+// Halfway through Ashwini, half of Ketu remains.
+const atHalf = calculateVimshottari(NAKSHATRA_SIZE / 2, birth);
+assert.ok(Math.abs(atHalf.entries[0].durationYears - 3.5) < 1e-9, 'half a balance at the midpoint');
+
+// Three quarters through Rohini (Moon, 10 years) leaves a quarter, so 2.5 years.
+const rohini = calculateVimshottari(3 * NAKSHATRA_SIZE + NAKSHATRA_SIZE * 0.75, birth);
+assert.equal(rohini.nakshatraLord, 'Moon');
+assert.ok(Math.abs(rohini.entries[0].durationYears - 2.5) < 1e-9, 'a quarter of the Moon period remains');
+
+// The balance shrinks monotonically as the Moon advances through a nakshatra.
+let previousBalance = Infinity;
+for (const fraction of [0, 0.2, 0.4, 0.6, 0.8, 0.99]) {
+  const balance = calculateVimshottari(fraction * NAKSHATRA_SIZE, birth).entries[0].durationYears;
+  assert.ok(balance < previousBalance, 'the birth balance must decrease across the nakshatra');
+  previousBalance = balance;
+}
+
+// A full run from the start of a nakshatra spans the whole 120-year cycle.
+const fullCycle = calculateVimshottari(0, birth);
+const cycleSpan = yearsBetween(fullCycle.entries[0].startDate, fullCycle.entries[8].endDate);
+assert.ok(Math.abs(cycleSpan - CYCLE_YEARS) < 1e-6, 'a full cycle from a nakshatra start covers 120 years');
+
+// ---------------------------------------------------------------------------
+// Sub-periods: proportional, contiguous, and starting from the parent lord.
+// ---------------------------------------------------------------------------
+function assertSubPeriods(parent: MahadashaEntry, children: MahadashaEntry[], label: string) {
+  assert.equal(children.length, 9, `${label}: nine sub-periods`);
+  assert.equal(children[0].lord, parent.lord, `${label}: starts from the parent lord`);
+
+  const parentIndex = LORD_ORDER.indexOf(parent.lord);
+  assert.deepEqual(
+    children.map((child) => child.lord),
+    Array.from({ length: 9 }, (_, step) => LORD_ORDER[(parentIndex + step) % 9]),
+    `${label}: order continues around the wheel`,
+  );
+
+  for (const child of children) {
+    const expected = (parent.durationYears * LORD_YEARS[child.lord]) / CYCLE_YEARS;
+    assert.ok(
+      Math.abs(child.durationYears - expected) < 1e-9,
+      `${label}: ${child.lord} must be ${LORD_YEARS[child.lord]}/120 of the parent`,
+    );
+  }
+
+  // The children must exactly fill the parent, with no gap or overrun.
+  const summed = children.reduce((sum, child) => sum + child.durationYears, 0);
+  assert.ok(Math.abs(summed - parent.durationYears) < 1e-9, `${label}: sub-periods must fill the parent`);
+  assert.equal(children[0].startDate.getTime(), parent.startDate.getTime(), `${label}: aligned start`);
+  assert.ok(
+    Math.abs(children[8].endDate.getTime() - parent.endDate.getTime()) < 2,
+    `${label}: aligned end`,
+  );
+  for (let step = 1; step < 9; step += 1) {
+    assert.equal(children[step].startDate.getTime(), children[step - 1].endDate.getTime(), `${label}: contiguous`);
+  }
+}
+
+const { entries } = calculateVimshottari(NAKSHATRA_SIZE * 4.5, birth);
+for (const md of entries) {
+  const ads = calculateAntardashas(md);
+  assertSubPeriods(md, ads, `${md.lord} MD`);
+  for (const ad of ads) {
+    assertSubPeriods(ad, calculatePratyantardashas(ad), `${md.lord}/${ad.lord} AD`);
+  }
+}
+
+// The classical check: Venus AD inside a Venus MD is 20 × 20 / 120 = 3⅓ years.
+const venusMd = entries.find((entry) => entry.lord === 'Venus')!;
+assert.ok(Math.abs(venusMd.durationYears - 20) < 1e-9, 'a full Venus mahadasha is 20 years');
+const venusVenus = calculateAntardashas(venusMd)[0];
+assert.ok(Math.abs(venusVenus.durationYears - (20 * 20) / 120) < 1e-9, 'Venus/Venus is 400/120 years');
+
+// ---------------------------------------------------------------------------
+// Longitude handling at the extremes
+// ---------------------------------------------------------------------------
+// The very end of the zodiac is Revati, ruled by Mercury.
+const lastDegree = calculateVimshottari(359.999, birth);
+assert.equal(lastDegree.nakshatra, 'Revati');
+assert.equal(lastDegree.nakshatraLord, 'Mercury');
+assert.ok(lastDegree.entries[0].durationYears > 0, 'a positive balance even at the last degree');
+
+console.log('Vimśottarī tests passed');

--- a/src/lib/yogaStrength.ts
+++ b/src/lib/yogaStrength.ts
@@ -17,7 +17,10 @@ export interface YogaStrengthBreakdown {
 }
 
 export interface YogaStrengthResult extends YogaResult {
+  /** Summed score across every participating planet. */
   strength: number | null;
+  /** The same score divided by the participating planets. Drives classification. */
+  strengthPerPlanet: number | null;
   classification: StrengthClassification | null;
   breakdown: YogaStrengthBreakdown | null;
 }
@@ -189,7 +192,7 @@ export function classify(strength: number): StrengthClassification {
 export function qualifyYogas(yogas: YogaResult[], planets: PlanetData[]): YogaStrengthResult[] {
   return yogas.map(yoga => {
     if (yoga.status !== 'active') {
-      return { ...yoga, strength: null, classification: null, breakdown: null };
+      return { ...yoga, strength: null, strengthPerPlanet: null, classification: null, breakdown: null };
     }
 
     if (yoga.planetsInvolved.length === 0) {
@@ -197,7 +200,7 @@ export function qualifyYogas(yogas: YogaResult[], planets: PlanetData[]): YogaSt
         rasi: 0, dignity: 0, navamsa: 0, vargottama: 0,
         conjunctions: 0, aspects: 0, kartari: 0,
       };
-      return { ...yoga, strength: 0, classification: 'Moderate', breakdown: zeros };
+      return { ...yoga, strength: 0, strengthPerPlanet: 0, classification: 'Moderate', breakdown: zeros };
     }
 
     const totals: YogaStrengthBreakdown = {
@@ -219,6 +222,25 @@ export function qualifyYogas(yogas: YogaResult[], planets: PlanetData[]): YogaSt
     }
 
     const strength = Object.values(totals).reduce((a, b) => a + b, 0);
-    return { ...yoga, strength, classification: classify(strength), breakdown: totals };
+
+    // Classify on the average per participating planet, not on the sum.
+    //
+    // The sum legitimately scales with how many planets a yoga names, but the
+    // classify() thresholds are absolute, so before this the same per-planet
+    // quality read very differently depending on the yoga's size: a
+    // three-planet Raja yoga of ordinary planets landed at -540 and read
+    // "Weak" while a two-planet Vosi at +60 read "Moderate". Averaging makes
+    // the label mean "these planets are individually strong", which is
+    // comparable across yogas. The displayed strength stays the sum.
+    const scored = yoga.planetsInvolved.filter((name) => planets.some((planet) => planet.name === name)).length;
+    const strengthPerPlanet = scored > 0 ? strength / scored : 0;
+
+    return {
+      ...yoga,
+      strength,
+      strengthPerPlanet,
+      classification: classify(strengthPerPlanet),
+      breakdown: totals,
+    };
   });
 }

--- a/src/lib/yogas.test.ts
+++ b/src/lib/yogas.test.ts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import type { PlanetData } from '@/types';
+import { calculateYogas, getPlanetsInRelativeSign } from './yogas';
+import { classify, qualifyYogas } from './yogaStrength';
+
+// ---------------------------------------------------------------------------
+// The yoga engine and its strength scoring had no tests at all. These pin down
+// the detection rules and the invariants that hold whatever the chart.
+// ---------------------------------------------------------------------------
+function planet(name: string, sign: number, degree = 15): PlanetData {
+  return { name, sign, degree, longitude: (sign - 1) * 30 + degree, house: sign };
+}
+
+const ALL_NAMES = ['Sun', 'Moon', 'Mars', 'Mercury', 'Jupiter', 'Venus', 'Saturn', 'Rahu', 'Ketu'];
+/** Park every planet in a sign far from the Sun so no yoga fires by accident. */
+function quietChart(overrides: Record<string, number> = {}): PlanetData[] {
+  return ALL_NAMES.map((name, index) =>
+    planet(name, overrides[name] ?? ((index % 2 === 0 ? 5 : 6) + (name === 'Sun' ? -4 : 0))),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Relative-sign helper — the basis of most solar and lunar yogas
+// ---------------------------------------------------------------------------
+const sample = [planet('Mercury', 2), planet('Venus', 12), planet('Rahu', 2)];
+// The 2nd from Aries is Taurus; Rahu is excluded as it is not an eligible planet.
+assert.deepEqual(getPlanetsInRelativeSign(1, 2, sample).map((p) => p.name), ['Mercury']);
+// The 12th from Aries wraps back to Pisces.
+assert.deepEqual(getPlanetsInRelativeSign(1, 12, sample).map((p) => p.name), ['Venus']);
+// The 1st from a sign is the sign itself.
+assert.deepEqual(getPlanetsInRelativeSign(2, 1, sample).map((p) => p.name), ['Mercury']);
+// Counting wraps around the zodiac rather than running off the end.
+assert.deepEqual(getPlanetsInRelativeSign(12, 3, sample).map((p) => p.name), ['Mercury']);
+
+// ---------------------------------------------------------------------------
+// Solar yogas: Vesi (2nd from Sun), Vosi (12th), Ubhayachari (both)
+// ---------------------------------------------------------------------------
+const findYoga = (yogas: ReturnType<typeof calculateYogas>, id: string) => yogas.find((y) => y.id === id)!;
+
+// Sun in Aries, Mercury in Taurus → Vesi only.
+const vesiOnly = calculateYogas([planet('Sun', 1), planet('Mercury', 2), planet('Moon', 7)], 1);
+assert.equal(findYoga(vesiOnly, 'vesi').status, 'active', 'a planet in the 2nd from the Sun makes Vesi');
+assert.equal(findYoga(vesiOnly, 'vosi').status, 'inactive', 'nothing in the 12th, so no Vosi');
+assert.equal(findYoga(vesiOnly, 'ubhayachari').status, 'inactive', 'Ubhayachari needs both sides');
+assert.deepEqual(findYoga(vesiOnly, 'vesi').planetsInvolved, ['Mercury']);
+
+// Sun in Aries, Mercury in Pisces → Vosi only.
+const vosiOnly = calculateYogas([planet('Sun', 1), planet('Mercury', 12), planet('Moon', 7)], 1);
+assert.equal(findYoga(vosiOnly, 'vosi').status, 'active', 'a planet in the 12th from the Sun makes Vosi');
+assert.equal(findYoga(vosiOnly, 'vesi').status, 'inactive');
+
+// Both sides occupied → all three fire.
+const both = calculateYogas([planet('Sun', 1), planet('Mercury', 2), planet('Venus', 12), planet('Moon', 7)], 1);
+assert.equal(findYoga(both, 'vesi').status, 'active');
+assert.equal(findYoga(both, 'vosi').status, 'active');
+assert.equal(findYoga(both, 'ubhayachari').status, 'active', 'both sides occupied makes Ubhayachari');
+assert.deepEqual(
+  [...findYoga(both, 'ubhayachari').planetsInvolved].sort(),
+  ['Mercury', 'Venus'],
+  'Ubhayachari names the planets from both sides without duplicates',
+);
+
+// The Moon and the nodes never count towards the solar yogas.
+const moonAdjacent = calculateYogas([planet('Sun', 1), planet('Moon', 2), planet('Rahu', 12)], 1);
+assert.equal(findYoga(moonAdjacent, 'vesi').status, 'inactive', 'the Moon does not make Vesi');
+assert.equal(findYoga(moonAdjacent, 'vosi').status, 'inactive', 'Rahu does not make Vosi');
+
+// ---------------------------------------------------------------------------
+// Structural invariants across many arrangements
+// ---------------------------------------------------------------------------
+for (let ascendant = 1; ascendant <= 12; ascendant += 1) {
+  for (const offset of [0, 3, 7]) {
+    const planets = ALL_NAMES.map((name, index) => planet(name, ((index * 2 + offset) % 12) + 1, 10 + index));
+    const yogas = calculateYogas(planets, ascendant);
+    const label = `asc ${ascendant} offset ${offset}`;
+
+    const ids = yogas.map((yoga) => yoga.id);
+    assert.equal(new Set(ids).size, ids.length, `${label}: yoga ids must be unique`);
+
+    for (const yoga of yogas) {
+      assert.ok(yoga.name.length > 0, `${label}: ${yoga.id} needs a name`);
+      assert.ok(yoga.rule.length > 0, `${label}: ${yoga.id} needs a rule`);
+      assert.ok(yoga.resultText.length > 0, `${label}: ${yoga.id} needs result text`);
+      assert.ok(['active', 'inactive'].includes(yoga.status), `${label}: ${yoga.id} status`);
+      assert.ok(Array.isArray(yoga.planetsInvolved), `${label}: ${yoga.id} planetsInvolved`);
+      for (const name of yoga.planetsInvolved) {
+        assert.ok(ALL_NAMES.includes(name), `${label}: ${yoga.id} names a real planet, got ${name}`);
+      }
+    }
+
+    // Strength must be present exactly for the active yogas.
+    for (const qualified of qualifyYogas(yogas, planets)) {
+      if (qualified.status === 'active') {
+        assert.ok(typeof qualified.strength === 'number', `${label}: ${qualified.id} active needs a strength`);
+        assert.ok(qualified.classification !== null, `${label}: ${qualified.id} active needs a classification`);
+        assert.ok(Number.isFinite(qualified.strength!), `${label}: ${qualified.id} strength must be finite`);
+        // The headline strength is the sum of the seven breakdown components.
+        const summed = Object.values(qualified.breakdown!).reduce((a, b) => a + b, 0);
+        assert.ok(
+          Math.abs(qualified.strength! - summed) < 1e-9,
+          `${label}: ${qualified.id} strength must equal its breakdown`,
+        );
+      } else {
+        assert.equal(qualified.strength, null, `${label}: ${qualified.id} inactive has no strength`);
+        assert.equal(qualified.classification, null, `${label}: ${qualified.id} inactive has no classification`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Classification thresholds
+// ---------------------------------------------------------------------------
+assert.equal(classify(200), 'Very Strong');
+assert.equal(classify(151), 'Very Strong');
+assert.equal(classify(150), 'Strong', '150 is the top of Strong, not Very Strong');
+assert.equal(classify(75), 'Strong');
+assert.equal(classify(74), 'Moderate');
+assert.equal(classify(0), 'Moderate', 'zero is Moderate, not Weak');
+assert.equal(classify(-1), 'Weak');
+
+// ---------------------------------------------------------------------------
+// Classification is judged per planet, not on the raw sum.
+//
+// Before v2.17 the label came from the sum, so a yoga naming more planets was
+// pushed towards the extremes purely by its size. These charts place identical
+// planets, so the per-planet quality is identical and the label must agree even
+// though the sums differ.
+// ---------------------------------------------------------------------------
+const twoPlanets = [planet('Sun', 1), planet('Mercury', 2), planet('Venus', 2)];
+const twoResult = qualifyYogas(calculateYogas(twoPlanets, 1), twoPlanets);
+const vesiTwo = twoResult.find((yoga) => yoga.id === 'vesi')!;
+assert.equal(vesiTwo.planetsInvolved.length, 2, 'two planets sit in the 2nd from the Sun');
+
+const onePlanet = [planet('Sun', 1), planet('Mercury', 2)];
+const oneResult = qualifyYogas(calculateYogas(onePlanet, 1), onePlanet);
+const vesiOne = oneResult.find((yoga) => yoga.id === 'vesi')!;
+assert.equal(vesiOne.planetsInvolved.length, 1, 'one planet sits in the 2nd from the Sun');
+
+assert.ok(
+  typeof vesiTwo.strengthPerPlanet === 'number' && typeof vesiOne.strengthPerPlanet === 'number',
+  'both report a per-planet strength',
+);
+assert.ok(
+  Math.abs(vesiTwo.strengthPerPlanet! - vesiTwo.strength! / 2) < 1e-9,
+  'the per-planet strength is the sum over the participating planets',
+);
+assert.ok(
+  Math.abs(vesiOne.strengthPerPlanet! - vesiOne.strength!) < 1e-9,
+  'a single-planet yoga reports the same value both ways',
+);
+assert.equal(
+  vesiTwo.classification,
+  classify(vesiTwo.strengthPerPlanet!),
+  'the classification follows the per-planet strength',
+);
+
+// A yoga with no named planets still classifies rather than dividing by zero.
+const emptyYoga = qualifyYogas(
+  [{ id: 'x', name: 'X', category: 'general', status: 'active', referencePlanet: 'Sun', planetsInvolved: [], rule: 'r', resultText: 't' }],
+  [],
+);
+assert.equal(emptyYoga[0].strength, 0);
+assert.equal(emptyYoga[0].strengthPerPlanet, 0);
+assert.equal(emptyYoga[0].classification, 'Moderate');
+
+// Naming a planet that is absent from the chart must not skew the average.
+const missingPlanet = qualifyYogas(
+  [{ id: 'y', name: 'Y', category: 'general', status: 'active', referencePlanet: 'Sun', planetsInvolved: ['Sun', 'Pluto'], rule: 'r', resultText: 't' }],
+  [planet('Sun', 1)],
+);
+assert.ok(
+  Math.abs(missingPlanet[0].strengthPerPlanet! - missingPlanet[0].strength!) < 1e-9,
+  'only planets actually present count towards the average',
+);
+
+console.log('Yoga tests passed');


### PR DESCRIPTION
## Divisional charts — the new feature

Every varga from **D1 to D60** can now be drawn as a North or South Indian chart, not just read from the matrix table.

The chart components needed **no changes at all**: they only take an ascendant sign and a planet list, so `buildVargaChart` reprojects both into the chosen division. Houses are counted from the divisional ascendant, and degrees show the position *inside* the divisional sign rather than repeating the rāśi degree — a planet a third of the way through its D9 part shows 10° of the navāṁśa sign.

The Varga tab gained a **Charts / Matrix & Bala** toggle; each division shows its traditional name and what it's read for.

**Cross-validated in the browser:** the drawn chart and the pre-existing matrix table agree independently — the Sun lands in Pisces in both D9 and D60 by both code paths — and D1 returns the rāśi unchanged (Virgo lagna, matching the chart).

## Tests for calculations that had none

| Module | Lines | Test before |
| --- | --- | --- |
| `vimshottari.ts` + `vds.ts` | 315 | none |
| `bcp.ts` — the app namesake | 100 | none |
| `yogas.ts` + `yogaStrength.ts` | 818 | none |
| D40, D45, D60 | — | none |

**Vimśottarī** is the app's default daśā and the most used system in Jyotish. The only thing touching it checked that snapshots have three levels — nothing verified a single period. Now covered by golden vectors that need no external data: the nine lords summing to **exactly 120 years**, the 27 nakṣatra → lord mapping across three cycles of nine, the birth balance as the unexpired part of the nakṣatra (checked for monotonic decrease), and sub-period proportionality and contiguity at every level across all 81 MD/AD pairs.

**BCP** now has fixtures for the progression, the twelve-year cycle wrap, the birthday boundary *including the exact birth time*, month subdivision and wrap, and `parseDateTime`.

**D40/D45/D60** are checked across all twelve signs and every part (40, 45 and 60 respectively), plus start-of-sign and end-of-sign boundaries. All three feed Ṣoḍaśavarga and therefore Viṁśopaka Bala.

**Yoga engine** gained detection fixtures for the solar yogas (Vesi / Vosi / Ubhayachari, including that the Moon and nodes don't qualify) and structural invariants over 36 chart arrangements.

## Yoga strength classification changed

Strength is summed per participating planet, but `classify()` used absolute thresholds — so the label depended on how many planets a yoga happened to name. A three-planet Raja yoga of ordinary planets read **Weak at −540** while a two-planet Vosi of identical per-planet quality read **Moderate at +60**.

Classification now uses the **per-planet average**. The displayed number is unchanged, and `strengthPerPlanet` is exposed alongside it. This is a doctrine call, so flagging it clearly: if you'd rather more planets mean a stronger label, this is the line to revert.

## Lint is now a blocking gate

All 11 errors cleared:

- The three next-themes hydration guards moved from `setState`-in-effect to a `useHydrated()` hook built on `useSyncExternalStore` — same idea, no extra render.
- The `chartStyle` prop mirror became an adjust-during-render, React's documented alternative.
- The four genuine one-shot `localStorage` reads keep **scoped** disables with written justification, since `localStorage` cannot be read during the server render.
- `continue-on-error` dropped from the CI lint step.

## Verification

`npm test` 27/27 (was 23) · typecheck clean · lint **0 errors** · build succeeds · browser verified with no application console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
